### PR TITLE
Rework TUI state

### DIFF
--- a/incus-osd/internal/providers/provider_github.go
+++ b/incus-osd/internal/providers/provider_github.go
@@ -29,6 +29,41 @@ type github struct {
 	releaseMu        sync.Mutex
 }
 
+func (p *github) GetOSUpdate(ctx context.Context) (OSUpdate, error) {
+	// Get latest release.
+	err := p.checkRelease(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepare the OS update struct.
+	update := githubOSUpdate{
+		provider: p,
+		assets:   p.releaseAssets,
+		version:  p.releaseVersion,
+	}
+
+	return &update, nil
+}
+
+func (p *github) GetApplication(ctx context.Context, name string) (Application, error) {
+	// Get latest release.
+	err := p.checkRelease(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepare the application struct.
+	app := githubApplication{
+		provider: p,
+		name:     name,
+		assets:   p.releaseAssets,
+		version:  p.releaseVersion,
+	}
+
+	return &app, nil
+}
+
 func (p *github) load(ctx context.Context) error {
 	// Setup the Github client.
 	p.gh = ghapi.NewClient(nil)
@@ -115,41 +150,6 @@ func (p *github) downloadAsset(ctx context.Context, assetID int64, target string
 	}
 
 	return nil
-}
-
-func (p *github) GetOSUpdate(ctx context.Context) (OSUpdate, error) {
-	// Get latest release.
-	err := p.checkRelease(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// Prepare the OS update struct.
-	update := githubOSUpdate{
-		provider: p,
-		assets:   p.releaseAssets,
-		version:  p.releaseVersion,
-	}
-
-	return &update, nil
-}
-
-func (p *github) GetApplication(ctx context.Context, name string) (Application, error) {
-	// Get latest release.
-	err := p.checkRelease(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// Prepare the application struct.
-	app := githubApplication{
-		provider: p,
-		name:     name,
-		assets:   p.releaseAssets,
-		version:  p.releaseVersion,
-	}
-
-	return &app, nil
 }
 
 // An application from the Github provider.

--- a/incus-osd/internal/providers/provider_local.go
+++ b/incus-osd/internal/providers/provider_local.go
@@ -19,6 +19,29 @@ type local struct {
 	releaseVersion string
 }
 
+func (p *local) GetOSUpdate(_ context.Context) (OSUpdate, error) {
+	// Prepare the OS update struct.
+	update := localOSUpdate{
+		provider: p,
+		assets:   p.releaseAssets,
+		version:  p.releaseVersion,
+	}
+
+	return &update, nil
+}
+
+func (p *local) GetApplication(_ context.Context, name string) (Application, error) {
+	// Prepare the application struct.
+	app := localApplication{
+		provider: p,
+		name:     name,
+		assets:   p.releaseAssets,
+		version:  p.releaseVersion,
+	}
+
+	return &app, nil
+}
+
 func (p *local) load(ctx context.Context) error {
 	// Use a hardcoded path for now.
 	p.path = "/root/updates/"
@@ -100,29 +123,6 @@ func (p *local) copyAsset(_ context.Context, name string, target string) error {
 	}
 
 	return nil
-}
-
-func (p *local) GetOSUpdate(_ context.Context) (OSUpdate, error) {
-	// Prepare the OS update struct.
-	update := localOSUpdate{
-		provider: p,
-		assets:   p.releaseAssets,
-		version:  p.releaseVersion,
-	}
-
-	return &update, nil
-}
-
-func (p *local) GetApplication(_ context.Context, name string) (Application, error) {
-	// Prepare the application struct.
-	app := localApplication{
-		provider: p,
-		name:     name,
-		assets:   p.releaseAssets,
-		version:  p.releaseVersion,
-	}
-
-	return &app, nil
 }
 
 // An application from the Local provider.

--- a/incus-osd/internal/tui/tui.go
+++ b/incus-osd/internal/tui/tui.go
@@ -1,7 +1,6 @@
 package tui
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"os"
@@ -13,36 +12,63 @@ import (
 	"github.com/rivo/tview"
 
 	"github.com/lxc/incus-os/incus-osd/internal/state"
-	"github.com/lxc/incus-os/incus-osd/internal/systemd"
 )
 
-// tui represents a terminal user interface.
-type tui struct {
+// TUI represents a terminal user interface.
+type TUI struct {
 	app      *tview.Application
 	frame    *tview.Frame
 	pages    *tview.Pages
 	screen   tcell.Screen
 	textView *tview.TextView
+
+	state *state.State
 }
 
-var tuiInstance *tui
-
-// GetTUI returns a pointer the initialized TUI application.
-func GetTUI() (*tui, error) { //nolint:revive,nolintlint
-	var err error
-	if tuiInstance == nil {
-		tuiInstance, err = newTUI()
-		if err != nil {
-			return nil, err
-		}
+// NewTUI constructs a new TUI application that will show basic information and recent
+// log entries on the system's console.
+func NewTUI(s *state.State) (*TUI, error) {
+	ret := &TUI{
+		state: s,
 	}
 
-	return tuiInstance, nil
+	// Attempt to open the system's consoles.
+	ttys, err := newTtyMultiplexer("/dev/console", "/dev/tty1", "/dev/tty2", "/dev/tty3", "/dev/tty4", "/dev/tty5", "/dev/tty6", "/dev/tty7")
+	if err != nil {
+		return ret, err
+	}
+
+	// Construct a screen that is bound to the system console.
+	ret.screen, err = tcell.NewTerminfoScreenFromTty(ttys)
+	if err != nil {
+		return ret, err
+	}
+
+	// Define a text view to show recent log entries.
+	ret.textView = tview.NewTextView().
+		SetDynamicColors(true).
+		SetScrollable(false).
+		SetWordWrap(true).
+		SetChangedFunc(func() {
+			ret.app.Draw()
+		})
+	ret.textView.SetBorder(true)
+
+	// Define a frame to hold the TUI's primary content.
+	ret.frame = tview.NewFrame(nil).SetBorders(0, 0, 1, 1, 0, 0)
+
+	// Define a set of pages so we can present modal popups.
+	ret.pages = tview.NewPages().AddPage("frame", ret.frame, true, true)
+
+	// Define the TUI application.
+	ret.app = tview.NewApplication().SetScreen(ret.screen).SetRoot(ret.pages, true)
+
+	return ret, nil
 }
 
 // Write implements the Writer interface, so we can be passed to slog.NewTextHandler()
 // to update both the TUI and stdout with log entries.
-func (t *tui) Write(p []byte) (int, error) {
+func (t *TUI) Write(p []byte) (int, error) {
 	s := string(p)
 
 	// Colorize any warning or error level messages.
@@ -61,7 +87,7 @@ func (t *tui) Write(p []byte) (int, error) {
 }
 
 // Run is a wrapper to start the underlying TUI application.
-func (t *tui) Run() error {
+func (t *TUI) Run() error {
 	// Setup a gofunc to periodically re-draw the screen.
 	go func() {
 		for i := 0; ; i++ {
@@ -83,7 +109,7 @@ func (t *tui) Run() error {
 
 // DisplayModal displays a centered popup dialog. Optionally, if maxProgress is greater than zero,
 // renders a progress bar at the bottom.
-func (t *tui) DisplayModal(title string, msg string, progress int64, maxProgress int64) {
+func (t *TUI) DisplayModal(title string, msg string, progress int64, maxProgress int64) {
 	// Returns a new primitive which puts the provided primitive in the center and
 	// sets its size to the given width and height.
 	modal := func(p tview.Primitive, width, height int) tview.Primitive {
@@ -130,75 +156,27 @@ func (t *tui) DisplayModal(title string, msg string, progress int64, maxProgress
 }
 
 // RemoveModal hides the modal popup.
-func (t *tui) RemoveModal() {
+func (t *TUI) RemoveModal() {
 	t.pages.RemovePage("modal")
-}
-
-// newTUI constructs a new TUI application that will show basic information and recent
-// log entries on the system's console.
-func newTUI() (*tui, error) {
-	ret := &tui{}
-
-	// Attempt to open the system's consoles.
-	ttys, err := newTtyMultiplexer("/dev/console", "/dev/tty1", "/dev/tty2", "/dev/tty3", "/dev/tty4", "/dev/tty5", "/dev/tty6", "/dev/tty7")
-	if err != nil {
-		return ret, err
-	}
-
-	// Construct a screen that is bound to the system console.
-	ret.screen, err = tcell.NewTerminfoScreenFromTty(ttys)
-	if err != nil {
-		return ret, err
-	}
-
-	// Define a text view to show recent log entries.
-	ret.textView = tview.NewTextView().
-		SetDynamicColors(true).
-		SetScrollable(false).
-		SetWordWrap(true).
-		SetChangedFunc(func() {
-			ret.app.Draw()
-		})
-	ret.textView.SetBorder(true)
-
-	// Define a frame to hold the TUI's primary content.
-	ret.frame = tview.NewFrame(nil).SetBorders(0, 0, 1, 1, 0, 0)
-
-	// Define a set of pages so we can present modal popups.
-	ret.pages = tview.NewPages().AddPage("frame", ret.frame, true, true)
-
-	// Define the TUI application.
-	ret.app = tview.NewApplication().SetScreen(ret.screen).SetRoot(ret.pages, true)
-
-	return ret, nil
 }
 
 // redrawScreen clears and completely re-draws the TUI frame. This is necessary when updating
 // header or footer values, such as showing the current time.
-func (t *tui) redrawScreen() {
+func (t *TUI) redrawScreen() {
 	if t.frame == nil {
 		return
 	}
 
-	// Always directly fetch the OS version, since it won't be in the state on first startup.
-	incusOSVersion, err := systemd.GetCurrentRelease(context.TODO())
-	if err != nil {
-		incusOSVersion = "[" + err.Error() + "]"
-	}
-
 	// Get list of applications from state.
 	applications := []string{}
-	s, err := state.LoadOrCreate(context.TODO(), "/var/lib/incus-os/state.json")
-	if err == nil {
-		for app, info := range s.Applications {
-			applications = append(applications, app+"("+info.Version+")")
-		}
+	for app, info := range t.state.Applications {
+		applications = append(applications, app+"("+info.Version+")")
 	}
 	slices.Sort(applications)
 
 	t.frame.Clear()
 
-	t.frame.AddText("Incus OS "+incusOSVersion, true, tview.AlignCenter, tcell.ColorWhite)
+	t.frame.AddText("Incus OS "+t.state.RunningRelease, true, tview.AlignCenter, tcell.ColorWhite)
 	t.frame.AddText(time.Now().UTC().Format("2006-01-02 15:04 UTC"), true, tview.AlignRight, tcell.ColorWhite)
 
 	consoleWidth, _ := t.screen.Size()


### PR DESCRIPTION
Closes #38

We can't directly place a reference to the TUI package into the state struct, since that introduces an import loop. I've done some refactoring in main to pass the state when creating the TUI, then passing the TUI into the installer code.