### PR TITLE
Add encryption recovery API

### DIFF
--- a/incus-osd/api/system_encryption.go
+++ b/incus-osd/api/system_encryption.go
@@ -1,0 +1,7 @@
+package api
+
+// SystemEncryption defines a struct to hold information about the system's encryption state.
+type SystemEncryption struct {
+	RecoveryKeys          []string `json:"recovery_keys"`
+	RecoveryKeysRetrieved bool     `json:"recovery_keys_retrieved"`
+}

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -161,7 +161,7 @@ func shutdown(ctx context.Context, s *state.State, t *tui.TUI) error {
 	slog.Info("Shutting down", "release", s.RunningRelease)
 	t.DisplayModal("System shutdown", "Shutting down the system", 0, 0)
 
-	// Run application shutdown actions..
+	// Run application shutdown actions.
 	for appName, appInfo := range s.Applications {
 		// Get the application.
 		app, err := applications.Load(ctx, appName)
@@ -169,7 +169,7 @@ func shutdown(ctx context.Context, s *state.State, t *tui.TUI) error {
 			return err
 		}
 
-		// Start the application.
+		// Stop the application.
 		slog.Info("Stopping application", "name", appName, "version", appInfo.Version)
 
 		err = app.Stop(ctx, appInfo.Version)
@@ -178,7 +178,7 @@ func shutdown(ctx context.Context, s *state.State, t *tui.TUI) error {
 		}
 	}
 
-	// Run services startup actions.
+	// Run services shutdown actions.
 	for _, srvName := range services.ValidNames {
 		srv, err := services.Load(ctx, s, srvName)
 		if err != nil {

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -96,6 +96,9 @@ func main() {
 func run(ctx context.Context, s *state.State, t *tui.TUI) error {
 	// Check if we should try to install to a local disk.
 	if install.IsInstallNeeded() {
+		// Don't display warning about recovery key during install.
+		s.System.Encryption.RecoveryKeysRetrieved = true
+
 		inst, err := install.NewInstall(t)
 		if err != nil {
 			return err

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -239,6 +239,14 @@ func startup(ctx context.Context, s *state.State, t *tui.TUI) error {
 		slog.Info("Platform keyring entry", "name", key.Description, "key", key.Fingerprint)
 	}
 
+	// If no encryption recovery keys have been defined for the root partition, generate one before going any further.
+	if len(s.System.Encryption.RecoveryKeys) == 0 {
+		err := systemd.GenerateRecoveryKey(ctx, s)
+		if err != nil {
+			return err
+		}
+	}
+
 	slog.Info("Starting up", "mode", mode, "release", s.RunningRelease)
 
 	// If there's no network configuration in the state, attempt to fetch from the seed info.

--- a/incus-osd/internal/rest/api_encryption.go
+++ b/incus-osd/internal/rest/api_encryption.go
@@ -1,0 +1,55 @@
+package rest
+
+import (
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/lxc/incus-os/incus-osd/internal/rest/response"
+	"github.com/lxc/incus-os/incus-osd/internal/systemd"
+)
+
+func (s *Server) apiSystemEncryption(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	switch r.Method {
+	case http.MethodGet:
+		// Mark that the keys have been retrieved via the API.
+		s.state.System.Encryption.RecoveryKeysRetrieved = true
+
+		// Return the current system encryption state.
+		_ = response.SyncResponse(true, s.state.System.Encryption).Render(w)
+	case http.MethodPut, http.MethodDelete:
+		// Add or remove an encryption key.
+		if r.ContentLength <= 0 {
+			_ = response.BadRequest(errors.New("no encryption key provided")).Render(w)
+
+			return
+		}
+
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			_ = response.BadRequest(err).Render(w)
+
+			return
+		}
+
+		if r.Method == http.MethodPut {
+			err = systemd.AddEncryptionKey(r.Context(), s.state, string(b))
+		} else {
+			err = systemd.DeleteEncryptionKey(r.Context(), s.state, string(b))
+		}
+		if err != nil {
+			_ = response.BadRequest(err).Render(w)
+
+			return
+		}
+
+		_ = response.EmptySyncResponse.Render(w)
+	default:
+		// If none of the supported methods, return NotImplemented.
+		_ = response.NotImplemented(nil).Render(w)
+	}
+
+	_ = s.state.Save(r.Context())
+}

--- a/incus-osd/internal/rest/api_system_network.go
+++ b/incus-osd/internal/rest/api_system_network.go
@@ -67,6 +67,8 @@ func (s *Server) apiSystemNetwork(w http.ResponseWriter, r *http.Request) {
 		}
 
 		_ = response.EmptySyncResponse.Render(w)
+
+		_ = s.state.Save(r.Context())
 	default:
 		// If none of the supported methods, return NotImplemented.
 		_ = response.NotImplemented(nil).Render(w)

--- a/incus-osd/internal/rest/server.go
+++ b/incus-osd/internal/rest/server.go
@@ -51,6 +51,7 @@ func (s *Server) Serve(_ context.Context) error {
 	router.HandleFunc("/1.0/services", s.apiServices)
 	router.HandleFunc("/1.0/services/{name}", s.apiServicesEndpoint)
 	router.HandleFunc("/1.0/system", s.apiSystem)
+	router.HandleFunc("/1.0/system/encryption", s.apiSystemEncryption)
 	router.HandleFunc("/1.0/system/network", s.apiSystemNetwork)
 
 	// Setup server.

--- a/incus-osd/internal/state/file.go
+++ b/incus-osd/internal/state/file.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+
+	"github.com/lxc/incus-os/incus-osd/api"
 )
 
 // LoadOrCreate parses the on-disk state file and returns a State struct.
@@ -14,6 +16,7 @@ func LoadOrCreate(ctx context.Context, path string) (*State, error) {
 
 		Applications: map[string]Application{},
 	}
+	s.System.Encryption = new(api.SystemEncryption)
 
 	body, err := os.ReadFile(s.path)
 	if err != nil {

--- a/incus-osd/internal/state/struct.go
+++ b/incus-osd/internal/state/struct.go
@@ -27,6 +27,7 @@ type State struct {
 	} `json:"services"`
 
 	System struct {
-		Network *api.SystemNetwork `json:"network"`
+		Encryption *api.SystemEncryption `json:"encryption"`
+		Network    *api.SystemNetwork    `json:"network"`
 	} `json:"system"`
 }

--- a/incus-osd/internal/systemd/cryptenroll.go
+++ b/incus-osd/internal/systemd/cryptenroll.go
@@ -1,0 +1,78 @@
+package systemd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/lxc/incus/v6/shared/subprocess"
+
+	"github.com/lxc/incus-os/incus-osd/internal/state"
+)
+
+// GenerateRecoveryKey utilizes systemd-cryptenroll to generate a recovery key for the
+// root LUKS volume. Depends on an existing tpm2-backed key being enrolled and accessible.
+func GenerateRecoveryKey(ctx context.Context, s *state.State) error {
+	output, err := subprocess.RunCommandContext(ctx, "systemd-cryptenroll", "--unlock-tpm2-device", "auto", "--recovery-key", "/dev/disk/by-partlabel/root-x86-64")
+	if err != nil {
+		return err
+	}
+
+	s.System.Encryption.RecoveryKeys = append(s.System.Encryption.RecoveryKeys, strings.TrimSuffix(output, "\n"))
+	s.System.Encryption.RecoveryKeysRetrieved = false
+
+	return nil
+}
+
+// AddEncryptionKey utilizes systemd-cryptenroll to add a user-specified key for the
+// root LUKS volume. Depends on an existing tpm2-backed key being enrolled and accessible.
+func AddEncryptionKey(ctx context.Context, s *state.State, key string) error {
+	if slices.Contains(s.System.Encryption.RecoveryKeys, key) {
+		return errors.New("provided encryption key is already enrolled")
+	}
+
+	// Add the new encryption password. Need to pass to systemd-cryptenroll via NEWPASSWORD environment variable.
+	_, _, err := subprocess.RunCommandSplit(ctx, append(os.Environ(), "NEWPASSWORD="+key), nil, "systemd-cryptenroll", "--unlock-tpm2-device", "auto", "--password", "/dev/disk/by-partlabel/root-x86-64")
+	if err != nil {
+		return err
+	}
+
+	s.System.Encryption.RecoveryKeys = append(s.System.Encryption.RecoveryKeys, key)
+
+	return nil
+}
+
+// DeleteEncryptionKey utilizes systemd-cryptenroll to remove a user-specified key from the
+// root LUKS volume. Depends on an existing tpm2-backed key being enrolled and accessible.
+// Due to systemd-cryptenroll only being able to wipe slots by index or type, we must first
+// remove all recovery and password slots, then re-add any remaining keys.
+func DeleteEncryptionKey(ctx context.Context, s *state.State, key string) error {
+	if !slices.Contains(s.System.Encryption.RecoveryKeys, key) {
+		return errors.New("provided encryption key is not enrolled")
+	}
+
+	// First, wipe all recovery and password slots.
+	_, err := subprocess.RunCommandContext(ctx, "systemd-cryptenroll", "--unlock-tpm2-device", "auto", "--wipe-slot", "recovery,password", "/dev/disk/by-partlabel/root-x86-64")
+	if err != nil {
+		return err
+	}
+
+	existingKeys := s.System.Encryption.RecoveryKeys
+	s.System.Encryption.RecoveryKeys = []string{}
+
+	// Re-add remaining keys.
+	for _, existingKey := range existingKeys {
+		if existingKey == key {
+			continue
+		}
+
+		err := AddEncryptionKey(ctx, s, existingKey)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/incus-osd/internal/tui/tui.go
+++ b/incus-osd/internal/tui/tui.go
@@ -187,6 +187,10 @@ func (t *TUI) redrawScreen() {
 		t.frame.AddText(line, false, tview.AlignLeft, tcell.ColorWhite)
 	}
 
+	if !t.state.System.Encryption.RecoveryKeysRetrieved {
+		t.frame.AddText("WARNING: Encryption recovery key has not been retrieved yet!", false, tview.AlignLeft, tcell.ColorRed)
+	}
+
 	if t.textView != nil {
 		t.frame.SetPrimitive(t.textView)
 	}

--- a/mkosi.images/base/mkosi.extra/usr/lib/repart.d/40-root.conf
+++ b/mkosi.images/base/mkosi.extra/usr/lib/repart.d/40-root.conf
@@ -3,4 +3,4 @@ Type=root
 Format=ext4
 SizeMinBytes=25G
 SizeMaxBytes=25G
-Encrypt=key-file+tpm2
+Encrypt=tpm2


### PR DESCRIPTION
Closes #52

We no longer set an empty encryption password in the repart configuration for the root partition.

The tpm binding defaults to looking at just PCR 7; do we want to modify that?

`systemd-cryptenroll` has a nice built-in option to generate recovery keys that look similar to BitLocker's: `fikibljt-rikgbifh-uijvcivb-eljkfufv-uugitiin-ujcdugdt-vibnnrev-iivubuiv`.

Adds a REST endpoint to get a list of current recovery passwords, as well as adding and removing individual passwords.

![image](https://github.com/user-attachments/assets/3db88aee-5bf3-4c4b-b572-2fc78a39b05f)