### PR TITLE
Disable write timeouts

### DIFF
--- a/incus-osd/internal/rest/server.go
+++ b/incus-osd/internal/rest/server.go
@@ -59,7 +59,7 @@ func (s *Server) Serve(_ context.Context) error {
 		Handler: router,
 
 		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		WriteTimeout: 0,
 	}
 
 	return server.Serve(listener)


### PR DESCRIPTION
Calls to the encryption endpoints to add/remove an encryption key can take more than 10 seconds. Since this is a restricted server running on a local unix socket disable the write timeout.