### PR TITLE
Align system API with services API

### DIFF
--- a/incus-osd/api/system_encryption.go
+++ b/incus-osd/api/system_encryption.go
@@ -2,6 +2,11 @@ package api
 
 // SystemEncryption defines a struct to hold information about the system's encryption state.
 type SystemEncryption struct {
-	RecoveryKeys          []string `json:"recovery_keys"`
-	RecoveryKeysRetrieved bool     `json:"recovery_keys_retrieved"`
+	Config struct {
+		RecoveryKeys []string `json:"recovery_keys" yaml:"recovery_keys"`
+	} `json:"config" yaml:"config"`
+
+	State struct {
+		RecoveryKeysRetrieved bool `json:"-" yaml:"-"`
+	} `json:"state" yaml:"state"`
 }

--- a/incus-osd/api/system_network.go
+++ b/incus-osd/api/system_network.go
@@ -2,6 +2,13 @@ package api
 
 // SystemNetwork defines a struct to hold the three types of supported network configuration.
 type SystemNetwork struct {
+	Config *SystemNetworkConfig `json:"config" yaml:"config"`
+
+	State struct{} `json:"state" yaml:"state"`
+}
+
+// SystemNetworkConfig represents the user modifiable network configuration.
+type SystemNetworkConfig struct {
 	Version string `json:"version" yaml:"version"`
 
 	DNS   *SystemNetworkDNS   `json:"dns"   yaml:"dns"`

--- a/incus-osd/api/system_network.go
+++ b/incus-osd/api/system_network.go
@@ -9,8 +9,6 @@ type SystemNetwork struct {
 
 // SystemNetworkConfig represents the user modifiable network configuration.
 type SystemNetworkConfig struct {
-	Version string `json:"version" yaml:"version"`
-
 	DNS   *SystemNetworkDNS   `json:"dns"   yaml:"dns"`
 	NTP   *SystemNetworkNTP   `json:"ntp"   yaml:"ntp"`
 	Proxy *SystemNetworkProxy `json:"proxy" yaml:"proxy"`

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -250,8 +250,8 @@ func startup(ctx context.Context, s *state.State, t *tui.TUI) error {
 	slog.Info("Starting up", "mode", mode, "release", s.RunningRelease)
 
 	// If there's no network configuration in the state, attempt to fetch from the seed info.
-	if s.System.Network == nil {
-		s.System.Network, err = seed.GetNetwork(ctx, seed.SeedPartitionPath)
+	if s.System.Network.Config == nil {
+		s.System.Network.Config, err = seed.GetNetwork(ctx, seed.SeedPartitionPath)
 		if err != nil && !seed.IsMissing(err) {
 			return err
 		}
@@ -259,7 +259,7 @@ func startup(ctx context.Context, s *state.State, t *tui.TUI) error {
 
 	// Perform network configuration.
 	slog.Info("Bringing up the network")
-	err = systemd.ApplyNetworkConfiguration(ctx, s.System.Network, 10*time.Second)
+	err = systemd.ApplyNetworkConfiguration(ctx, s.System.Network.Config, 10*time.Second)
 	if err != nil {
 		return err
 	}

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -97,7 +97,7 @@ func run(ctx context.Context, s *state.State, t *tui.TUI) error {
 	// Check if we should try to install to a local disk.
 	if install.IsInstallNeeded() {
 		// Don't display warning about recovery key during install.
-		s.System.Encryption.RecoveryKeysRetrieved = true
+		s.System.Encryption.State.RecoveryKeysRetrieved = true
 
 		inst, err := install.NewInstall(t)
 		if err != nil {
@@ -240,7 +240,7 @@ func startup(ctx context.Context, s *state.State, t *tui.TUI) error {
 	}
 
 	// If no encryption recovery keys have been defined for the root partition, generate one before going any further.
-	if len(s.System.Encryption.RecoveryKeys) == 0 {
+	if len(s.System.Encryption.Config.RecoveryKeys) == 0 {
 		err := systemd.GenerateRecoveryKey(ctx, s)
 		if err != nil {
 			return err

--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -22,7 +22,7 @@ import (
 
 // Install holds information necessary to perform an installation.
 type Install struct {
-	config *seed.InstallConfig
+	config *seed.InstallSeed
 	tui    *tui.TUI
 }
 

--- a/incus-osd/internal/rest/api_encryption.go
+++ b/incus-osd/internal/rest/api_encryption.go
@@ -15,7 +15,7 @@ func (s *Server) apiSystemEncryption(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		// Mark that the keys have been retrieved via the API.
-		s.state.System.Encryption.RecoveryKeysRetrieved = true
+		s.state.System.Encryption.State.RecoveryKeysRetrieved = true
 
 		// Return the current system encryption state.
 		_ = response.SyncResponse(true, s.state.System.Encryption).Render(w)

--- a/incus-osd/internal/rest/api_system_network.go
+++ b/incus-osd/internal/rest/api_system_network.go
@@ -21,7 +21,7 @@ func (s *Server) apiSystemNetwork(w http.ResponseWriter, r *http.Request) {
 		_ = response.SyncResponse(true, s.state.System.Network).Render(w)
 	case http.MethodPatch, http.MethodPut:
 		// Apply an update or completely replace the network configuration.
-		newConfig := &api.SystemNetwork{}
+		newConfig := &api.SystemNetworkConfig{}
 
 		// If updating, grab the current configuration.
 		if r.Method == http.MethodPatch {
@@ -58,8 +58,8 @@ func (s *Server) apiSystemNetwork(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Apply the updated configuration.
-		s.state.System.Network = newConfig
-		err = systemd.ApplyNetworkConfiguration(r.Context(), s.state.System.Network, 10*time.Second)
+		s.state.System.Network.Config = newConfig
+		err = systemd.ApplyNetworkConfiguration(r.Context(), s.state.System.Network.Config, 10*time.Second)
 		if err != nil {
 			_ = response.BadRequest(err).Render(w)
 

--- a/incus-osd/internal/rest/api_system_network.go
+++ b/incus-osd/internal/rest/api_system_network.go
@@ -21,7 +21,7 @@ func (s *Server) apiSystemNetwork(w http.ResponseWriter, r *http.Request) {
 		_ = response.SyncResponse(true, s.state.System.Network).Render(w)
 	case http.MethodPatch, http.MethodPut:
 		// Apply an update or completely replace the network configuration.
-		newConfig := new(api.SystemNetwork)
+		newConfig := &api.SystemNetwork{}
 
 		// If updating, grab the current configuration.
 		if r.Method == http.MethodPatch {

--- a/incus-osd/internal/seed/install.go
+++ b/incus-osd/internal/seed/install.go
@@ -1,27 +1,27 @@
 package seed
 
-// InstallConfig defines a struct to hold install configuration.
-type InstallConfig struct {
+// InstallSeed defines a struct to hold install configuration.
+type InstallSeed struct {
 	Version string `json:"version" yaml:"version"`
 
-	ForceInstall bool                 `json:"force_install" yaml:"force_install"` // If true, ignore any existing data on target install disk.
-	ForceReboot  bool                 `json:"force_reboot"  yaml:"force_reboot"`  // If true, reboot the system automatically upon completion rather than waiting for the install media to be removed.
-	Target       *InstallConfigTarget `json:"target"        yaml:"target"`        // Optional selector for the target install disk; if not set, expect a single drive to be present.
+	ForceInstall bool               `json:"force_install" yaml:"force_install"` // If true, ignore any existing data on target install disk.
+	ForceReboot  bool               `json:"force_reboot"  yaml:"force_reboot"`  // If true, reboot the system automatically upon completion rather than waiting for the install media to be removed.
+	Target       *InstallSeedTarget `json:"target"        yaml:"target"`        // Optional selector for the target install disk; if not set, expect a single drive to be present.
 }
 
-// InstallConfigTarget defines options used to select the target install disk.
-type InstallConfigTarget struct {
+// InstallSeedTarget defines options used to select the target install disk.
+type InstallSeedTarget struct {
 	ID string `json:"id" yaml:"id"` // Name as listed in /dev/disk/by-id/, glob supported.
 }
 
 // GetInstallConfig extracts the list of applications from the seed data.
-func GetInstallConfig(partition string) (*InstallConfig, error) {
+func GetInstallConfig(partition string) (*InstallSeed, error) {
 	// Get the install configuration.
-	var config InstallConfig
+	var config InstallSeed
 
 	err := parseFileContents(partition, "install", &config)
 	if err != nil {
-		return &InstallConfig{}, err
+		return &InstallSeed{}, err
 	}
 
 	return &config, nil

--- a/incus-osd/internal/seed/network.go
+++ b/incus-osd/internal/seed/network.go
@@ -49,7 +49,7 @@ func getDefaultNetworkConfig() (*api.SystemNetwork, error) {
 		return nil, err
 	}
 
-	ret := new(api.SystemNetwork)
+	ret := &api.SystemNetwork{}
 
 	for _, i := range interfaces {
 		if i.Name == "lo" {

--- a/incus-osd/internal/seed/network.go
+++ b/incus-osd/internal/seed/network.go
@@ -7,11 +7,18 @@ import (
 	"github.com/lxc/incus-os/incus-osd/api"
 )
 
+// NetworkSeed defines a struct to hold network configuration.
+type NetworkSeed struct {
+	api.SystemNetworkConfig
+
+	Version string `json:"version" yaml:"version"`
+}
+
 // GetNetwork extracts the network configuration from the seed data.
 // If no seed network found, a default minimal network config will be returned.
 func GetNetwork(_ context.Context, partition string) (*api.SystemNetworkConfig, error) {
 	// Get the network configuration.
-	var config api.SystemNetworkConfig
+	var config NetworkSeed
 
 	err := parseFileContents(partition, "network", &config)
 	if err != nil {
@@ -25,7 +32,7 @@ func GetNetwork(_ context.Context, partition string) (*api.SystemNetworkConfig, 
 	}
 
 	// If no interfaces, bonds, or vlans are defined, add a minimal default configuration for the interfaces.
-	if NetworkConfigHasEmptyDevices(config) {
+	if NetworkConfigHasEmptyDevices(config.SystemNetworkConfig) {
 		defaultNetwork, err := getDefaultNetworkConfig()
 		if err != nil {
 			return nil, err
@@ -33,7 +40,7 @@ func GetNetwork(_ context.Context, partition string) (*api.SystemNetworkConfig, 
 		config.Interfaces = defaultNetwork.Interfaces
 	}
 
-	return &config, nil
+	return &config.SystemNetworkConfig, nil
 }
 
 // NetworkConfigHasEmptyDevices checks if any device (interface, bond, or vlan) is defined in the given config.

--- a/incus-osd/internal/seed/network.go
+++ b/incus-osd/internal/seed/network.go
@@ -9,9 +9,9 @@ import (
 
 // GetNetwork extracts the network configuration from the seed data.
 // If no seed network found, a default minimal network config will be returned.
-func GetNetwork(_ context.Context, partition string) (*api.SystemNetwork, error) {
+func GetNetwork(_ context.Context, partition string) (*api.SystemNetworkConfig, error) {
 	// Get the network configuration.
-	var config api.SystemNetwork
+	var config api.SystemNetworkConfig
 
 	err := parseFileContents(partition, "network", &config)
 	if err != nil {
@@ -37,19 +37,19 @@ func GetNetwork(_ context.Context, partition string) (*api.SystemNetwork, error)
 }
 
 // NetworkConfigHasEmptyDevices checks if any device (interface, bond, or vlan) is defined in the given config.
-func NetworkConfigHasEmptyDevices(networkCfg api.SystemNetwork) bool {
+func NetworkConfigHasEmptyDevices(networkCfg api.SystemNetworkConfig) bool {
 	return len(networkCfg.Interfaces) == 0 && len(networkCfg.Bonds) == 0 && len(networkCfg.Vlans) == 0
 }
 
 // getDefaultNetworkConfig returns a minimal network configuration, with every interface
 // configured to acquire an IP via DHCP and SLAAC.
-func getDefaultNetworkConfig() (*api.SystemNetwork, error) {
+func getDefaultNetworkConfig() (*api.SystemNetworkConfig, error) {
 	interfaces, err := net.Interfaces()
 	if err != nil {
 		return nil, err
 	}
 
-	ret := &api.SystemNetwork{}
+	ret := &api.SystemNetworkConfig{}
 
 	for _, i := range interfaces {
 		if i.Name == "lo" {

--- a/incus-osd/internal/seed/seed_test.go
+++ b/incus-osd/internal/seed/seed_test.go
@@ -11,7 +11,7 @@ import (
 func TestGetFileContents(t *testing.T) {
 	t.Parallel()
 
-	var config api.SystemNetwork
+	var config api.SystemNetworkConfig
 	err := parseFileContents("testdata.tar", "network", &config)
 	require.NoError(t, err)
 }

--- a/incus-osd/internal/services/service_iscsi.go
+++ b/incus-osd/internal/services/service_iscsi.go
@@ -210,10 +210,6 @@ func (*ISCSI) Struct() any {
 	return &api.ServiceISCSI{}
 }
 
-func (n *ISCSI) init(_ context.Context) error {
-	if n.state.Services.ISCSI == nil {
-		n.state.Services.ISCSI = &api.ServiceISCSI{}
-	}
-
+func (*ISCSI) init(_ context.Context) error {
 	return nil
 }

--- a/incus-osd/internal/services/service_nvme.go
+++ b/incus-osd/internal/services/service_nvme.go
@@ -208,10 +208,6 @@ func (*NVME) Struct() any {
 	return &api.ServiceNVME{}
 }
 
-func (n *NVME) init(_ context.Context) error {
-	if n.state.Services.NVME == nil {
-		n.state.Services.NVME = &api.ServiceNVME{}
-	}
-
+func (*NVME) init(_ context.Context) error {
 	return nil
 }

--- a/incus-osd/internal/state/file.go
+++ b/incus-osd/internal/state/file.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"os"
-
-	"github.com/lxc/incus-os/incus-osd/api"
 )
 
 // LoadOrCreate parses the on-disk state file and returns a State struct.
@@ -16,8 +14,6 @@ func LoadOrCreate(ctx context.Context, path string) (*State, error) {
 
 		Applications: map[string]Application{},
 	}
-
-	s.System.Encryption = &api.SystemEncryption{}
 
 	body, err := os.ReadFile(s.path)
 	if err != nil {

--- a/incus-osd/internal/state/file.go
+++ b/incus-osd/internal/state/file.go
@@ -16,7 +16,8 @@ func LoadOrCreate(ctx context.Context, path string) (*State, error) {
 
 		Applications: map[string]Application{},
 	}
-	s.System.Encryption = new(api.SystemEncryption)
+
+	s.System.Encryption = &api.SystemEncryption{}
 
 	body, err := os.ReadFile(s.path)
 	if err != nil {

--- a/incus-osd/internal/state/struct.go
+++ b/incus-osd/internal/state/struct.go
@@ -22,12 +22,12 @@ type State struct {
 	RunningRelease string                 `json:"running_release"`
 
 	Services struct {
-		ISCSI *api.ServiceISCSI `json:"iscsi"`
-		NVME  *api.ServiceNVME  `json:"nvme"`
+		ISCSI api.ServiceISCSI `json:"iscsi"`
+		NVME  api.ServiceNVME  `json:"nvme"`
 	} `json:"services"`
 
 	System struct {
-		Encryption *api.SystemEncryption `json:"encryption"`
-		Network    *api.SystemNetwork    `json:"network"`
+		Encryption api.SystemEncryption `json:"encryption"`
+		Network    api.SystemNetwork    `json:"network"`
 	} `json:"system"`
 }

--- a/incus-osd/internal/systemd/networkd.go
+++ b/incus-osd/internal/systemd/networkd.go
@@ -23,7 +23,7 @@ type networkdConfigFile struct {
 
 // generateNetworkConfiguration clears any existing configuration from /run/systemd/network/ and generates
 // new config files from the supplied NetworkConfig struct.
-func generateNetworkConfiguration(_ context.Context, networkCfg *api.SystemNetwork) error {
+func generateNetworkConfiguration(_ context.Context, networkCfg *api.SystemNetworkConfig) error {
 	// Remove any existing configuration.
 	err := os.RemoveAll(SystemdNetworkConfigPath)
 	if err != nil {
@@ -81,7 +81,7 @@ func generateNetworkConfiguration(_ context.Context, networkCfg *api.SystemNetwo
 }
 
 // ApplyNetworkConfiguration instructs systemd-networkd to apply the supplied network configuration.
-func ApplyNetworkConfiguration(ctx context.Context, networkCfg *api.SystemNetwork, timeout time.Duration) error {
+func ApplyNetworkConfiguration(ctx context.Context, networkCfg *api.SystemNetworkConfig, timeout time.Duration) error {
 	if networkCfg == nil {
 		return errors.New("no network configuration provided")
 	}
@@ -147,7 +147,7 @@ func ApplyNetworkConfiguration(ctx context.Context, networkCfg *api.SystemNetwor
 
 // waitForNetworkRoutable waits up to a provided timeout for all configured network interfaces,
 // bonds, and vlans to become routable.
-func waitForNetworkRoutable(ctx context.Context, networkCfg *api.SystemNetwork, timeout time.Duration) error {
+func waitForNetworkRoutable(ctx context.Context, networkCfg *api.SystemNetworkConfig, timeout time.Duration) error {
 	isRoutable := func(name string) bool {
 		output, err := subprocess.RunCommandContext(ctx, "networkctl", "status", name)
 		if err != nil {
@@ -191,7 +191,7 @@ mainloop:
 
 // generateLinkFileContents generates the contents of systemd.link files. Returns an array of ConfigFile structs.
 // https://www.freedesktop.org/software/systemd/man/latest/systemd.link.html
-func generateLinkFileContents(networkCfg api.SystemNetwork) []networkdConfigFile {
+func generateLinkFileContents(networkCfg api.SystemNetworkConfig) []networkdConfigFile {
 	ret := []networkdConfigFile{}
 
 	for _, i := range networkCfg.Interfaces {
@@ -213,7 +213,7 @@ Name=en%s
 
 // generateNetdevFileContents generates the contents of systemd.netdev files. Returns an array of networkdConfigFile structs.
 // https://www.freedesktop.org/software/systemd/man/latest/systemd.netdev.html
-func generateNetdevFileContents(networkCfg api.SystemNetwork) []networkdConfigFile {
+func generateNetdevFileContents(networkCfg api.SystemNetworkConfig) []networkdConfigFile {
 	ret := []networkdConfigFile{}
 
 	// Create bridge devices for each interface.
@@ -265,7 +265,7 @@ Id=%d
 
 // generateNetworkFileContents generates the contents of systemd.network files. Returns an array of networkdConfigFile structs.
 // https://www.freedesktop.org/software/systemd/man/latest/systemd.network.html
-func generateNetworkFileContents(networkCfg api.SystemNetwork) []networkdConfigFile {
+func generateNetworkFileContents(networkCfg api.SystemNetworkConfig) []networkdConfigFile {
 	ret := []networkdConfigFile{}
 
 	// Create networks for each interface.

--- a/incus-osd/internal/systemd/networkd_test.go
+++ b/incus-osd/internal/systemd/networkd_test.go
@@ -100,7 +100,7 @@ func TestNetworkConfigMarshalling(t *testing.T) {
 	t.Parallel()
 
 	{
-		var cfg, cfgAgain api.SystemNetwork
+		var cfg, cfgAgain api.SystemNetworkConfig
 
 		// Test unmarshalling of the first test config.
 		err := yaml.Unmarshal([]byte(networkdConfig1), &cfg)
@@ -138,7 +138,7 @@ func TestNetworkConfigMarshalling(t *testing.T) {
 	}
 
 	{
-		var cfg, cfgAgain api.SystemNetwork
+		var cfg, cfgAgain api.SystemNetworkConfig
 
 		// Test unmarshalling of the second test config.
 		err := yaml.Unmarshal([]byte(networkdConfig2), &cfg)
@@ -164,7 +164,7 @@ func TestNetworkConfigMarshalling(t *testing.T) {
 	}
 
 	{
-		var cfg, cfgAgain api.SystemNetwork
+		var cfg, cfgAgain api.SystemNetworkConfig
 
 		// Test unmarshalling of the third test config.
 		err := yaml.Unmarshal([]byte(networkdConfig3), &cfg)
@@ -197,7 +197,7 @@ func TestNetworkConfigMarshalling(t *testing.T) {
 func TestLinkFileGeneration(t *testing.T) {
 	t.Parallel()
 
-	var networkCfg api.SystemNetwork
+	var networkCfg api.SystemNetworkConfig
 
 	// Test first config .link file generation.
 	err := yaml.Unmarshal([]byte(networkdConfig1), &networkCfg)
@@ -211,7 +211,7 @@ func TestLinkFileGeneration(t *testing.T) {
 	require.Equal(t, "[Match]\nMACAddress=AA:BB:CC:DD:EE:02\n\n[Link]\nNamePolicy=\nName=enaabbccddee02\n", cfgs[1].Contents)
 
 	// Test second config .link file generation.
-	networkCfg = api.SystemNetwork{}
+	networkCfg = api.SystemNetworkConfig{}
 	err = yaml.Unmarshal([]byte(networkdConfig2), &networkCfg)
 	require.NoError(t, err)
 
@@ -221,7 +221,7 @@ func TestLinkFileGeneration(t *testing.T) {
 	require.Equal(t, "[Match]\nMACAddress=AA:BB:CC:DD:EE:01\n\n[Link]\nNamePolicy=\nName=enaabbccddee01\n", cfgs[0].Contents)
 
 	// Test third config .link file generation.
-	networkCfg = api.SystemNetwork{}
+	networkCfg = api.SystemNetworkConfig{}
 	err = yaml.Unmarshal([]byte(networkdConfig3), &networkCfg)
 	require.NoError(t, err)
 
@@ -234,7 +234,7 @@ func TestLinkFileGeneration(t *testing.T) {
 func TestNetdevFileGeneration(t *testing.T) {
 	t.Parallel()
 
-	var networkCfg api.SystemNetwork
+	var networkCfg api.SystemNetworkConfig
 
 	// Test first config .netdev file generation.
 	err := yaml.Unmarshal([]byte(networkdConfig1), &networkCfg)
@@ -252,7 +252,7 @@ func TestNetdevFileGeneration(t *testing.T) {
 	require.Equal(t, "[NetDev]\nName=vluplink\nKind=vlan\nMTUBytes=1500\n\n[Bridge]\nId=1234\n", cfgs[3].Contents)
 
 	// Test second config .netdev file generation.
-	networkCfg = api.SystemNetwork{}
+	networkCfg = api.SystemNetworkConfig{}
 	err = yaml.Unmarshal([]byte(networkdConfig2), &networkCfg)
 	require.NoError(t, err)
 
@@ -262,7 +262,7 @@ func TestNetdevFileGeneration(t *testing.T) {
 	require.Equal(t, "[NetDev]\nName=management\nKind=bridge\n\n[Bridge]\nVLANFiltering=true\n", cfgs[0].Contents)
 
 	// Test third config .netdev file generation.
-	networkCfg = api.SystemNetwork{}
+	networkCfg = api.SystemNetworkConfig{}
 	err = yaml.Unmarshal([]byte(networkdConfig3), &networkCfg)
 	require.NoError(t, err)
 
@@ -275,7 +275,7 @@ func TestNetdevFileGeneration(t *testing.T) {
 func TestNetworkFileGeneration(t *testing.T) {
 	t.Parallel()
 
-	var networkCfg api.SystemNetwork
+	var networkCfg api.SystemNetworkConfig
 
 	// Test first config .network file generation.
 	err := yaml.Unmarshal([]byte(networkdConfig1), &networkCfg)
@@ -299,7 +299,7 @@ func TestNetworkFileGeneration(t *testing.T) {
 	require.Equal(t, "[Match]\nMACAddress=AA:BB:CC:DD:EE:04\n\n[Network]\nBond=bnmanagement\n", cfgs[6].Contents)
 
 	// Test second config .network file generation.
-	networkCfg = api.SystemNetwork{}
+	networkCfg = api.SystemNetworkConfig{}
 	err = yaml.Unmarshal([]byte(networkdConfig2), &networkCfg)
 	require.NoError(t, err)
 
@@ -311,7 +311,7 @@ func TestNetworkFileGeneration(t *testing.T) {
 	require.Equal(t, "[Match]\nName=enaabbccddee01\n\n[Network]\nBridge=management\n", cfgs[1].Contents)
 
 	// Test third config .network file generation.
-	networkCfg = api.SystemNetwork{}
+	networkCfg = api.SystemNetworkConfig{}
 	err = yaml.Unmarshal([]byte(networkdConfig3), &networkCfg)
 	require.NoError(t, err)
 

--- a/incus-osd/internal/systemd/networkd_test.go
+++ b/incus-osd/internal/systemd/networkd_test.go
@@ -74,7 +74,6 @@ interfaces:
 `
 
 var networkdConfig3 = `
-version: 1.2.3
 dns:
   hostname: host
   domain: example.org
@@ -171,7 +170,6 @@ func TestNetworkConfigMarshalling(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify values were parsed correctly.
-		require.Equal(t, "1.2.3", cfg.Version)
 		require.Equal(t, "host", cfg.DNS.Hostname)
 		require.Equal(t, "example.org", cfg.DNS.Domain)
 		require.Len(t, cfg.DNS.SearchDomains, 1)

--- a/incus-osd/internal/tui/tui.go
+++ b/incus-osd/internal/tui/tui.go
@@ -187,7 +187,7 @@ func (t *TUI) redrawScreen() {
 		t.frame.AddText(line, false, tview.AlignLeft, tcell.ColorWhite)
 	}
 
-	if !t.state.System.Encryption.RecoveryKeysRetrieved {
+	if !t.state.System.Encryption.State.RecoveryKeysRetrieved {
 		t.frame.AddText("WARNING: Encryption recovery key has not been retrieved yet!", false, tview.AlignLeft, tcell.ColorRed)
 	}
 


### PR DESCRIPTION
This makes it so all endpoints have both a `config` and `state` section with `config` being the user-editable section.