### PR TITLE
Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,6 @@ test:
 	# Prepare the install media
 	cp $(shell ls mkosi.output/IncusOS_*.raw | grep -v usr | grep -v esp | sort | tail -1) mkosi.output/IncusOS_boot_media.img
 	dd if=test/seed.install.tar of=mkosi.output/IncusOS_boot_media.img seek=4196352 bs=512 conv=notrunc
-	truncate --size=50GiB mkosi.output/IncusOS_boot_media.img
 
 	# Create the VM
 	incus init --empty --vm test-incus-os \

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -95,7 +95,7 @@ func main() {
 
 func run(ctx context.Context, s *state.State, t *tui.TUI) error {
 	// Verify that the system meets minimum requirements for running Incus OS.
-	err := install.CheckSystemRequirements()
+	err := install.CheckSystemRequirements(ctx)
 	if err != nil {
 		t.DisplayModal("Incus OS", "System check error: [red]"+err.Error()+"[white]\nIncus OS is unable to run until the problem is resolved.", 0, 0)
 
@@ -103,7 +103,7 @@ func run(ctx context.Context, s *state.State, t *tui.TUI) error {
 	}
 
 	// Check if we should try to install to a local disk.
-	if install.IsInstallNeeded() {
+	if install.ShouldPerformInstall() {
 		// Don't display warning about recovery key during install.
 		s.System.Encryption.State.RecoveryKeysRetrieved = true
 

--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -357,6 +357,11 @@ func copyPartitionDefinition(ctx context.Context, src string, tgt string, partit
 		return err
 	}
 
+	// Annoyingly, sgdisk exits with zero if given a non-existent partition.
+	if strings.Contains(output, "does not exist") {
+		return errors.New(output)
+	}
+
 	partitionTypeRegex := regexp.MustCompile(`Partition GUID code: .+ \((.+)\)`)
 	partitionGUIDRegex := regexp.MustCompile(`Partition unique GUID: (.+)`)
 	partitionNameRegex := regexp.MustCompile(`Partition name: '(.+)'`)

--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -283,6 +283,17 @@ func (i *Install) performInstall(ctx context.Context, sourceDevice string, targe
 		}
 	}
 
+	if !sourceIsReadonly {
+		// Delete auto-created partitions from source device before proceeding with the install, so we can
+		// re-use the installer media on other systems.
+		for i := 9; i <= 11; i++ {
+			_, err = subprocess.RunCommandContext(ctx, "sgdisk", "-d", strconv.Itoa(i), sourceDevice)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	// Number of partitions to copy.
 	numPartitionsToCopy := 8
 	if sourceIsReadonly {

--- a/incus-osd/internal/systemd/systemctl.go
+++ b/incus-osd/internal/systemd/systemctl.go
@@ -62,3 +62,13 @@ func EnableUnit(ctx context.Context, now bool, units ...string) error {
 
 	return nil
 }
+
+// IsFailed returns a boolean indicating if the specified unit is in a failed state.
+func IsFailed(ctx context.Context, unit string) bool {
+	result, err := subprocess.RunCommandContext(ctx, "systemctl", "is-failed", unit)
+	if err != nil {
+		return false
+	}
+
+	return result == "failed\n"
+}

--- a/scripts/spawn-image
+++ b/scripts/spawn-image
@@ -24,7 +24,6 @@ curl -sL "https://github.com/lxc/incus-os/releases/download/${1}/IncusOS_${1}.ra
 # Add seed data
 echo "=> Injecting seed data"
 dd status=none if=test/seed.install.tar of=.incus-os.img seek=4196352 bs=512 conv=notrunc
-truncate --size=50GiB .incus-os.img
 
 # Create an instance
 echo "=> Creating an Incus OS instance"


### PR DESCRIPTION
Fix a few more bugs:
* Delete auto-created partitions from install media if present
* Error out early if in read-only mode but no seed is present
* Run the installer properly when systemd-repart can't resize if running from a small USB stick