### PR TITLE
Add a debug log endpoint

### DIFF
--- a/incus-osd/internal/rest/api_debug.go
+++ b/incus-osd/internal/rest/api_debug.go
@@ -1,0 +1,88 @@
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/lxc/incus/v6/shared/subprocess"
+
+	"github.com/lxc/incus-os/incus-osd/internal/rest/response"
+)
+
+func (*Server) apiDebug(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method != http.MethodGet {
+		_ = response.NotImplemented(nil).Render(w)
+
+		return
+	}
+
+	_ = response.SyncResponse(true, []string{"/1.0/debug/log"}).Render(w)
+}
+
+func (*Server) apiDebugLog(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method != http.MethodGet {
+		_ = response.NotImplemented(nil).Render(w)
+
+		return
+	}
+
+	err := r.ParseForm()
+	if err != nil {
+		_ = response.InternalError(err).Render(w)
+
+		return
+	}
+
+	unitName := r.Form.Get("unit")
+	bootNumber := r.Form.Get("boot")
+	numEntries := r.Form.Get("entries")
+
+	journalCmdArgs := []string{"-o", "json"}
+
+	if unitName != "" {
+		journalCmdArgs = append(journalCmdArgs, "-u", unitName)
+	}
+
+	if bootNumber != "" {
+		journalCmdArgs = append(journalCmdArgs, "-b", bootNumber)
+	} else {
+		journalCmdArgs = append(journalCmdArgs, "-b", "0")
+	}
+
+	if numEntries != "" {
+		journalCmdArgs = append(journalCmdArgs, "-n", numEntries)
+	}
+
+	jsonOutput, err := subprocess.RunCommandContext(r.Context(), "journalctl", journalCmdArgs...)
+	if err != nil {
+		_ = response.InternalError(err).Render(w)
+
+		return
+	}
+
+	jsonObj := []map[string]any{}
+
+	for _, line := range strings.Split(jsonOutput, "\n") {
+		if line == "" {
+			continue
+		}
+
+		obj := map[string]any{}
+
+		err = json.Unmarshal([]byte(line), &obj)
+		if err != nil {
+			_ = response.InternalError(err).Render(w)
+
+			return
+		}
+
+		jsonObj = append(jsonObj, obj)
+	}
+
+	_ = response.SyncResponse(true, jsonObj).Render(w)
+}

--- a/incus-osd/internal/rest/server.go
+++ b/incus-osd/internal/rest/server.go
@@ -48,6 +48,8 @@ func (s *Server) Serve(_ context.Context) error {
 
 	router.HandleFunc("/", s.apiRoot)
 	router.HandleFunc("/1.0", s.apiRoot10)
+	router.HandleFunc("/1.0/debug", s.apiDebug)
+	router.HandleFunc("/1.0/debug/log", s.apiDebugLog)
 	router.HandleFunc("/1.0/services", s.apiServices)
 	router.HandleFunc("/1.0/services/{name}", s.apiServicesEndpoint)
 	router.HandleFunc("/1.0/system", s.apiSystem)

--- a/mkosi.images/base/mkosi.extra/usr/lib/systemd/journald.conf.d/00-persistent-journal.conf
+++ b/mkosi.images/base/mkosi.extra/usr/lib/systemd/journald.conf.d/00-persistent-journal.conf
@@ -1,0 +1,2 @@
+[Journal]
+Storage=persistent


### PR DESCRIPTION
Closes #85 

Returns the JSON representation of each log entry from `journalctl`.