### PR TITLE
Extend device timeout to 3 minutes

### DIFF
--- a/mkosi.packages/initrd-tmpfs-root/00-device-timeout.conf
+++ b/mkosi.packages/initrd-tmpfs-root/00-device-timeout.conf
@@ -1,0 +1,2 @@
+[Manager]
+DefaultDeviceTimeoutSec=180

--- a/mkosi.packages/initrd-tmpfs-root/debian/initrd-tmpfs-root.install
+++ b/mkosi.packages/initrd-tmpfs-root/debian/initrd-tmpfs-root.install
@@ -2,3 +2,5 @@ override.conf usr/lib/systemd/system/systemd-repart.service.d/
 initrd-tmpfs-root.service usr/lib/systemd/system/
 
 99-add-cdrom-partitions.rules usr/lib/udev/rules.d/
+
+00-device-timeout.conf usr/lib/systemd/system.conf.d/


### PR DESCRIPTION
When running on real hardware with very slow install media, we're sometimes hitting the default 90 second limit. Double to 3 minutes.