### PR TITLE
Rework logic for determining when network is up

### DIFF
--- a/incus-osd/api/system_network.go
+++ b/incus-osd/api/system_network.go
@@ -20,41 +20,44 @@ type SystemNetworkConfig struct {
 
 // SystemNetworkInterface contains information about a network interface.
 type SystemNetworkInterface struct {
-	Name      string               `json:"name"                yaml:"name"`
-	MTU       int                  `json:"mtu"                 yaml:"mtu"`
-	VLAN      int                  `json:"vlan"                yaml:"vlan"`
-	VLANTags  []int                `json:"vlan_tags,omitempty" yaml:"vlan_tags,omitempty"`
-	Addresses []string             `json:"addresses,omitempty" yaml:"addresses,omitempty"`
-	Routes    []SystemNetworkRoute `json:"routes,omitempty"    yaml:"routes,omitempty"`
-	Hwaddr    string               `json:"hwaddr"              yaml:"hwaddr"`
-	Roles     []string             `json:"roles,omitempty"     yaml:"roles,omitempty"`
-	LLDP      bool                 `json:"lldp"                yaml:"lldp"`
+	Name              string               `json:"name"                          yaml:"name"`
+	MTU               int                  `json:"mtu"                           yaml:"mtu"`
+	VLAN              int                  `json:"vlan"                          yaml:"vlan"`
+	VLANTags          []int                `json:"vlan_tags,omitempty"           yaml:"vlan_tags,omitempty"`
+	Addresses         []string             `json:"addresses,omitempty"           yaml:"addresses,omitempty"`
+	RequiredForOnline string               `json:"required_for_online,omitempty" yaml:"required_for_online,omitempty"`
+	Routes            []SystemNetworkRoute `json:"routes,omitempty"              yaml:"routes,omitempty"`
+	Hwaddr            string               `json:"hwaddr"                        yaml:"hwaddr"`
+	Roles             []string             `json:"roles,omitempty"               yaml:"roles,omitempty"`
+	LLDP              bool                 `json:"lldp"                          yaml:"lldp"`
 }
 
 // SystemNetworkBond contains information about a network bond.
 type SystemNetworkBond struct {
-	Name      string               `json:"name"                yaml:"name"`
-	Mode      string               `json:"mode"                yaml:"mode"`
-	MTU       int                  `json:"mtu"                 yaml:"mtu"`
-	VLAN      int                  `json:"vlan"                yaml:"vlan"`
-	VLANTags  []int                `json:"vlan_tags,omitempty" yaml:"vlan_tags,omitempty"`
-	Addresses []string             `json:"addresses,omitempty" yaml:"addresses,omitempty"`
-	Routes    []SystemNetworkRoute `json:"routes,omitempty"    yaml:"routes,omitempty"`
-	Hwaddr    string               `json:"hwaddr"              yaml:"hwaddr"`
-	Members   []string             `json:"members,omitempty"   yaml:"members,omitempty"`
-	Roles     []string             `json:"roles,omitempty"     yaml:"roles,omitempty"`
-	LLDP      bool                 `json:"lldp"                yaml:"lldp"`
+	Name              string               `json:"name"                          yaml:"name"`
+	Mode              string               `json:"mode"                          yaml:"mode"`
+	MTU               int                  `json:"mtu"                           yaml:"mtu"`
+	VLAN              int                  `json:"vlan"                          yaml:"vlan"`
+	VLANTags          []int                `json:"vlan_tags,omitempty"           yaml:"vlan_tags,omitempty"`
+	Addresses         []string             `json:"addresses,omitempty"           yaml:"addresses,omitempty"`
+	RequiredForOnline string               `json:"required_for_online,omitempty" yaml:"required_for_online,omitempty"`
+	Routes            []SystemNetworkRoute `json:"routes,omitempty"              yaml:"routes,omitempty"`
+	Hwaddr            string               `json:"hwaddr"                        yaml:"hwaddr"`
+	Members           []string             `json:"members,omitempty"             yaml:"members,omitempty"`
+	Roles             []string             `json:"roles,omitempty"               yaml:"roles,omitempty"`
+	LLDP              bool                 `json:"lldp"                          yaml:"lldp"`
 }
 
 // SystemNetworkVLAN contains information about a network vlan.
 type SystemNetworkVLAN struct {
-	Name      string               `json:"name"                yaml:"name"`
-	Parent    string               `json:"parent"              yaml:"parent"`
-	ID        int                  `json:"id"                  yaml:"id"`
-	MTU       int                  `json:"mtu"                 yaml:"mtu"`
-	Addresses []string             `json:"addresses,omitempty" yaml:"addresses,omitempty"`
-	Routes    []SystemNetworkRoute `json:"routes,omitempty"    yaml:"routes,omitempty"`
-	Roles     []string             `json:"roles,omitempty"     yaml:"roles,omitempty"`
+	Name              string               `json:"name"                          yaml:"name"`
+	Parent            string               `json:"parent"                        yaml:"parent"`
+	ID                int                  `json:"id"                            yaml:"id"`
+	MTU               int                  `json:"mtu"                           yaml:"mtu"`
+	Addresses         []string             `json:"addresses,omitempty"           yaml:"addresses,omitempty"`
+	RequiredForOnline string               `json:"required_for_online,omitempty" yaml:"required_for_online,omitempty"`
+	Routes            []SystemNetworkRoute `json:"routes,omitempty"              yaml:"routes,omitempty"`
+	Roles             []string             `json:"roles,omitempty"               yaml:"roles,omitempty"`
 }
 
 // SystemNetworkRoute defines a route.

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -238,7 +238,7 @@ func startup(ctx context.Context, s *state.State, t *tui.TUI) error {
 
 	// Perform network configuration.
 	slog.Info("Bringing up the network")
-	err = systemd.ApplyNetworkConfiguration(ctx, s.System.Network.Config, 10*time.Second)
+	err = systemd.ApplyNetworkConfiguration(ctx, s.System.Network.Config, 30*time.Second)
 	if err != nil {
 		return err
 	}

--- a/incus-osd/internal/rest/api_system_network.go
+++ b/incus-osd/internal/rest/api_system_network.go
@@ -59,7 +59,7 @@ func (s *Server) apiSystemNetwork(w http.ResponseWriter, r *http.Request) {
 
 		// Apply the updated configuration.
 		s.state.System.Network.Config = newConfig.Config
-		err = systemd.ApplyNetworkConfiguration(r.Context(), s.state.System.Network.Config, 10*time.Second)
+		err = systemd.ApplyNetworkConfiguration(r.Context(), s.state.System.Network.Config, 30*time.Second)
 		if err != nil {
 			_ = response.BadRequest(err).Render(w)
 

--- a/incus-osd/internal/seed/network.go
+++ b/incus-osd/internal/seed/network.go
@@ -14,14 +14,6 @@ type NetworkSeed struct {
 	Version string `json:"version" yaml:"version"`
 }
 
-// NetworkSeedExists returns true if a network seed exists.
-func NetworkSeedExists() bool {
-	var config NetworkSeed
-	err := parseFileContents(SeedPartitionPath, "network", &config)
-
-	return err == nil
-}
-
 // GetNetwork extracts the network configuration from the seed data.
 // If no seed network found, a default minimal network config will be returned.
 func GetNetwork(_ context.Context, partition string) (*api.SystemNetworkConfig, error) {

--- a/incus-osd/internal/systemd/networkd.go
+++ b/incus-osd/internal/systemd/networkd.go
@@ -162,7 +162,7 @@ func waitForUdevInterfaceRename(ctx context.Context, timeout time.Duration) erro
 
 		// Check if the kernel has noticed the renaming of (at least) one interface to
 		// the expected "en<MAC address>" format.
-		_, err = subprocess.RunCommandContext(ctx, "journalctl", "-t", "kernel", "-g", "en[[:xdigit:]]{12}: renamed from ")
+		_, err = subprocess.RunCommandContext(ctx, "journalctl", "-b", "-t", "kernel", "-g", "en[[:xdigit:]]{12}: renamed from ")
 		if err == nil {
 			return nil
 		}

--- a/incus-osd/internal/systemd/networkd_test.go
+++ b/incus-osd/internal/systemd/networkd_test.go
@@ -15,6 +15,7 @@ interfaces:
     addresses:
       - 10.0.101.10/24
       - fd40:1234:1234:101::10/64
+    required_for_online: both
     hwaddr: AA:BB:CC:DD:EE:01
     roles:
       - storage
@@ -23,6 +24,7 @@ interfaces:
     addresses:
       - 10.0.102.10/24
       - fd40:1234:1234:102::10/64
+    required_for_online: both
     hwaddr: AA:BB:CC:DD:EE:02
     vlan_tags:
       - 10
@@ -58,6 +60,7 @@ vlans:
     mtu: 1500
     addresses:
       - dhcp4
+    required_for_online: ipv4
     routes:
       - to: 0.0.0.0/0
         via: dhcp4
@@ -72,6 +75,7 @@ interfaces:
     addresses:
       - dhcp4
       - slaac
+    required_for_online: ipv6
     routes:
       - to: 0.0.0.0/0
         via: dhcp4
@@ -102,6 +106,7 @@ interfaces:
   - name: eth0
     addresses:
       - dhcp4
+    required_for_online: no
     hwaddr: FF:EE:DD:CC:BB:AA
 `
 
@@ -128,6 +133,7 @@ vlans:
    addresses:
     - "dhcp4"
     - "slaac"
+   required_for_online: both
    roles:
     - "management"
 `
@@ -397,15 +403,15 @@ func TestNetworkFileGeneration(t *testing.T) {
 	cfgs := generateNetworkFileContents(networkCfg)
 	require.Len(t, cfgs, 10)
 	require.Equal(t, "20-san1.network", cfgs[0].Name)
-	require.Equal(t, "[Match]\nName=san1\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.0.101.10/24\nAddress=fd40:1234:1234:101::10/64\nIPv6AcceptRA=false\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nName=san1\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=both\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.0.101.10/24\nAddress=fd40:1234:1234:101::10/64\nIPv6AcceptRA=false\n", cfgs[0].Contents)
 	require.Equal(t, "20-enaabbccddee01.network", cfgs[1].Name)
 	require.Equal(t, "[Match]\nName=enaabbccddee01\n\n[Network]\nBridge=san1\nLLDP=false\nEmitLLDP=false\n", cfgs[1].Contents)
 	require.Equal(t, "20-san2.network", cfgs[2].Name)
-	require.Equal(t, "[Match]\nName=san2\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.0.102.10/24\nAddress=fd40:1234:1234:102::10/64\nIPv6AcceptRA=false\n", cfgs[2].Contents)
+	require.Equal(t, "[Match]\nName=san2\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=both\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.0.102.10/24\nAddress=fd40:1234:1234:102::10/64\nIPv6AcceptRA=false\n", cfgs[2].Contents)
 	require.Equal(t, "20-enaabbccddee02.network", cfgs[3].Name)
 	require.Equal(t, "[Match]\nName=enaabbccddee02\n\n[Network]\nBridge=san2\nLLDP=false\nEmitLLDP=false\n\n[BridgeVLAN]\nVLAN=10\n", cfgs[3].Contents)
 	require.Equal(t, "21-management.network", cfgs[4].Name)
-	require.Equal(t, "[Match]\nName=management\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.0.100.10/24\nAddress=fd40:1234:1234:100::10/64\nIPv6AcceptRA=false\n\n[Route]\nGateway=10.0.100.1\nDestination=0.0.0.0/0\n\n[Route]\nGateway=fd40:1234:1234:100::1\nDestination=::/0\n", cfgs[4].Contents)
+	require.Equal(t, "[Match]\nName=management\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=any\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.0.100.10/24\nAddress=fd40:1234:1234:100::10/64\nIPv6AcceptRA=false\n\n[Route]\nGateway=10.0.100.1\nDestination=0.0.0.0/0\n\n[Route]\nGateway=fd40:1234:1234:100::1\nDestination=::/0\n", cfgs[4].Contents)
 	require.Equal(t, "21-bnaabbccddee03.network", cfgs[5].Name)
 	require.Equal(t, "[Match]\nName=bnaabbccddee03\n\n[Network]\nBridge=management\n\n[BridgeVLAN]\nPVID=100\nEgressUntagged=100\n\n[BridgeVLAN]\nVLAN=100\n\n[BridgeVLAN]\nVLAN=1234\n", cfgs[5].Contents)
 	require.Equal(t, "21-bnaabbccddee03-dev0.network", cfgs[6].Name)
@@ -415,7 +421,7 @@ func TestNetworkFileGeneration(t *testing.T) {
 	require.Equal(t, "22-vluplink.network", cfgs[8].Name)
 	require.Equal(t, "[Match]\nName=vluplink\n\n[Network]\nBridge=management\n\n[BridgeVLAN]\nVLAN=1234\nPVID=1234\nEgressUntagged=1234\n", cfgs[8].Contents)
 	require.Equal(t, "22-uplink.network", cfgs[9].Name)
-	require.Equal(t, "[Match]\nName=uplink\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=false\nDHCP=ipv4\n\n[Route]\nGateway=_dhcp4\nDestination=0.0.0.0/0\n", cfgs[9].Contents)
+	require.Equal(t, "[Match]\nName=uplink\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=ipv4\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=false\nDHCP=ipv4\n\n[Route]\nGateway=_dhcp4\nDestination=0.0.0.0/0\n", cfgs[9].Contents)
 
 	// Test second config .network file generation.
 	networkCfg = api.SystemNetworkConfig{}
@@ -425,7 +431,7 @@ func TestNetworkFileGeneration(t *testing.T) {
 	cfgs = generateNetworkFileContents(networkCfg)
 	require.Len(t, cfgs, 2)
 	require.Equal(t, "20-management.network", cfgs[0].Name)
-	require.Equal(t, "[Match]\nName=management\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=true\nDHCP=ipv4\n\n[Route]\nGateway=_dhcp4\nDestination=0.0.0.0/0\n\n[Route]\nGateway=_ipv6ra\nDestination=::/0\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nName=management\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=ipv6\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=true\nDHCP=ipv4\n\n[Route]\nGateway=_dhcp4\nDestination=0.0.0.0/0\n\n[Route]\nGateway=_ipv6ra\nDestination=::/0\n", cfgs[0].Contents)
 	require.Equal(t, "20-enaabbccddee01.network", cfgs[1].Name)
 	require.Equal(t, "[Match]\nName=enaabbccddee01\n\n[Network]\nBridge=management\nLLDP=false\nEmitLLDP=false\n", cfgs[1].Contents)
 
@@ -437,7 +443,7 @@ func TestNetworkFileGeneration(t *testing.T) {
 	cfgs = generateNetworkFileContents(networkCfg)
 	require.Len(t, cfgs, 2)
 	require.Equal(t, "20-eth0.network", cfgs[0].Name)
-	require.Equal(t, "[Match]\nName=eth0\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nDomains=example.org\nDNS=ns1.example.org\nDNS=ns2.example.org\nNTP=pool.ntp.example.org\nNTP=10.10.10.10\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=false\nDHCP=ipv4\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nName=eth0\n\n[Link]\nRequiredForOnline=no\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nDomains=example.org\nDNS=ns1.example.org\nDNS=ns2.example.org\nNTP=pool.ntp.example.org\nNTP=10.10.10.10\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=false\nDHCP=ipv4\n", cfgs[0].Contents)
 	require.Equal(t, "20-enffeeddccbbaa.network", cfgs[1].Name)
 	require.Equal(t, "[Match]\nName=enffeeddccbbaa\n\n[Network]\nBridge=eth0\nLLDP=false\nEmitLLDP=false\n", cfgs[1].Contents)
 
@@ -449,7 +455,7 @@ func TestNetworkFileGeneration(t *testing.T) {
 	cfgs = generateNetworkFileContents(networkCfg)
 	require.Len(t, cfgs, 6)
 	require.Equal(t, "21-uplink.network", cfgs[0].Name)
-	require.Equal(t, "[Match]\nName=uplink\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\nIPv6AcceptRA=false\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nName=uplink\n\n[Link]\nRequiredForOnline=no\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\nIPv6AcceptRA=false\n", cfgs[0].Contents)
 	require.Equal(t, "21-bnaabbccddeee1.network", cfgs[1].Name)
 	require.Equal(t, "[Match]\nName=bnaabbccddeee1\n\n[Network]\nBridge=uplink\n\n[BridgeVLAN]\nVLAN=10\n", cfgs[1].Contents)
 	require.Equal(t, "21-bnaabbccddeee1-dev0.network", cfgs[2].Name)
@@ -459,5 +465,5 @@ func TestNetworkFileGeneration(t *testing.T) {
 	require.Equal(t, "22-vlmanagement.network", cfgs[4].Name)
 	require.Equal(t, "[Match]\nName=vlmanagement\n\n[Network]\nBridge=uplink\n\n[BridgeVLAN]\nVLAN=10\nPVID=10\nEgressUntagged=10\n", cfgs[4].Contents)
 	require.Equal(t, "22-management.network", cfgs[5].Name)
-	require.Equal(t, "[Match]\nName=management\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=true\nDHCP=ipv4\n", cfgs[5].Contents)
+	require.Equal(t, "[Match]\nName=management\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=both\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=true\nDHCP=ipv4\n", cfgs[5].Contents)
 }

--- a/incus-osd/internal/tui/tui.go
+++ b/incus-osd/internal/tui/tui.go
@@ -221,8 +221,8 @@ func (t *TUI) getIPAddresses() []string {
 		matches := ipAddressRegex.FindAllStringSubmatch(output, -1)
 
 		for _, addr := range matches {
-			// Don't show link-local address.
-			if strings.HasPrefix(addr[1], "fe80:") {
+			// Don't show link-local addresses.
+			if strings.HasPrefix(addr[1], "169.254.") || strings.HasPrefix(addr[1], "fe80:") {
 				continue
 			}
 


### PR DESCRIPTION
Rather than just relying on a network device to be reported as routable, check if it's actually online and has an appropriate IP addres(es) assigned. The required IP address type(s) required (ipv4, ipv6, both, any, no) can be specified with the `RequiredForOnline` option.

Closes #78