### PR TITLE
Minor cleanup

### DIFF
--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -59,17 +59,17 @@ func CheckSystemRequirements(ctx context.Context) error {
 		// Check that we have either been told what target device to use, or that we can automatically figure it out.
 		source, _, err := getSourceDevice(ctx)
 		if err != nil {
-			return err
+			return errors.New("unable to determine source device: " + err.Error())
 		}
 
 		targets, err := getAllTargets(ctx)
 		if err != nil {
-			return err
+			return errors.New("unable to get list of potential target devices: " + err.Error())
 		}
 
 		config, err := seed.GetInstallConfig(seed.SeedPartitionPath)
 		if err != nil && !errors.Is(err, io.EOF) {
-			return err
+			return errors.New("unable to get seed config: " + err.Error())
 		}
 
 		_, err = getTargetDevice(targets, config.Target, source)

--- a/incus-osd/internal/providers/provider_local.go
+++ b/incus-osd/internal/providers/provider_local.go
@@ -105,7 +105,7 @@ func (p *local) checkRelease(_ context.Context) error {
 	_, err := os.Lstat(p.path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return ErrProviderUnavailable
+			return ErrNoUpdateAvailable
 		}
 
 		return err

--- a/incus-osd/internal/seed/network.go
+++ b/incus-osd/internal/seed/network.go
@@ -9,7 +9,7 @@ import (
 
 // NetworkSeed defines a struct to hold network configuration.
 type NetworkSeed struct {
-	api.SystemNetworkConfig
+	api.SystemNetworkConfig `yaml:",inline"`
 
 	Version string `json:"version" yaml:"version"`
 }


### PR DESCRIPTION
Three bits of cleanup:

* Add a bit of context to raw errors in `CheckSystemRequirements()`
* If the local provider doesn't exist, return `ErrNoUpdateAvailable` rather than `ErrProviderUnavailable`; this is nicer and doesn't toss a big error on the screen
* Fix unmarshalling of network yaml configs