### PR TITLE
Rework network config generation and add validation

### DIFF
--- a/incus-osd/internal/seed/network.go
+++ b/incus-osd/internal/seed/network.go
@@ -2,7 +2,12 @@ package seed
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
+	"regexp"
+
+	"github.com/lxc/incus/v6/shared/subprocess"
 
 	"github.com/lxc/incus-os/incus-osd/api"
 )
@@ -16,7 +21,7 @@ type NetworkSeed struct {
 
 // GetNetwork extracts the network configuration from the seed data.
 // If no seed network found, a default minimal network config will be returned.
-func GetNetwork(_ context.Context, partition string) (*api.SystemNetworkConfig, error) {
+func GetNetwork(ctx context.Context, partition string) (*api.SystemNetworkConfig, error) {
 	// Get the network configuration.
 	var config NetworkSeed
 
@@ -33,6 +38,42 @@ func GetNetwork(_ context.Context, partition string) (*api.SystemNetworkConfig, 
 		}
 
 		return defaultNetwork, nil
+	}
+
+	// When reading in a network seed, we will dynamically lookup any MAC address that is referred to by an interface name.
+	hwaddrhRegex := regexp.MustCompile(`^[[:xdigit:]]{2}:[[:xdigit:]]{2}:[[:xdigit:]]{2}:[[:xdigit:]]{2}:[[:xdigit:]]{2}:[[:xdigit:]]{2}$`)
+
+	for i := range len(config.Interfaces) {
+		if !hwaddrhRegex.MatchString(config.Interfaces[i].Hwaddr) {
+			hwaddr, err := getMacForInterface(ctx, config.Interfaces[i].Hwaddr)
+			if err != nil {
+				return nil, fmt.Errorf("interface %d failed getting MAC for '%s': %s", i, config.Interfaces[i].Hwaddr, err.Error())
+			}
+
+			config.Interfaces[i].Hwaddr = hwaddr
+		}
+	}
+
+	for i := range len(config.Bonds) {
+		if config.Bonds[i].Hwaddr != "" && !hwaddrhRegex.MatchString(config.Bonds[i].Hwaddr) {
+			hwaddr, err := getMacForInterface(ctx, config.Bonds[i].Hwaddr)
+			if err != nil {
+				return nil, fmt.Errorf("bond %d failed getting MAC for '%s': %s", i, config.Bonds[i].Hwaddr, err.Error())
+			}
+
+			config.Bonds[i].Hwaddr = hwaddr
+		}
+
+		for j := range len(config.Bonds[i].Members) {
+			if !hwaddrhRegex.MatchString(config.Bonds[i].Members[j]) {
+				hwaddr, err := getMacForInterface(ctx, config.Bonds[i].Members[j])
+				if err != nil {
+					return nil, fmt.Errorf("bond %d member %d failed getting MAC for '%s': %s", i, j, config.Bonds[i].Members[j], err.Error())
+				}
+
+				config.Bonds[i].Members[j] = hwaddr
+			}
+		}
 	}
 
 	// If no interfaces, bonds, or vlans are defined, add a minimal default configuration for the interfaces.
@@ -76,4 +117,20 @@ func getDefaultNetworkConfig() (*api.SystemNetworkConfig, error) {
 	}
 
 	return ret, nil
+}
+
+// getMacForInterface attempts to query a give network interface and return its MAC address.
+func getMacForInterface(ctx context.Context, iface string) (string, error) {
+	macAddressRegex := regexp.MustCompile(`link/ether (.+) brd`)
+	output, err := subprocess.RunCommandContext(ctx, "ip", "link", "show", iface)
+	if err != nil {
+		return "", err
+	}
+
+	match := macAddressRegex.FindAllStringSubmatch(output, -1)
+	if len(match) != 1 {
+		return "", errors.New("no MAC address found")
+	}
+
+	return match[0][1], nil
 }

--- a/incus-osd/internal/systemd/networkd.go
+++ b/incus-osd/internal/systemd/networkd.go
@@ -299,6 +299,7 @@ func generateLinkFileContents(networkCfg api.SystemNetworkConfig) []networkdConf
 PermanentMACAddress=%s
 
 [Link]
+MACAddressPolicy=random
 NamePolicy=
 Name=en%s
 `, i.Hwaddr, strippedHwaddr),
@@ -329,36 +330,43 @@ Name=en%s
 func generateNetdevFileContents(networkCfg api.SystemNetworkConfig) []networkdConfigFile {
 	ret := []networkdConfigFile{}
 
-	// Create a bridge device for each interface.
+	// Create bridge and veth devices for each interface.
 	for _, i := range networkCfg.Interfaces {
-		strippedHwaddr := strings.ToLower(strings.ReplaceAll(i.Hwaddr, ":", ""))
 		mtuString := ""
 		if i.MTU != 0 {
 			mtuString = fmt.Sprintf("MTUBytes=%d", i.MTU)
 		}
+
+		// Bridge.
 		ret = append(ret, networkdConfigFile{
-			Name: fmt.Sprintf("10-br%s.netdev", strippedHwaddr),
+			Name: fmt.Sprintf("10-br%s.netdev", i.Name),
 			Contents: fmt.Sprintf(`[NetDev]
-Name=%s
+Name=br%s
 Kind=bridge
-MACAddress=%s
 %s
 
 [Bridge]
 VLANFiltering=true
-`, i.Name, i.Hwaddr, mtuString),
+`, i.Name, mtuString),
+		})
+
+		// veth.
+		ret = append(ret, networkdConfigFile{
+			Name: fmt.Sprintf("10-%s.netdev", i.Name),
+			Contents: fmt.Sprintf(`[NetDev]
+Name=%s
+Kind=veth
+MACAddress=%s
+%s
+
+[Peer]
+Name=vt%s
+`, i.Name, i.Hwaddr, mtuString, i.Name),
 		})
 	}
 
-	// Create bond and bridge devices for each bond.
+	// Create bond, bridge, and veth devices for each bond.
 	for _, b := range networkCfg.Bonds {
-		bondMacAddr := b.Hwaddr
-		if bondMacAddr == "" {
-			bondMacAddr = b.Members[0]
-		}
-
-		strippedHwaddr := strings.ToLower(strings.ReplaceAll(bondMacAddr, ":", ""))
-
 		mtuString := ""
 		if b.MTU != 0 {
 			mtuString = fmt.Sprintf("MTUBytes=%d", b.MTU)
@@ -366,57 +374,52 @@ VLANFiltering=true
 
 		// Bond.
 		ret = append(ret, networkdConfigFile{
-			Name: fmt.Sprintf("11-bn%s.netdev", strippedHwaddr),
+			Name: fmt.Sprintf("11-bn%s.netdev", b.Name),
 			Contents: fmt.Sprintf(`[NetDev]
 Name=bn%s
 Kind=bond
-MACAddress=%s
 %s
 
 [Bond]
 Mode=%s
-`, strippedHwaddr, bondMacAddr, mtuString, b.Mode),
+`, b.Name, mtuString, b.Mode),
 		})
 
 		// Bridge.
 		ret = append(ret, networkdConfigFile{
-			Name: fmt.Sprintf("11-br%s.netdev", strippedHwaddr),
+			Name: fmt.Sprintf("11-br%s.netdev", b.Name),
 			Contents: fmt.Sprintf(`[NetDev]
-Name=%s
+Name=br%s
 Kind=bridge
-MACAddress=%s
 %s
 
 [Bridge]
 VLANFiltering=true
-`, b.Name, bondMacAddr, mtuString),
+`, b.Name, mtuString),
+		})
+
+		// veth.
+		bondMacAddr := b.Hwaddr
+		if bondMacAddr == "" {
+			bondMacAddr = b.Members[0]
+		}
+
+		ret = append(ret, networkdConfigFile{
+			Name: fmt.Sprintf("11-%s.netdev", b.Name),
+			Contents: fmt.Sprintf(`[NetDev]
+Name=%s
+Kind=veth
+MACAddress=%s
+%s
+
+[Peer]
+Name=vt%s
+`, b.Name, bondMacAddr, mtuString, b.Name),
 		})
 	}
 
 	// Create vlans.
 	for _, v := range networkCfg.VLANs {
-		parentMACAddress := ""
-		for _, i := range networkCfg.Interfaces {
-			if i.Name == v.Parent {
-				parentMACAddress = i.Hwaddr
-
-				break
-			}
-		}
-		if parentMACAddress == "" {
-			for _, b := range networkCfg.Bonds {
-				if b.Name == v.Parent {
-					if b.Hwaddr != "" {
-						parentMACAddress = b.Hwaddr
-					} else {
-						parentMACAddress = b.Members[0]
-					}
-
-					break
-				}
-			}
-		}
-
 		mtuString := ""
 		if v.MTU != 0 {
 			mtuString = fmt.Sprintf("MTUBytes=%d", v.MTU)
@@ -426,13 +429,12 @@ VLANFiltering=true
 			Name: fmt.Sprintf("12-%s.netdev", v.Name),
 			Contents: fmt.Sprintf(`[NetDev]
 Name=%s
-Kind=veth
-MACAddress=%s
+Kind=vlan
 %s
 
-[Peer]
-Name=vl%s
-`, v.Name, parentMACAddress, mtuString, v.Name),
+[VLAN]
+Id=%d
+`, v.Name, mtuString, v.ID),
 		})
 	}
 
@@ -444,9 +446,9 @@ Name=vl%s
 func generateNetworkFileContents(networkCfg api.SystemNetworkConfig) []networkdConfigFile {
 	ret := []networkdConfigFile{}
 
-	// Create networks for each interface.
+	// Create networks for each interface and its bridge.
 	for _, i := range networkCfg.Interfaces {
-		strippedHwaddr := strings.ToLower(strings.ReplaceAll(i.Hwaddr, ":", ""))
+		// User side of veth device.
 		cfgString := fmt.Sprintf(`[Match]
 Name=%s
 
@@ -459,7 +461,7 @@ RouteMetric=100
 UseMTU=true
 
 [Network]
-%s`, i.Name, generateLinkSectionContents(i.Addresses, i.RequiredForOnline), generateNetworkSectionContents(networkCfg.DNS, networkCfg.NTP))
+%s`, i.Name, generateLinkSectionContents(i.Addresses, i.RequiredForOnline), generateNetworkSectionContents(i.Name, networkCfg.VLANs, networkCfg.DNS, networkCfg.NTP))
 
 		cfgString += processAddresses(i.Addresses)
 
@@ -472,14 +474,31 @@ UseMTU=true
 			Contents: cfgString,
 		})
 
+		// Bridge side of veth device.
+		cfgString = fmt.Sprintf(`[Match]
+Name=vt%s
+
+[Network]
+Bridge=br%s
+`, i.Name, i.Name)
+
+		cfgString += generateBridgeVLANContents(i.Name, i.VLAN, i.VLANTags, networkCfg.VLANs)
+
+		ret = append(ret, networkdConfigFile{
+			Name:     fmt.Sprintf("20-vt%s.network", i.Name),
+			Contents: cfgString,
+		})
+
+		// Add underlying interface to bridge.
+		strippedHwaddr := strings.ToLower(strings.ReplaceAll(i.Hwaddr, ":", ""))
 		cfgString = fmt.Sprintf(`[Match]
 Name=en%s
 
 [Network]
-Bridge=%s
 LLDP=%s
 EmitLLDP=%s
-`, strippedHwaddr, i.Name, strconv.FormatBool(i.LLDP), strconv.FormatBool(i.LLDP))
+Bridge=br%s
+`, strippedHwaddr, strconv.FormatBool(i.LLDP), strconv.FormatBool(i.LLDP), i.Name)
 
 		cfgString += generateBridgeVLANContents(i.Name, i.VLAN, i.VLANTags, networkCfg.VLANs)
 
@@ -487,18 +506,25 @@ EmitLLDP=%s
 			Name:     fmt.Sprintf("20-en%s.network", strippedHwaddr),
 			Contents: cfgString,
 		})
+
+		// Bridge.
+		cfgString = fmt.Sprintf(`[Match]
+Name=br%s
+
+[Network]
+LinkLocalAddressing=no
+ConfigureWithoutCarrier=yes
+`, i.Name)
+
+		ret = append(ret, networkdConfigFile{
+			Name:     fmt.Sprintf("20-br%s.network", i.Name),
+			Contents: cfgString,
+		})
 	}
 
-	// Create networks for each bond and its member(s).
+	// Create networks for each bond, its member(s), and its bridge.
 	for _, b := range networkCfg.Bonds {
-		bondMacAddr := b.Hwaddr
-		if bondMacAddr == "" {
-			bondMacAddr = b.Members[0]
-		}
-
-		strippedHwaddr := strings.ToLower(strings.ReplaceAll(bondMacAddr, ":", ""))
-
-		// Bond.
+		// User side of veth device.
 		cfgString := fmt.Sprintf(`[Match]
 Name=%s
 
@@ -511,7 +537,7 @@ RouteMetric=100
 UseMTU=true
 
 [Network]
-%s`, b.Name, generateLinkSectionContents(b.Addresses, b.RequiredForOnline), generateNetworkSectionContents(networkCfg.DNS, networkCfg.NTP))
+%s`, b.Name, generateLinkSectionContents(b.Addresses, b.RequiredForOnline), generateNetworkSectionContents(b.Name, networkCfg.VLANs, networkCfg.DNS, networkCfg.NTP))
 
 		cfgString += processAddresses(b.Addresses)
 
@@ -524,18 +550,49 @@ UseMTU=true
 			Contents: cfgString,
 		})
 
-		// Bridge.
+		// Bridge side of veth device.
 		cfgString = fmt.Sprintf(`[Match]
-Name=bn%s
+Name=vt%s
 
 [Network]
-Bridge=%s
-`, strippedHwaddr, b.Name)
+Bridge=br%s
+`, b.Name, b.Name)
 
 		cfgString += generateBridgeVLANContents(b.Name, b.VLAN, b.VLANTags, networkCfg.VLANs)
 
 		ret = append(ret, networkdConfigFile{
-			Name:     fmt.Sprintf("21-bn%s.network", strippedHwaddr),
+			Name:     fmt.Sprintf("21-vt%s.network", b.Name),
+			Contents: cfgString,
+		})
+
+		// Add bond to bridge.
+		cfgString = fmt.Sprintf(`[Match]
+Name=bn%s
+
+[Network]
+LinkLocalAddressing=no
+ConfigureWithoutCarrier=yes
+Bridge=br%s
+`, b.Name, b.Name)
+
+		cfgString += generateBridgeVLANContents(b.Name, b.VLAN, b.VLANTags, networkCfg.VLANs)
+
+		ret = append(ret, networkdConfigFile{
+			Name:     fmt.Sprintf("21-bn%s.network", b.Name),
+			Contents: cfgString,
+		})
+
+		// Bridge.
+		cfgString = fmt.Sprintf(`[Match]
+Name=br%s
+
+[Network]
+LinkLocalAddressing=no
+ConfigureWithoutCarrier=yes
+`, b.Name)
+
+		ret = append(ret, networkdConfigFile{
+			Name:     fmt.Sprintf("21-br%s.network", b.Name),
 			Contents: cfgString,
 		})
 
@@ -544,39 +601,22 @@ Bridge=%s
 			memberStrippedHwaddr := strings.ToLower(strings.ReplaceAll(member, ":", ""))
 
 			ret = append(ret, networkdConfigFile{
-				Name: fmt.Sprintf("21-bn%s-dev%d.network", strippedHwaddr, index),
+				Name: fmt.Sprintf("21-bn%s-dev%d.network", b.Name, index),
 				Contents: fmt.Sprintf(`[Match]
 Name=en%s
 
 [Network]
-Bond=bn%s
 LLDP=%s
 EmitLLDP=%s
-`, memberStrippedHwaddr, strippedHwaddr, strconv.FormatBool(b.LLDP), strconv.FormatBool(b.LLDP)),
+Bond=bn%s
+`, memberStrippedHwaddr, strconv.FormatBool(b.LLDP), strconv.FormatBool(b.LLDP), b.Name),
 			})
 		}
 	}
 
-	// Create networks for each VLAN.
+	// Create network for each VLAN.
 	for _, v := range networkCfg.VLANs {
 		cfgString := fmt.Sprintf(`[Match]
-Name=vl%s
-
-[Network]
-Bridge=%s
-
-[BridgeVLAN]
-VLAN=%d
-PVID=%d
-EgressUntagged=%d
-`, v.Name, v.Parent, v.ID, v.ID, v.ID)
-
-		ret = append(ret, networkdConfigFile{
-			Name:     fmt.Sprintf("22-vl%s.network", v.Name),
-			Contents: cfgString,
-		})
-
-		cfgString = fmt.Sprintf(`[Match]
 Name=%s
 
 [Link]
@@ -588,7 +628,7 @@ RouteMetric=100
 UseMTU=true
 
 [Network]
-%s`, v.Name, generateLinkSectionContents(v.Addresses, v.RequiredForOnline), generateNetworkSectionContents(networkCfg.DNS, networkCfg.NTP))
+%s`, v.Name, generateLinkSectionContents(v.Addresses, v.RequiredForOnline), generateNetworkSectionContents(v.Name, nil, networkCfg.DNS, networkCfg.NTP))
 
 		cfgString += processAddresses(v.Addresses)
 
@@ -669,8 +709,15 @@ func processRoutes(routes []api.SystemNetworkRoute) string {
 	return ret
 }
 
-func generateNetworkSectionContents(dns *api.SystemNetworkDNS, ntp *api.SystemNetworkNTP) string {
+func generateNetworkSectionContents(name string, vlans []api.SystemNetworkVLAN, dns *api.SystemNetworkDNS, ntp *api.SystemNetworkNTP) string {
 	ret := ""
+
+	// Add any matching VLANs to the config.
+	for _, v := range vlans {
+		if v.Parent == name {
+			ret += fmt.Sprintf("VLAN=%s\n", v.Name)
+		}
+	}
 
 	// If there are search domains or name servers, add those to the config.
 	if dns != nil {

--- a/incus-osd/internal/systemd/networkd_test.go
+++ b/incus-osd/internal/systemd/networkd_test.go
@@ -35,9 +35,9 @@ bonds:
   - name: management
     mode: 802.3ad
     mtu: 9000
-    vlan: 100
+    vlan: 1234
     vlan_tags:
-      - 1234
+      - 100
     addresses:
       - 10.0.100.10/24
       - fd40:1234:1234:100::10/64
@@ -148,6 +148,9 @@ func TestNetworkConfigMarshalling(t *testing.T) {
 		err := yaml.Unmarshal([]byte(networkdConfig1), &cfg)
 		require.NoError(t, err)
 
+		err = ValidateNetworkConfiguration(&cfg)
+		require.NoError(t, err)
+
 		// Verify values were parsed correctly.
 		require.Len(t, cfg.Interfaces, 2)
 		require.Equal(t, "san1", cfg.Interfaces[0].Name)
@@ -192,6 +195,9 @@ func TestNetworkConfigMarshalling(t *testing.T) {
 		err := yaml.Unmarshal([]byte(networkdConfig2), &cfg)
 		require.NoError(t, err)
 
+		err = ValidateNetworkConfiguration(&cfg)
+		require.NoError(t, err)
+
 		// Verify values were parsed correctly.
 		require.Len(t, cfg.Interfaces, 1)
 		require.Equal(t, "management", cfg.Interfaces[0].Name)
@@ -216,6 +222,9 @@ func TestNetworkConfigMarshalling(t *testing.T) {
 
 		// Test unmarshalling of the third test config.
 		err := yaml.Unmarshal([]byte(networkdConfig3), &cfg)
+		require.NoError(t, err)
+
+		err = ValidateNetworkConfiguration(&cfg)
 		require.NoError(t, err)
 
 		// Verify values were parsed correctly.
@@ -245,6 +254,9 @@ func TestNetworkConfigMarshalling(t *testing.T) {
 
 		// Test unmarshalling of the fourth test config.
 		err := yaml.Unmarshal([]byte(networkdConfig4), &cfg)
+		require.NoError(t, err)
+
+		err = ValidateNetworkConfiguration(&cfg)
 		require.NoError(t, err)
 
 		// Verify values were parsed correctly.
@@ -413,7 +425,7 @@ func TestNetworkFileGeneration(t *testing.T) {
 	require.Equal(t, "21-management.network", cfgs[4].Name)
 	require.Equal(t, "[Match]\nName=management\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=any\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.0.100.10/24\nAddress=fd40:1234:1234:100::10/64\nIPv6AcceptRA=false\n\n[Route]\nGateway=10.0.100.1\nDestination=0.0.0.0/0\n\n[Route]\nGateway=fd40:1234:1234:100::1\nDestination=::/0\n", cfgs[4].Contents)
 	require.Equal(t, "21-bnaabbccddee03.network", cfgs[5].Name)
-	require.Equal(t, "[Match]\nName=bnaabbccddee03\n\n[Network]\nBridge=management\n\n[BridgeVLAN]\nPVID=100\nEgressUntagged=100\n\n[BridgeVLAN]\nVLAN=100\n\n[BridgeVLAN]\nVLAN=1234\n", cfgs[5].Contents)
+	require.Equal(t, "[Match]\nName=bnaabbccddee03\n\n[Network]\nBridge=management\n\n[BridgeVLAN]\nPVID=1234\nEgressUntagged=1234\n\n[BridgeVLAN]\nVLAN=100\n\n[BridgeVLAN]\nVLAN=1234\n", cfgs[5].Contents)
 	require.Equal(t, "21-bnaabbccddee03-dev0.network", cfgs[6].Name)
 	require.Equal(t, "[Match]\nName=enaabbccddee03\n\n[Network]\nBond=bnaabbccddee03\nLLDP=false\nEmitLLDP=false\n", cfgs[6].Contents)
 	require.Equal(t, "21-bnaabbccddee03-dev1.network", cfgs[7].Name)

--- a/incus-osd/internal/systemd/networkd_test.go
+++ b/incus-osd/internal/systemd/networkd_test.go
@@ -117,8 +117,7 @@ bonds:
    hwaddr: "aa:bb:cc:dd:ee:e1"
    lldp: true
    mtu: 9000
-   vlan_tags:
-     - 10
+   vlan: 10
    members:
     - "aa:bb:cc:dd:ee:e1"
     - "aa:bb:cc:dd:ee:e2"
@@ -305,9 +304,9 @@ func TestLinkFileGeneration(t *testing.T) {
 	cfgs := generateLinkFileContents(networkCfg)
 	require.Len(t, cfgs, 4)
 	require.Equal(t, "00-enaabbccddee01.link", cfgs[0].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:01\n\n[Link]\nNamePolicy=\nName=enaabbccddee01\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:01\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=enaabbccddee01\n", cfgs[0].Contents)
 	require.Equal(t, "00-enaabbccddee02.link", cfgs[1].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:02\n\n[Link]\nNamePolicy=\nName=enaabbccddee02\n", cfgs[1].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:02\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=enaabbccddee02\n", cfgs[1].Contents)
 	require.Equal(t, "01-enaabbccddee03.link", cfgs[2].Name)
 	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:03\n\n[Link]\nNamePolicy=\nName=enaabbccddee03\n", cfgs[2].Contents)
 	require.Equal(t, "01-enaabbccddee04.link", cfgs[3].Name)
@@ -321,7 +320,7 @@ func TestLinkFileGeneration(t *testing.T) {
 	cfgs = generateLinkFileContents(networkCfg)
 	require.Len(t, cfgs, 1)
 	require.Equal(t, "00-enaabbccddee01.link", cfgs[0].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:01\n\n[Link]\nNamePolicy=\nName=enaabbccddee01\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:01\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=enaabbccddee01\n", cfgs[0].Contents)
 
 	// Test third config .link file generation.
 	networkCfg = api.SystemNetworkConfig{}
@@ -331,7 +330,7 @@ func TestLinkFileGeneration(t *testing.T) {
 	cfgs = generateLinkFileContents(networkCfg)
 	require.Len(t, cfgs, 1)
 	require.Equal(t, "00-enffeeddccbbaa.link", cfgs[0].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=FF:EE:DD:CC:BB:AA\n\n[Link]\nNamePolicy=\nName=enffeeddccbbaa\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=FF:EE:DD:CC:BB:AA\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=enffeeddccbbaa\n", cfgs[0].Contents)
 
 	// Test fourth config .link file generation.
 	networkCfg = api.SystemNetworkConfig{}
@@ -356,17 +355,23 @@ func TestNetdevFileGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	cfgs := generateNetdevFileContents(networkCfg)
-	require.Len(t, cfgs, 5)
-	require.Equal(t, "10-braabbccddee01.netdev", cfgs[0].Name)
-	require.Equal(t, "[NetDev]\nName=san1\nKind=bridge\nMACAddress=AA:BB:CC:DD:EE:01\n\n\n[Bridge]\nVLANFiltering=true\n", cfgs[0].Contents)
-	require.Equal(t, "10-braabbccddee02.netdev", cfgs[1].Name)
-	require.Equal(t, "[NetDev]\nName=san2\nKind=bridge\nMACAddress=AA:BB:CC:DD:EE:02\n\n\n[Bridge]\nVLANFiltering=true\n", cfgs[1].Contents)
-	require.Equal(t, "11-bnaabbccddee03.netdev", cfgs[2].Name)
-	require.Equal(t, "[NetDev]\nName=bnaabbccddee03\nKind=bond\nMACAddress=AA:BB:CC:DD:EE:03\nMTUBytes=9000\n\n[Bond]\nMode=802.3ad\n", cfgs[2].Contents)
-	require.Equal(t, "11-braabbccddee03.netdev", cfgs[3].Name)
-	require.Equal(t, "[NetDev]\nName=management\nKind=bridge\nMACAddress=AA:BB:CC:DD:EE:03\nMTUBytes=9000\n\n[Bridge]\nVLANFiltering=true\n", cfgs[3].Contents)
-	require.Equal(t, "12-uplink.netdev", cfgs[4].Name)
-	require.Equal(t, "[NetDev]\nName=uplink\nKind=veth\nMACAddress=AA:BB:CC:DD:EE:03\nMTUBytes=1500\n\n[Peer]\nName=vluplink\n", cfgs[4].Contents)
+	require.Len(t, cfgs, 8)
+	require.Equal(t, "10-brsan1.netdev", cfgs[0].Name)
+	require.Equal(t, "[NetDev]\nName=brsan1\nKind=bridge\n\n\n[Bridge]\nVLANFiltering=true\n", cfgs[0].Contents)
+	require.Equal(t, "10-san1.netdev", cfgs[1].Name)
+	require.Equal(t, "[NetDev]\nName=san1\nKind=veth\nMACAddress=AA:BB:CC:DD:EE:01\n\n\n[Peer]\nName=vtsan1\n", cfgs[1].Contents)
+	require.Equal(t, "10-brsan2.netdev", cfgs[2].Name)
+	require.Equal(t, "[NetDev]\nName=brsan2\nKind=bridge\n\n\n[Bridge]\nVLANFiltering=true\n", cfgs[2].Contents)
+	require.Equal(t, "10-san2.netdev", cfgs[3].Name)
+	require.Equal(t, "[NetDev]\nName=san2\nKind=veth\nMACAddress=AA:BB:CC:DD:EE:02\n\n\n[Peer]\nName=vtsan2\n", cfgs[3].Contents)
+	require.Equal(t, "11-bnmanagement.netdev", cfgs[4].Name)
+	require.Equal(t, "[NetDev]\nName=bnmanagement\nKind=bond\nMTUBytes=9000\n\n[Bond]\nMode=802.3ad\n", cfgs[4].Contents)
+	require.Equal(t, "11-brmanagement.netdev", cfgs[5].Name)
+	require.Equal(t, "[NetDev]\nName=brmanagement\nKind=bridge\nMTUBytes=9000\n\n[Bridge]\nVLANFiltering=true\n", cfgs[5].Contents)
+	require.Equal(t, "11-management.netdev", cfgs[6].Name)
+	require.Equal(t, "[NetDev]\nName=management\nKind=veth\nMACAddress=AA:BB:CC:DD:EE:03\nMTUBytes=9000\n\n[Peer]\nName=vtmanagement\n", cfgs[6].Contents)
+	require.Equal(t, "12-uplink.netdev", cfgs[7].Name)
+	require.Equal(t, "[NetDev]\nName=uplink\nKind=vlan\nMTUBytes=1500\n\n[VLAN]\nId=1234\n", cfgs[7].Contents)
 
 	// Test second config .netdev file generation.
 	networkCfg = api.SystemNetworkConfig{}
@@ -374,9 +379,11 @@ func TestNetdevFileGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	cfgs = generateNetdevFileContents(networkCfg)
-	require.Len(t, cfgs, 1)
-	require.Equal(t, "10-braabbccddee01.netdev", cfgs[0].Name)
-	require.Equal(t, "[NetDev]\nName=management\nKind=bridge\nMACAddress=AA:BB:CC:DD:EE:01\nMTUBytes=9000\n\n[Bridge]\nVLANFiltering=true\n", cfgs[0].Contents)
+	require.Len(t, cfgs, 2)
+	require.Equal(t, "10-brmanagement.netdev", cfgs[0].Name)
+	require.Equal(t, "[NetDev]\nName=brmanagement\nKind=bridge\nMTUBytes=9000\n\n[Bridge]\nVLANFiltering=true\n", cfgs[0].Contents)
+	require.Equal(t, "10-management.netdev", cfgs[1].Name)
+	require.Equal(t, "[NetDev]\nName=management\nKind=veth\nMACAddress=AA:BB:CC:DD:EE:01\nMTUBytes=9000\n\n[Peer]\nName=vtmanagement\n", cfgs[1].Contents)
 
 	// Test third config .netdev file generation.
 	networkCfg = api.SystemNetworkConfig{}
@@ -384,9 +391,11 @@ func TestNetdevFileGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	cfgs = generateNetdevFileContents(networkCfg)
-	require.Len(t, cfgs, 1)
-	require.Equal(t, "10-brffeeddccbbaa.netdev", cfgs[0].Name)
-	require.Equal(t, "[NetDev]\nName=eth0\nKind=bridge\nMACAddress=FF:EE:DD:CC:BB:AA\n\n\n[Bridge]\nVLANFiltering=true\n", cfgs[0].Contents)
+	require.Len(t, cfgs, 2)
+	require.Equal(t, "10-breth0.netdev", cfgs[0].Name)
+	require.Equal(t, "[NetDev]\nName=breth0\nKind=bridge\n\n\n[Bridge]\nVLANFiltering=true\n", cfgs[0].Contents)
+	require.Equal(t, "10-eth0.netdev", cfgs[1].Name)
+	require.Equal(t, "[NetDev]\nName=eth0\nKind=veth\nMACAddress=FF:EE:DD:CC:BB:AA\n\n\n[Peer]\nName=vteth0\n", cfgs[1].Contents)
 
 	// Test fourth config .netdev file generation.
 	networkCfg = api.SystemNetworkConfig{}
@@ -394,13 +403,15 @@ func TestNetdevFileGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	cfgs = generateNetdevFileContents(networkCfg)
-	require.Len(t, cfgs, 3)
-	require.Equal(t, "11-bnaabbccddeee1.netdev", cfgs[0].Name)
-	require.Equal(t, "[NetDev]\nName=bnaabbccddeee1\nKind=bond\nMACAddress=aa:bb:cc:dd:ee:e1\nMTUBytes=9000\n\n[Bond]\nMode=802.3ad\n", cfgs[0].Contents)
-	require.Equal(t, "11-braabbccddeee1.netdev", cfgs[1].Name)
-	require.Equal(t, "[NetDev]\nName=uplink\nKind=bridge\nMACAddress=aa:bb:cc:dd:ee:e1\nMTUBytes=9000\n\n[Bridge]\nVLANFiltering=true\n", cfgs[1].Contents)
-	require.Equal(t, "12-management.netdev", cfgs[2].Name)
-	require.Equal(t, "[NetDev]\nName=management\nKind=veth\nMACAddress=aa:bb:cc:dd:ee:e1\nMTUBytes=1500\n\n[Peer]\nName=vlmanagement\n", cfgs[2].Contents)
+	require.Len(t, cfgs, 4)
+	require.Equal(t, "11-bnuplink.netdev", cfgs[0].Name)
+	require.Equal(t, "[NetDev]\nName=bnuplink\nKind=bond\nMTUBytes=9000\n\n[Bond]\nMode=802.3ad\n", cfgs[0].Contents)
+	require.Equal(t, "11-bruplink.netdev", cfgs[1].Name)
+	require.Equal(t, "[NetDev]\nName=bruplink\nKind=bridge\nMTUBytes=9000\n\n[Bridge]\nVLANFiltering=true\n", cfgs[1].Contents)
+	require.Equal(t, "11-uplink.netdev", cfgs[2].Name)
+	require.Equal(t, "[NetDev]\nName=uplink\nKind=veth\nMACAddress=aa:bb:cc:dd:ee:e1\nMTUBytes=9000\n\n[Peer]\nName=vtuplink\n", cfgs[2].Contents)
+	require.Equal(t, "12-management.netdev", cfgs[3].Name)
+	require.Equal(t, "[NetDev]\nName=management\nKind=vlan\nMTUBytes=1500\n\n[VLAN]\nId=10\n", cfgs[3].Contents)
 }
 
 func TestNetworkFileGeneration(t *testing.T) {
@@ -413,27 +424,37 @@ func TestNetworkFileGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	cfgs := generateNetworkFileContents(networkCfg)
-	require.Len(t, cfgs, 10)
+	require.Len(t, cfgs, 15)
 	require.Equal(t, "20-san1.network", cfgs[0].Name)
 	require.Equal(t, "[Match]\nName=san1\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=both\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.0.101.10/24\nAddress=fd40:1234:1234:101::10/64\nIPv6AcceptRA=false\n", cfgs[0].Contents)
-	require.Equal(t, "20-enaabbccddee01.network", cfgs[1].Name)
-	require.Equal(t, "[Match]\nName=enaabbccddee01\n\n[Network]\nBridge=san1\nLLDP=false\nEmitLLDP=false\n", cfgs[1].Contents)
-	require.Equal(t, "20-san2.network", cfgs[2].Name)
-	require.Equal(t, "[Match]\nName=san2\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=both\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.0.102.10/24\nAddress=fd40:1234:1234:102::10/64\nIPv6AcceptRA=false\n", cfgs[2].Contents)
-	require.Equal(t, "20-enaabbccddee02.network", cfgs[3].Name)
-	require.Equal(t, "[Match]\nName=enaabbccddee02\n\n[Network]\nBridge=san2\nLLDP=false\nEmitLLDP=false\n\n[BridgeVLAN]\nVLAN=10\n", cfgs[3].Contents)
-	require.Equal(t, "21-management.network", cfgs[4].Name)
-	require.Equal(t, "[Match]\nName=management\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=any\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.0.100.10/24\nAddress=fd40:1234:1234:100::10/64\nIPv6AcceptRA=false\n\n[Route]\nGateway=10.0.100.1\nDestination=0.0.0.0/0\n\n[Route]\nGateway=fd40:1234:1234:100::1\nDestination=::/0\n", cfgs[4].Contents)
-	require.Equal(t, "21-bnaabbccddee03.network", cfgs[5].Name)
-	require.Equal(t, "[Match]\nName=bnaabbccddee03\n\n[Network]\nBridge=management\n\n[BridgeVLAN]\nPVID=1234\nEgressUntagged=1234\n\n[BridgeVLAN]\nVLAN=100\n\n[BridgeVLAN]\nVLAN=1234\n", cfgs[5].Contents)
-	require.Equal(t, "21-bnaabbccddee03-dev0.network", cfgs[6].Name)
-	require.Equal(t, "[Match]\nName=enaabbccddee03\n\n[Network]\nBond=bnaabbccddee03\nLLDP=false\nEmitLLDP=false\n", cfgs[6].Contents)
-	require.Equal(t, "21-bnaabbccddee03-dev1.network", cfgs[7].Name)
-	require.Equal(t, "[Match]\nName=enaabbccddee04\n\n[Network]\nBond=bnaabbccddee03\nLLDP=false\nEmitLLDP=false\n", cfgs[7].Contents)
-	require.Equal(t, "22-vluplink.network", cfgs[8].Name)
-	require.Equal(t, "[Match]\nName=vluplink\n\n[Network]\nBridge=management\n\n[BridgeVLAN]\nVLAN=1234\nPVID=1234\nEgressUntagged=1234\n", cfgs[8].Contents)
-	require.Equal(t, "22-uplink.network", cfgs[9].Name)
-	require.Equal(t, "[Match]\nName=uplink\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=ipv4\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=false\nDHCP=ipv4\n\n[Route]\nGateway=_dhcp4\nDestination=0.0.0.0/0\n", cfgs[9].Contents)
+	require.Equal(t, "20-vtsan1.network", cfgs[1].Name)
+	require.Equal(t, "[Match]\nName=vtsan1\n\n[Network]\nBridge=brsan1\n", cfgs[1].Contents)
+	require.Equal(t, "20-enaabbccddee01.network", cfgs[2].Name)
+	require.Equal(t, "[Match]\nName=enaabbccddee01\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBridge=brsan1\n", cfgs[2].Contents)
+	require.Equal(t, "20-brsan1.network", cfgs[3].Name)
+	require.Equal(t, "[Match]\nName=brsan1\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[3].Contents)
+	require.Equal(t, "20-san2.network", cfgs[4].Name)
+	require.Equal(t, "[Match]\nName=san2\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=both\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.0.102.10/24\nAddress=fd40:1234:1234:102::10/64\nIPv6AcceptRA=false\n", cfgs[4].Contents)
+	require.Equal(t, "20-vtsan2.network", cfgs[5].Name)
+	require.Equal(t, "[Match]\nName=vtsan2\n\n[Network]\nBridge=brsan2\n\n[BridgeVLAN]\nVLAN=10\n", cfgs[5].Contents)
+	require.Equal(t, "20-enaabbccddee02.network", cfgs[6].Name)
+	require.Equal(t, "[Match]\nName=enaabbccddee02\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBridge=brsan2\n\n[BridgeVLAN]\nVLAN=10\n", cfgs[6].Contents)
+	require.Equal(t, "20-brsan2.network", cfgs[7].Name)
+	require.Equal(t, "[Match]\nName=brsan2\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[7].Contents)
+	require.Equal(t, "21-management.network", cfgs[8].Name)
+	require.Equal(t, "[Match]\nName=management\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=any\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nVLAN=uplink\nLinkLocalAddressing=ipv6\nAddress=10.0.100.10/24\nAddress=fd40:1234:1234:100::10/64\nIPv6AcceptRA=false\n\n[Route]\nGateway=10.0.100.1\nDestination=0.0.0.0/0\n\n[Route]\nGateway=fd40:1234:1234:100::1\nDestination=::/0\n", cfgs[8].Contents)
+	require.Equal(t, "21-vtmanagement.network", cfgs[9].Name)
+	require.Equal(t, "[Match]\nName=vtmanagement\n\n[Network]\nBridge=brmanagement\n\n[BridgeVLAN]\nPVID=1234\nEgressUntagged=1234\n\n[BridgeVLAN]\nVLAN=100\n\n[BridgeVLAN]\nVLAN=1234\n", cfgs[9].Contents)
+	require.Equal(t, "21-bnmanagement.network", cfgs[10].Name)
+	require.Equal(t, "[Match]\nName=bnmanagement\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\nBridge=brmanagement\n\n[BridgeVLAN]\nPVID=1234\nEgressUntagged=1234\n\n[BridgeVLAN]\nVLAN=100\n\n[BridgeVLAN]\nVLAN=1234\n", cfgs[10].Contents)
+	require.Equal(t, "21-brmanagement.network", cfgs[11].Name)
+	require.Equal(t, "[Match]\nName=brmanagement\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[11].Contents)
+	require.Equal(t, "21-bnmanagement-dev0.network", cfgs[12].Name)
+	require.Equal(t, "[Match]\nName=enaabbccddee03\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBond=bnmanagement\n", cfgs[12].Contents)
+	require.Equal(t, "21-bnmanagement-dev1.network", cfgs[13].Name)
+	require.Equal(t, "[Match]\nName=enaabbccddee04\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBond=bnmanagement\n", cfgs[13].Contents)
+	require.Equal(t, "22-uplink.network", cfgs[14].Name)
+	require.Equal(t, "[Match]\nName=uplink\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=ipv4\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=false\nDHCP=ipv4\n\n[Route]\nGateway=_dhcp4\nDestination=0.0.0.0/0\n", cfgs[14].Contents)
 
 	// Test second config .network file generation.
 	networkCfg = api.SystemNetworkConfig{}
@@ -441,11 +462,15 @@ func TestNetworkFileGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	cfgs = generateNetworkFileContents(networkCfg)
-	require.Len(t, cfgs, 2)
+	require.Len(t, cfgs, 4)
 	require.Equal(t, "20-management.network", cfgs[0].Name)
 	require.Equal(t, "[Match]\nName=management\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=ipv6\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=true\nDHCP=ipv4\n\n[Route]\nGateway=_dhcp4\nDestination=0.0.0.0/0\n\n[Route]\nGateway=_ipv6ra\nDestination=::/0\n", cfgs[0].Contents)
-	require.Equal(t, "20-enaabbccddee01.network", cfgs[1].Name)
-	require.Equal(t, "[Match]\nName=enaabbccddee01\n\n[Network]\nBridge=management\nLLDP=false\nEmitLLDP=false\n", cfgs[1].Contents)
+	require.Equal(t, "20-vtmanagement.network", cfgs[1].Name)
+	require.Equal(t, "[Match]\nName=vtmanagement\n\n[Network]\nBridge=brmanagement\n", cfgs[1].Contents)
+	require.Equal(t, "20-enaabbccddee01.network", cfgs[2].Name)
+	require.Equal(t, "[Match]\nName=enaabbccddee01\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBridge=brmanagement\n", cfgs[2].Contents)
+	require.Equal(t, "20-brmanagement.network", cfgs[3].Name)
+	require.Equal(t, "[Match]\nName=brmanagement\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[3].Contents)
 
 	// Test third config .network file generation.
 	networkCfg = api.SystemNetworkConfig{}
@@ -453,11 +478,15 @@ func TestNetworkFileGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	cfgs = generateNetworkFileContents(networkCfg)
-	require.Len(t, cfgs, 2)
+	require.Len(t, cfgs, 4)
 	require.Equal(t, "20-eth0.network", cfgs[0].Name)
 	require.Equal(t, "[Match]\nName=eth0\n\n[Link]\nRequiredForOnline=no\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nDomains=example.org\nDNS=ns1.example.org\nDNS=ns2.example.org\nNTP=pool.ntp.example.org\nNTP=10.10.10.10\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=false\nDHCP=ipv4\n", cfgs[0].Contents)
-	require.Equal(t, "20-enffeeddccbbaa.network", cfgs[1].Name)
-	require.Equal(t, "[Match]\nName=enffeeddccbbaa\n\n[Network]\nBridge=eth0\nLLDP=false\nEmitLLDP=false\n", cfgs[1].Contents)
+	require.Equal(t, "20-vteth0.network", cfgs[1].Name)
+	require.Equal(t, "[Match]\nName=vteth0\n\n[Network]\nBridge=breth0\n", cfgs[1].Contents)
+	require.Equal(t, "20-enffeeddccbbaa.network", cfgs[2].Name)
+	require.Equal(t, "[Match]\nName=enffeeddccbbaa\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBridge=breth0\n", cfgs[2].Contents)
+	require.Equal(t, "20-breth0.network", cfgs[3].Name)
+	require.Equal(t, "[Match]\nName=breth0\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[3].Contents)
 
 	// Test fourth config .network file generation.
 	networkCfg = api.SystemNetworkConfig{}
@@ -465,17 +494,19 @@ func TestNetworkFileGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	cfgs = generateNetworkFileContents(networkCfg)
-	require.Len(t, cfgs, 6)
+	require.Len(t, cfgs, 7)
 	require.Equal(t, "21-uplink.network", cfgs[0].Name)
-	require.Equal(t, "[Match]\nName=uplink\n\n[Link]\nRequiredForOnline=no\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\nIPv6AcceptRA=false\n", cfgs[0].Contents)
-	require.Equal(t, "21-bnaabbccddeee1.network", cfgs[1].Name)
-	require.Equal(t, "[Match]\nName=bnaabbccddeee1\n\n[Network]\nBridge=uplink\n\n[BridgeVLAN]\nVLAN=10\n", cfgs[1].Contents)
-	require.Equal(t, "21-bnaabbccddeee1-dev0.network", cfgs[2].Name)
-	require.Equal(t, "[Match]\nName=enaabbccddeee1\n\n[Network]\nBond=bnaabbccddeee1\nLLDP=true\nEmitLLDP=true\n", cfgs[2].Contents)
-	require.Equal(t, "21-bnaabbccddeee1-dev1.network", cfgs[3].Name)
-	require.Equal(t, "[Match]\nName=enaabbccddeee2\n\n[Network]\nBond=bnaabbccddeee1\nLLDP=true\nEmitLLDP=true\n", cfgs[3].Contents)
-	require.Equal(t, "22-vlmanagement.network", cfgs[4].Name)
-	require.Equal(t, "[Match]\nName=vlmanagement\n\n[Network]\nBridge=uplink\n\n[BridgeVLAN]\nVLAN=10\nPVID=10\nEgressUntagged=10\n", cfgs[4].Contents)
-	require.Equal(t, "22-management.network", cfgs[5].Name)
-	require.Equal(t, "[Match]\nName=management\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=both\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=true\nDHCP=ipv4\n", cfgs[5].Contents)
+	require.Equal(t, "[Match]\nName=uplink\n\n[Link]\nRequiredForOnline=no\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nVLAN=management\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\nIPv6AcceptRA=false\n", cfgs[0].Contents)
+	require.Equal(t, "21-vtuplink.network", cfgs[1].Name)
+	require.Equal(t, "[Match]\nName=vtuplink\n\n[Network]\nBridge=bruplink\n\n[BridgeVLAN]\nPVID=10\nEgressUntagged=10\n\n[BridgeVLAN]\nVLAN=10\n", cfgs[1].Contents)
+	require.Equal(t, "21-bnuplink.network", cfgs[2].Name)
+	require.Equal(t, "[Match]\nName=bnuplink\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\nBridge=bruplink\n\n[BridgeVLAN]\nPVID=10\nEgressUntagged=10\n\n[BridgeVLAN]\nVLAN=10\n", cfgs[2].Contents)
+	require.Equal(t, "21-bruplink.network", cfgs[3].Name)
+	require.Equal(t, "[Match]\nName=bruplink\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[3].Contents)
+	require.Equal(t, "21-bnuplink-dev0.network", cfgs[4].Name)
+	require.Equal(t, "[Match]\nName=enaabbccddeee1\n\n[Network]\nLLDP=true\nEmitLLDP=true\nBond=bnuplink\n", cfgs[4].Contents)
+	require.Equal(t, "21-bnuplink-dev1.network", cfgs[5].Name)
+	require.Equal(t, "[Match]\nName=enaabbccddeee2\n\n[Network]\nLLDP=true\nEmitLLDP=true\nBond=bnuplink\n", cfgs[5].Contents)
+	require.Equal(t, "22-management.network", cfgs[6].Name)
+	require.Equal(t, "[Match]\nName=management\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=both\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=true\nDHCP=ipv4\n", cfgs[6].Contents)
 }

--- a/incus-osd/internal/systemd/networkd_validate.go
+++ b/incus-osd/internal/systemd/networkd_validate.go
@@ -1,0 +1,289 @@
+package systemd
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/lxc/incus-os/incus-osd/api"
+)
+
+func validateInterfaces(interfaces []api.SystemNetworkInterface, vlans []api.SystemNetworkVLAN) error {
+	for index, iface := range interfaces {
+		err := validateName(iface.Name)
+		if err != nil {
+			return fmt.Errorf("interface %d %s", index, err.Error())
+		}
+
+		err = validateMTU(iface.MTU)
+		if err != nil {
+			return fmt.Errorf("interface %d %s", index, err.Error())
+		}
+
+		if iface.VLAN != 0 {
+			err := validateVLAN(iface.VLAN, vlans)
+			if err != nil {
+				return fmt.Errorf("interface %d %s", index, err.Error())
+			}
+		}
+
+		for addressIndex, address := range iface.Addresses {
+			err := validateAddress(address)
+			if err != nil {
+				return fmt.Errorf("interface %d address %d %s", index, addressIndex, err.Error())
+			}
+		}
+
+		err = validateRequiredForOnline(iface.RequiredForOnline)
+		if err != nil {
+			return fmt.Errorf("interface %d %s", index, err.Error())
+		}
+
+		for routeIndex, route := range iface.Routes {
+			err := validateAddress(route.To)
+			if err != nil {
+				return fmt.Errorf("interface %d route %d 'To' %s", index, routeIndex, err.Error())
+			}
+
+			err = validateAddress(route.Via)
+			if err != nil {
+				return fmt.Errorf("interface %d route %d 'Via' %s", index, routeIndex, err.Error())
+			}
+		}
+
+		err = validateHwaddr(iface.Hwaddr)
+		if err != nil {
+			return fmt.Errorf("interface %d %s", index, err.Error())
+		}
+	}
+
+	return nil
+}
+
+func validateBonds(bonds []api.SystemNetworkBond, vlans []api.SystemNetworkVLAN) error {
+	for index, bond := range bonds {
+		err := validateName(bond.Name)
+		if err != nil {
+			return fmt.Errorf("bond %d %s", index, err.Error())
+		}
+
+		err = validateMode(bond.Mode)
+		if err != nil {
+			return fmt.Errorf("bond %d %s", index, err.Error())
+		}
+
+		err = validateMTU(bond.MTU)
+		if err != nil {
+			return fmt.Errorf("bond %d %s", index, err.Error())
+		}
+
+		if bond.VLAN != 0 {
+			err := validateVLAN(bond.VLAN, vlans)
+			if err != nil {
+				return fmt.Errorf("bond %d %s", index, err.Error())
+			}
+		}
+
+		for addressIndex, address := range bond.Addresses {
+			err := validateAddress(address)
+			if err != nil {
+				return fmt.Errorf("bond %d address %d %s", index, addressIndex, err.Error())
+			}
+		}
+
+		err = validateRequiredForOnline(bond.RequiredForOnline)
+		if err != nil {
+			return fmt.Errorf("bond %d %s", index, err.Error())
+		}
+
+		for routeIndex, route := range bond.Routes {
+			err := validateAddress(route.To)
+			if err != nil {
+				return fmt.Errorf("bond %d route %d 'To' %s", index, routeIndex, err.Error())
+			}
+
+			err = validateAddress(route.Via)
+			if err != nil {
+				return fmt.Errorf("bond %d route %d 'Via' %s", index, routeIndex, err.Error())
+			}
+		}
+
+		if bond.Hwaddr != "" {
+			err = validateHwaddr(bond.Hwaddr)
+			if err != nil {
+				return fmt.Errorf("bond %d %s", index, err.Error())
+			}
+		}
+
+		if len(bond.Members) == 0 {
+			return fmt.Errorf("bond %d has no members", index)
+		}
+		for memberIndex, member := range bond.Members {
+			err := validateHwaddr(member)
+			if err != nil {
+				return fmt.Errorf("bond %d member %d %s", index, memberIndex, err.Error())
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateVLANs(cfg *api.SystemNetworkConfig) error {
+	for index, vlan := range cfg.VLANs {
+		err := validateName(vlan.Name)
+		if err != nil {
+			return fmt.Errorf("vlan %d %s", index, err.Error())
+		}
+
+		err = validateParent(vlan.Parent, cfg.Interfaces, cfg.Bonds)
+		if err != nil {
+			return fmt.Errorf("vlan %d %s", index, err.Error())
+		}
+
+		if vlan.ID < 0 || vlan.ID > 4094 {
+			return fmt.Errorf("vlan %d ID %d out of range", index, vlan.ID)
+		}
+
+		err = validateMTU(vlan.MTU)
+		if err != nil {
+			return fmt.Errorf("vlan %d %s", index, err.Error())
+		}
+
+		for addressIndex, address := range vlan.Addresses {
+			err := validateAddress(address)
+			if err != nil {
+				return fmt.Errorf("vlan %d address %d %s", index, addressIndex, err.Error())
+			}
+		}
+
+		err = validateRequiredForOnline(vlan.RequiredForOnline)
+		if err != nil {
+			return fmt.Errorf("vlan %d %s", index, err.Error())
+		}
+
+		for routeIndex, route := range vlan.Routes {
+			err := validateAddress(route.To)
+			if err != nil {
+				return fmt.Errorf("vlan %d route %d 'To' %s", index, routeIndex, err.Error())
+			}
+
+			err = validateAddress(route.Via)
+			if err != nil {
+				return fmt.Errorf("vlan %d route %d 'Via' %s", index, routeIndex, err.Error())
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateName(name string) error {
+	if name == "" {
+		return errors.New("has no name")
+	}
+
+	return nil
+}
+
+func validateMode(mode string) error {
+	if mode != "balance-rr" && mode != "active-backup" && mode != "balance-xor" && mode != "broadcast" && mode != "802.3ad" && mode != "balance-tlb" && mode != "balance-alb" {
+		return fmt.Errorf("invalid Mode value '%s'", mode)
+	}
+
+	return nil
+}
+
+func validateParent(parent string, interfaces []api.SystemNetworkInterface, bonds []api.SystemNetworkBond) error {
+	if parent == "" {
+		return errors.New("has no parent")
+	}
+
+	foundParent := false
+	for _, i := range interfaces {
+		if i.Name == parent {
+			foundParent = true
+
+			break
+		}
+	}
+
+	if !foundParent {
+		for _, b := range bonds {
+			if b.Name == parent {
+				foundParent = true
+
+				break
+			}
+		}
+	}
+
+	if !foundParent {
+		return fmt.Errorf("unable to find parent '%s'", parent)
+	}
+
+	return nil
+}
+
+func validateMTU(mtu int) error {
+	if mtu < 0 || mtu > 9000 {
+		return errors.New("MTU out of range")
+	}
+
+	return nil
+}
+
+func validateVLAN(vlan int, vlans []api.SystemNetworkVLAN) error {
+	foundVLAN := false
+	for _, v := range vlans {
+		if v.ID == vlan {
+			foundVLAN = true
+
+			break
+		}
+	}
+
+	if !foundVLAN {
+		return fmt.Errorf("no vlan %d defined", vlan)
+	}
+
+	return nil
+}
+
+func validateAddress(address string) error {
+	if address == "" {
+		return errors.New("has empty address")
+	}
+
+	if address == "dhcp4" || address == "dhcp6" || address == "slaac" {
+		return nil
+	}
+
+	addressishRegex := regexp.MustCompile(`^[.:[:xdigit:]]+(/\d+)?$`)
+	if !addressishRegex.MatchString(address) {
+		return fmt.Errorf("invalid IP address '%s'", address)
+	}
+
+	return nil
+}
+
+func validateRequiredForOnline(val string) error {
+	if val != "" && val != "ipv6" && val != "ipv4" && val != "both" && val != "any" && val != "no" {
+		return fmt.Errorf("invalid RequiredForOnline value '%s'", val)
+	}
+
+	return nil
+}
+
+func validateHwaddr(hwaddr string) error {
+	if hwaddr == "" {
+		return errors.New("has no MAC address")
+	}
+
+	hwaddrhRegex := regexp.MustCompile(`^[[:xdigit:]]{2}:[[:xdigit:]]{2}:[[:xdigit:]]{2}:[[:xdigit:]]{2}:[[:xdigit:]]{2}:[[:xdigit:]]{2}$`)
+	if !hwaddrhRegex.MatchString(hwaddr) {
+		return fmt.Errorf("invalid MAC address '%s'", hwaddr)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR completely reworks how network configuration is generated. Additionally, some validation logic was added which should help should catch several potential mis-configurations earlier, rather than having to figure out why `networkd` didn't start or didn't properly configure something.

It's also now possible to use a generic interface name where ever a MAC address is used in a seed file. At startup time, incus-osd will attempt to determine the local MAC address for the given interface and will then substitute that value into the daemon's state. (Closes #115)

```
interfaces:
  - name: link0
    hwaddr: enp5s0
    addresses:
      - dhcp4
```