### PR TITLE
Installer fixes

### DIFF
--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -102,8 +102,14 @@ func run(ctx context.Context, s *state.State, t *tui.TUI) error {
 	if err != nil {
 		modal := t.AddModal("Incus OS")
 		modal.Update("System check error: [red]" + err.Error() + "[white]\nIncus OS is unable to run until the problem is resolved.")
+		slog.Error(err.Error())
 
-		return err
+		// If we fail the system requirement check, we'll enter a startup loop with the systemd service
+		// constantly trying to restart the daemon. Rather than doing that, just sleep here for an hour
+		// so the error message doesn't flicker off and on, then exit and let systemd start us again.
+		time.Sleep(1 * time.Hour)
+
+		os.Exit(1) //nolint:revive
 	}
 
 	// Check if we should try to install to a local disk.

--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -518,7 +518,7 @@ func copyPartitionDefinition(ctx context.Context, src string, tgt string, partit
 	partitionNameRegex := regexp.MustCompile(`Partition name: '(.+)'`)
 	partitionSizeRegex := regexp.MustCompile(`Partition size: \d+ sectors \((.+)\)`)
 
-	partitionHexCode := ""
+	var partitionHexCode string
 	partitionType := partitionTypeRegex.FindStringSubmatch(output)[1]
 	partitionGUID := partitionGUIDRegex.FindStringSubmatch(output)[1]
 	partitionName := partitionNameRegex.FindStringSubmatch(output)[1]
@@ -535,6 +535,8 @@ func copyPartitionDefinition(ctx context.Context, src string, tgt string, partit
 		partitionHexCode = "8319"
 	case "Linux x86-64 /usr":
 		partitionHexCode = "8314"
+	default:
+		return fmt.Errorf("unrecognized partition type '%s'", partitionType)
 	}
 
 	// Create the partition on the target device.

--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -48,8 +48,16 @@ func CheckSystemRequirements(ctx context.Context) error {
 		return errors.New("unable to begin install without seed configuration")
 	}
 
+	// Check if Secure Boot is enabled.
+	output, err := subprocess.RunCommandContext(ctx, "bootctl", "status")
+	if err != nil {
+		return err
+	} else if !strings.Contains(output, "Secure Boot: enabled (user)") {
+		return errors.New("Secure Boot is not enabled") //nolint:staticcheck
+	}
+
 	// Check if a TPM device is present.
-	_, err := os.Stat("/dev/tpm0")
+	_, err = os.Stat("/dev/tpm0")
 	if err != nil {
 		return errors.New("no TPM device found")
 	}

--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -236,7 +236,7 @@ func getAllTargets(ctx context.Context) ([]blockdevices, error) {
 
 	// Get NVME drives first.
 	nvmeTargets := lsblkOutput{}
-	output, err := subprocess.RunCommandContext(ctx, "lsblk", "-N", "-iJnp", "-o", "KNAME,ID_LINK")
+	output, err := subprocess.RunCommandContext(ctx, "lsblk", "-N", "-iJnp", "-e", "1,2", "-o", "KNAME,ID_LINK")
 	if err != nil {
 		return []blockdevices{}, err
 	}
@@ -250,7 +250,7 @@ func getAllTargets(ctx context.Context) ([]blockdevices, error) {
 
 	// Get SCSI drives second.
 	scsiTargets := lsblkOutput{}
-	output, err = subprocess.RunCommandContext(ctx, "lsblk", "-S", "-iJnp", "-o", "KNAME,ID_LINK")
+	output, err = subprocess.RunCommandContext(ctx, "lsblk", "-S", "-iJnp", "-e", "1,2", "-o", "KNAME,ID_LINK")
 	if err != nil {
 		return []blockdevices{}, err
 	}
@@ -264,7 +264,7 @@ func getAllTargets(ctx context.Context) ([]blockdevices, error) {
 
 	// Get virtual drives last.
 	virtualTargets := lsblkOutput{}
-	output, err = subprocess.RunCommandContext(ctx, "lsblk", "-v", "-iJnp", "-o", "KNAME,ID_LINK")
+	output, err = subprocess.RunCommandContext(ctx, "lsblk", "-v", "-iJnp", "-e", "1,2", "-o", "KNAME,ID_LINK")
 	if err != nil {
 		return []blockdevices{}, err
 	}


### PR DESCRIPTION
* Don't consider ramdisks or floppy devices
* Run `blkdiscard` to wipe target device
* Handle partially wiped disks that don't have a main GPT table
* Check if Secure Boot is enabled
* When system requirements check fails, don't enter a tight startup loop