### PR TITLE
incus-osd/install: Allow secure boot in non-user mode

### DIFF
--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -52,7 +52,7 @@ func CheckSystemRequirements(ctx context.Context) error {
 	output, err := subprocess.RunCommandContext(ctx, "bootctl", "status")
 	if err != nil {
 		return err
-	} else if !strings.Contains(output, "Secure Boot: enabled (user)") {
+	} else if !strings.Contains(output, "Secure Boot: enabled") {
 		return errors.New("Secure Boot is not enabled") //nolint:staticcheck
 	}
 

--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -284,7 +284,18 @@ func getAllTargets(ctx context.Context) ([]blockdevices, error) {
 
 	ret = append(ret, virtualTargets.Blockdevices...)
 
-	return ret, nil
+	// Filter out devices that are known to not be valid targets.
+	filtered := make([]blockdevices, 0, len(ret))
+	for _, entry := range ret {
+		if strings.HasPrefix(entry.ID, "usb-Linux_Virtual_") {
+			// Virtual BMC devices on DELL servers.
+			continue
+		}
+
+		filtered = append(filtered, entry)
+	}
+
+	return filtered, nil
 }
 
 // getTargetDevice determines the underlying device to install incus-osd on.


### PR DESCRIPTION
Secure Boot can be enabled in "deployed" mode, so don't require "user" mode.