### PR TITLE
Display early startup message

### DIFF
--- a/mkosi.packages/initrd-tmpfs-root/debian/initrd-tmpfs-root.install
+++ b/mkosi.packages/initrd-tmpfs-root/debian/initrd-tmpfs-root.install
@@ -4,3 +4,5 @@ initrd-tmpfs-root.service usr/lib/systemd/system/
 99-add-cdrom-partitions.rules usr/lib/udev/rules.d/
 
 00-device-timeout.conf usr/lib/systemd/system.conf.d/
+
+initrd-message.service  usr/lib/systemd/system/

--- a/mkosi.packages/initrd-tmpfs-root/debian/initrd-tmpfs-root.links
+++ b/mkosi.packages/initrd-tmpfs-root/debian/initrd-tmpfs-root.links
@@ -1,0 +1,1 @@
+usr/lib/systemd/system/initrd-message.service usr/lib/systemd/system/veritysetup.target.wants/initrd-message.service

--- a/mkosi.packages/initrd-tmpfs-root/initrd-message.service
+++ b/mkosi.packages/initrd-tmpfs-root/initrd-message.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Display startup message
+Before=veritysetup.target
+After=veritysetup-pre.target
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+
+Environment=MSG="Incus OS is starting..."
+Environment=TTYS="/dev/tty1 /dev/tty2 /dev/tty3 /dev/tty4 /dev/tty5 /dev/tty6 /dev/tty6 /dev/tty7 /dev/ttyS0"
+
+ExecStart=/bin/sh -c "for TTY in $TTYS; do echo $MSG > $TTY; done"
+
+[Install]
+WantedBy=veritysetup.target


### PR DESCRIPTION
Display an early startup message so the user knows something is happening when Incus OS boots. The message isn't displayed for a few seconds until systemd has begun starting the system, but I think it's probably the best we can do without getting into the hacky realm.

Closes #124