### PR TITLE
Optimize the copying of /usr erofs partitions

### DIFF
--- a/mkosi.images/base/mkosi.conf.d/03-core-packages.conf
+++ b/mkosi.images/base/mkosi.conf.d/03-core-packages.conf
@@ -4,6 +4,7 @@ Packages=
     dbus
     dosfstools
     e2fsprogs
+    erofs-utils
     gdisk
     iproute2
     lvm2


### PR DESCRIPTION
We can easily enough get the exact size of the erofs image for /usr to optimize that copy.

Attempting to optimize copying the seed and /usr-verity partitions by looking for long runs of zeros to indicate end of data got to be too complicated for the benefit, in my opinion. They're also just 100MiB in size, so should copy pretty quickly. I did bump the chunk size up to 4MiB, which should also help a bit with the speed.

Closes #135