### PR TITLE
Make install faster

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
     name: End to end testing
     strategy:
       fail-fast: false
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on:
       - self-hosted
       - cpu-4
@@ -187,6 +187,6 @@ jobs:
 
           incus restart test-incus-os
 
-          sleep 1m
+          sleep 3m
 
           incus exec test-incus-os -- grep $RELEASE /usr/lib/os-release

--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -644,7 +644,7 @@ func doCopy(ctx context.Context, modal *tui.Modal, sourceDevice string, sourcePa
 	}
 	defer targetPartition.Close()
 
-	modal.Update(fmt.Sprintf("Copying partition %d of %d.", partitionIndex, numPartitionsToCopy))
+	modal.Update(fmt.Sprintf("Copying partition %d of %d (%.2fMiB).", partitionIndex, numPartitionsToCopy, float64(partitionSize)/1024.0/1024.0))
 
 	// Copy data in 4MiB chunks.
 	blockSize := int64(4 * 1024 * 1024)
@@ -659,10 +659,6 @@ func doCopy(ctx context.Context, modal *tui.Modal, sourceDevice string, sourcePa
 			return err
 		}
 
-		// Update progress every 24MiB.
-		if count%6 == 0 {
-			modal.UpdateProgress(float64(count*blockSize) / float64(partitionSize))
-		}
 		count++
 
 		// Break out of copy loop early, if possible.
@@ -670,9 +666,6 @@ func doCopy(ctx context.Context, modal *tui.Modal, sourceDevice string, sourcePa
 			break
 		}
 	}
-
-	// Hide the progress bar.
-	modal.UpdateProgress(0.0)
 
 	return nil
 }

--- a/incus-osd/internal/tui/tui.go
+++ b/incus-osd/internal/tui/tui.go
@@ -112,7 +112,8 @@ func (t *TUI) Run() error {
 				modalIndex := i % numModals
 				t.renderModal(fmt.Sprintf("[%d/%d] %s", modalIndex+1, numModals, t.modalMessages[modalIndex].title), t.modalMessages[modalIndex].message, t.modalMessages[modalIndex].progress)
 			case numModals == 1:
-				t.renderModal(t.modalMessages[0].title, t.modalMessages[0].message, t.modalMessages[0].progress)
+				// No point in re-drawing anything when there's just one modal. Any updates to it
+				// will have already been drawn in `quickDraw()`.
 			default:
 				// No modal to display.
 				t.pages.RemovePage("modal")

--- a/incus-osd/internal/tui/tui.go
+++ b/incus-osd/internal/tui/tui.go
@@ -39,7 +39,7 @@ func NewTUI(s *state.State) (*TUI, error) {
 	}
 
 	// Attempt to open the system's consoles.
-	ttys, err := newTtyMultiplexer("/dev/console", "/dev/tty1", "/dev/tty2", "/dev/tty3", "/dev/tty4", "/dev/tty5", "/dev/tty6", "/dev/tty7", "/dev/ttyS0")
+	ttys, err := newTtyMultiplexer("/dev/console", "/dev/tty1", "/dev/ttyS0")
 	if err != nil {
 		return ret, err
 	}

--- a/mkosi.packages/initrd-tmpfs-root/initrd-message.service.in
+++ b/mkosi.packages/initrd-tmpfs-root/initrd-message.service.in
@@ -8,7 +8,7 @@ DefaultDependencies=no
 Type=oneshot
 
 Environment=MSG="@OSNAME@ is starting..."
-Environment=TTYS="/dev/tty1 /dev/tty2 /dev/tty3 /dev/tty4 /dev/tty5 /dev/tty6 /dev/tty6 /dev/tty7 /dev/ttyS0"
+Environment=TTYS="/dev/tty1 /dev/ttyS0"
 
 ExecStart=/bin/sh -c "for TTY in $TTYS; do echo $MSG > $TTY; done"
 


### PR DESCRIPTION
This PR makes two main changes to help speed up the install process:

* Eliminate duplicate screen redrawing when there's only a single modal.
* Don't display progress when copying data partitions. While this is nice, the required screen updates cause a significant slowdown of the underlying copy loop. Since the amount of data to be copied from one disk to another is so small, the modal message for each partition should only be displayed for a few seconds on most systems.

The underlying libraries used for the TUI (tview/tcell) say that they attempt to buffer screen updates and then only send relevant changes to the actual console. In my testing I'm not sure how well this is working; I did strip down our TUI wrapper library to the bare minimum (simple text with no modals direct to a single tty), and still observed a significant cost to rendering progress updates.

Partially addresses #134