### PR TITLE
Implement custom state serialization

### DIFF
--- a/incus-osd/api/system_network.go
+++ b/incus-osd/api/system_network.go
@@ -4,7 +4,7 @@ package api
 type SystemNetwork struct {
 	Config *SystemNetworkConfig `json:"config" yaml:"config"`
 
-	State SystemNetworkState `json:"state" yaml:"state"`
+	State SystemNetworkState `incusos:"-" json:"state" yaml:"state"`
 }
 
 // SystemNetworkConfig represents the user modifiable network configuration.

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -64,7 +64,7 @@ func main() {
 	}
 
 	// Get persistent state.
-	s, err := state.LoadOrCreate(ctx, filepath.Join(varPath, "state.json"))
+	s, err := state.LoadOrCreate(ctx, filepath.Join(varPath, "state.txt"))
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/incus-osd/internal/state/decode.go
+++ b/incus-osd/internal/state/decode.go
@@ -1,0 +1,239 @@
+package state
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// UpgradeFuncs is a list of functions to apply in order to upgrade the version of a given state.
+// Each function consumes a list of strings, each representing one line of input, and returns a
+// list of strings representing the upgraded state.
+type UpgradeFuncs []func([]string) ([]string, error)
+
+// Decode reconstitutes a given state. Optionally, if provided, a list of upgrade functions will be
+// applied before decoding the state.
+func Decode(b []byte, upgradeFuncs UpgradeFuncs, s *State) error {
+	lines := strings.Split(string(b), "\n")
+
+	// Check if we need to run any update logic.
+	if strings.HasPrefix(lines[0], "#Version: ") {
+		version, err := strconv.Atoi(strings.TrimPrefix(lines[0], "#Version: "))
+		if err != nil {
+			return err
+		}
+
+		// Apply any needed upgrade functions to the input.
+		for i := version; i < len(upgradeFuncs); i++ {
+			lines, err = upgradeFuncs[i](lines)
+			if err != nil {
+				return err
+			}
+
+			s.StateVersion = i + 1
+		}
+	}
+
+	// Parse each line.
+	for _, line := range lines {
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, ": ", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("malformed line '%s'", line)
+		}
+
+		err := decodeHelper(reflect.ValueOf(s), strings.Split(parts[0], "."), parts[1])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// decodeHelper walks the state struct as defined by the provided keys and attempts to set the
+// value once it reaches the end.
+//
+// Because maps are unaddressable, when decoding a map we recursively call ourselves with the new
+// map as the root value, and once it is fully decoded then set the map as the new value and return.
+func decodeHelper(v reflect.Value, keys []string, value string) error {
+	// Walk the state struct to the appropriate location.
+	for keyIndex, key := range keys {
+		if reflect.Indirect(v).Kind() != reflect.Struct {
+			return fmt.Errorf("unsupported kind '%s'", reflect.Indirect(v).Kind())
+		}
+
+		// Potentially split the current key if it is indexing an array or a map.
+		parts := strings.Split(key, "[")
+		if len(parts) == 2 {
+			parts[1] = strings.TrimSuffix(parts[1], "]")
+		}
+
+		// Get the field from the current struct.
+		field := reflect.Indirect(v).FieldByName(parts[0])
+
+		if !field.IsValid() {
+			return fmt.Errorf("invalid field '%s' for struct '%s'", key, v.Type())
+		}
+
+		// Do additional processing, if needed.
+		switch field.Kind() { //nolint:exhaustive
+		case reflect.Map:
+			if field.IsNil() {
+				field.Set(reflect.MakeMap(field.Type()))
+			}
+
+			mapField := field.MapIndex(reflect.ValueOf(parts[1]))
+			if !mapField.IsValid() {
+				mapField = reflect.New(field.Type().Elem()).Elem()
+			} else {
+				newMapField := reflect.New(field.Type().Elem()).Elem()
+				newMapField.Set(mapField)
+				mapField = newMapField
+			}
+
+			err := decodeHelper(mapField, keys[keyIndex+1:], value)
+			if err != nil {
+				return err
+			}
+
+			field.SetMapIndex(reflect.ValueOf(parts[1]), mapField)
+
+			return nil
+		case reflect.Pointer:
+			if field.IsNil() {
+				field.Set(reflect.New(field.Type().Elem()))
+			}
+		case reflect.Slice:
+			index, err := strconv.Atoi(parts[1])
+			if err != nil {
+				return err
+			}
+
+			if field.IsNil() {
+				field.Set(reflect.MakeSlice(field.Type(), 0, 0))
+			}
+
+			for field.Len() <= index {
+				t := field.Type().Elem()
+				field.Set(reflect.Append(field, reflect.Zero(t)))
+			}
+
+			field = field.Index(index)
+		}
+
+		// Advance down one level into the state struct.
+		v = field
+	}
+
+	// We've reached the end, and are ready to set the actual value.
+	return setValue(v, value)
+}
+
+// setValue is a helper function to convert and set a string representation of a value.
+func setValue(v reflect.Value, value string) error {
+	// Set the value.
+	switch v.Kind() { //nolint:exhaustive
+	case reflect.Bool:
+		bVal, err := strconv.ParseBool(value)
+		if err != nil {
+			return err
+		}
+
+		v.SetBool(bVal)
+	case reflect.Float32:
+		fVal, err := strconv.ParseFloat(value, 32)
+		if err != nil {
+			return err
+		}
+
+		v.SetFloat(fVal)
+	case reflect.Float64:
+		fVal, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return err
+		}
+
+		v.SetFloat(fVal)
+	case reflect.Int:
+		iVal, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return err
+		}
+
+		v.SetInt(iVal)
+	case reflect.Int8:
+		iVal, err := strconv.ParseInt(value, 10, 8)
+		if err != nil {
+			return err
+		}
+
+		v.SetInt(iVal)
+	case reflect.Int16:
+		iVal, err := strconv.ParseInt(value, 10, 16)
+		if err != nil {
+			return err
+		}
+
+		v.SetInt(iVal)
+	case reflect.Int32:
+		iVal, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			return err
+		}
+
+		v.SetInt(iVal)
+	case reflect.Int64:
+		iVal, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return err
+		}
+
+		v.SetInt(iVal)
+	case reflect.String:
+		v.SetString(value)
+	case reflect.Uint:
+		uVal, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return err
+		}
+
+		v.SetUint(uVal)
+	case reflect.Uint8:
+		uVal, err := strconv.ParseUint(value, 10, 8)
+		if err != nil {
+			return err
+		}
+
+		v.SetUint(uVal)
+	case reflect.Uint16:
+		uVal, err := strconv.ParseUint(value, 10, 16)
+		if err != nil {
+			return err
+		}
+
+		v.SetUint(uVal)
+	case reflect.Uint32:
+		uVal, err := strconv.ParseUint(value, 10, 32)
+		if err != nil {
+			return err
+		}
+
+		v.SetUint(uVal)
+	case reflect.Uint64:
+		uVal, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return err
+		}
+
+		v.SetUint(uVal)
+	default:
+		return fmt.Errorf("unhandled kind '%s'", v.Kind())
+	}
+
+	return nil
+}

--- a/incus-osd/internal/state/encode.go
+++ b/incus-osd/internal/state/encode.go
@@ -1,0 +1,114 @@
+package state
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// Encode encodes the state and returns an array of bytes.
+func Encode(s *State) ([]byte, error) {
+	var b bytes.Buffer
+
+	_, err := fmt.Fprintf(&b, "#Version: %d\n", s.StateVersion)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	err = encodeHelper(&b, []string{}, reflect.ValueOf(s))
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return b.Bytes(), nil
+}
+
+// encodeHelper recursively walks the state struct and serializes each value, writing
+// the results to the provide buffer.
+//
+// To minimize space, we never write a zero value. The code also respects both "incusos"
+// and "json" tags with the value of "-" to omit exported fields that would otherwise
+// be encoded.
+func encodeHelper(b *bytes.Buffer, keyPrefix []string, v reflect.Value) error {
+	// Skip serializing any zero values.
+	if v.IsZero() {
+		return nil
+	}
+
+	switch v.Kind() { //nolint:exhaustive
+	case reflect.Bool:
+		_, err := fmt.Fprintf(b, "%s: %v\n", strings.Join(keyPrefix, "."), v.Bool())
+		if err != nil {
+			return err
+		}
+	case reflect.Float32, reflect.Float64:
+		_, err := fmt.Fprintf(b, "%s: %f\n", strings.Join(keyPrefix, "."), v.Float())
+		if err != nil {
+			return err
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		_, err := fmt.Fprintf(b, "%s: %d\n", strings.Join(keyPrefix, "."), v.Int())
+		if err != nil {
+			return err
+		}
+	case reflect.Map:
+		keyBase := keyPrefix[len(keyPrefix)-1]
+
+		iter := v.MapRange()
+		for iter.Next() {
+			keyPrefix[len(keyPrefix)-1] = fmt.Sprintf("%s[%s]", keyBase, iter.Key())
+
+			err := encodeHelper(b, keyPrefix, iter.Value())
+			if err != nil {
+				return err
+			}
+		}
+	case reflect.Pointer:
+		if v.IsNil() {
+			return nil
+		}
+
+		return encodeHelper(b, keyPrefix, v.Elem())
+	case reflect.Slice:
+		keyBase := keyPrefix[len(keyPrefix)-1]
+		for i := range v.Len() {
+			keyPrefix[len(keyPrefix)-1] = fmt.Sprintf("%s[%d]", keyBase, i)
+
+			err := encodeHelper(b, keyPrefix, v.Index(i))
+			if err != nil {
+				return err
+			}
+		}
+	case reflect.String:
+		_, err := fmt.Fprintf(b, "%s: %s\n", strings.Join(keyPrefix, "."), v.String())
+		if err != nil {
+			return err
+		}
+	case reflect.Struct:
+		fields := reflect.VisibleFields(v.Type())
+
+		for _, field := range fields {
+			if field.IsExported() {
+				// Skip any fields that shouldn't be marshalled.
+				if field.Tag.Get("json") == "-" || field.Tag.Get("incusos") == "-" {
+					continue
+				}
+
+				err := encodeHelper(b, append(keyPrefix, field.Name), v.FieldByIndex(field.Index))
+				if err != nil {
+					return err
+				}
+			}
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		_, err := fmt.Fprintf(b, "%s: %d\n", strings.Join(keyPrefix, "."), v.Uint())
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("%s: unhandled kind '%s'", strings.Join(keyPrefix, "."), v.Kind())
+	}
+
+	return nil
+}

--- a/incus-osd/internal/state/file.go
+++ b/incus-osd/internal/state/file.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strings"
 )
 
 // LoadOrCreate parses the on-disk state file and returns a State struct.
@@ -16,10 +17,17 @@ func LoadOrCreate(ctx context.Context, path string) (*State, error) {
 	}
 
 	body, err := os.ReadFile(s.path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			// State file doesn't exist, create it and return it.
-			err = s.Save(ctx)
+	if err == nil {
+		err = Decode(body, nil, &s)
+
+		return &s, err
+	}
+
+	if os.IsNotExist(err) {
+		// Check if a legacy json state file exists.
+		_, err := os.Stat(strings.Replace(s.path, ".txt", ".json", 1))
+		if err == nil {
+			err := convertLegacyJSON(ctx, strings.Replace(s.path, ".txt", ".json", 1), &s)
 			if err != nil {
 				return nil, err
 			}
@@ -27,20 +35,42 @@ func LoadOrCreate(ctx context.Context, path string) (*State, error) {
 			return &s, nil
 		}
 
-		return nil, err
+		// State file doesn't exist, create it and return it.
+		err = s.Save(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		return &s, nil
 	}
 
-	err = json.Unmarshal(body, &s)
+	return nil, err
+}
+
+// convertLegacyJSON reads a legacy json state file, saves using the new format and removes the old json file.
+func convertLegacyJSON(ctx context.Context, path string, s *State) error {
+	// #nosec G304
+	body, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return &s, nil
+	err = json.Unmarshal(body, s)
+	if err != nil {
+		return err
+	}
+
+	err = s.Save(ctx)
+	if err != nil {
+		return err
+	}
+
+	return os.Remove(path)
 }
 
 // Save writes out the current state struct into its on-disk storage.
 func (s *State) Save(_ context.Context) error {
-	body, err := json.Marshal(s)
+	body, err := Encode(s)
 	if err != nil {
 		return err
 	}

--- a/incus-osd/internal/state/state_test.go
+++ b/incus-osd/internal/state/state_test.go
@@ -1,0 +1,118 @@
+package state_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lxc/incus-os/incus-osd/internal/state"
+)
+
+var goldJSON = `{"secure_boot":{"version":"","fully_applied":false},"applications":{"incus":{"initialized":true,"version":"202506241635"}},"os":{"name":"IncusOS","running_release":"202506241635","next_release":"202506241635"},"services":{"iscsi":{"state":{"initiator_name":""},"config":{"enabled":false,"targets":null}},"lvm":{"state":{},"config":{"enabled":false,"system_id":0}},"nvme":{"state":{"host_id":"","host_nqn":""},"config":{"enabled":false,"targets":null}},"ovn":{"state":{},"config":{"enabled":false,"ic_chassis":false,"database":"","tls_client_certificate":"","tls_client_key":"","tls_ca_certificate":"","tunnel_address":"","tunnel_protocol":""}},"usbip":{"state":{},"config":{"targets":null}}},"system":{"encryption":{"config":{"recovery_keys":["ebbbibiu-ltgjfuhk-gvutdrvu-hijhvfje-gvlrgrfv-ndekdtdh-ghteuklj-ldedfifb"]},"state":{"recovery_keys_retrieved":true}},"network":{"config":{"interfaces":[{"name":"enp5s0","addresses":["dhcp4","slaac"],"hwaddr":"10:66:6a:7c:8c:b0","lldp":false}]},"state":{"interfaces":{"enp5s0":{"type":"interface","addresses":["10.234.136.156"],"routes":[{"to":"default","via":"10.234.136.1"}],"mtu":1500,"speed":"10Gbps","state":"routable","stats":{"rx_bytes":944,"tx_bytes":751,"rx_errors":0,"tx_errors":0}}}}},"provider":{"config":{"name":"local","config":null},"state":{"registered":false}}}}`
+
+var goldEncoding = `#Version: 0
+Applications[incus].Initialized: true
+Applications[incus].Version: 202506241635
+OS.Name: IncusOS
+OS.RunningRelease: 202506241635
+OS.NextRelease: 202506241635
+System.Encryption.Config.RecoveryKeys[0]: ebbbibiu-ltgjfuhk-gvutdrvu-hijhvfje-gvlrgrfv-ndekdtdh-ghteuklj-ldedfifb
+System.Encryption.State.RecoveryKeysRetrieved: true
+System.Network.Config.Interfaces[0].Name: enp5s0
+System.Network.Config.Interfaces[0].Addresses[0]: dhcp4
+System.Network.Config.Interfaces[0].Addresses[1]: slaac
+System.Network.Config.Interfaces[0].Hwaddr: 10:66:6a:7c:8c:b0
+System.Provider.Config.Name: local
+`
+
+// Test basic json decoding/encoding of state.
+func TestJsonEncoding(t *testing.T) {
+	t.Parallel()
+
+	var s state.State
+
+	err := json.Unmarshal([]byte(goldJSON), &s)
+	require.NoError(t, err)
+
+	content, err := json.Marshal(s)
+	require.NoError(t, err)
+
+	require.JSONEq(t, goldJSON, string(content))
+}
+
+// Test basic custom decoding/encoding of state.
+func TestCustomEncoding(t *testing.T) {
+	t.Parallel()
+
+	var s state.State
+
+	err := state.Decode([]byte(goldEncoding), nil, &s)
+	require.NoError(t, err)
+
+	content, err := state.Encode(&s)
+	require.NoError(t, err)
+
+	require.Equal(t, goldEncoding, string(content))
+	require.Equal(t, 0, s.StateVersion)
+}
+
+// Test that we can correctly read in the json format and produce the expected custom encoding.
+func TestEncodingSwitch(t *testing.T) {
+	t.Parallel()
+
+	var js state.State
+
+	err := json.Unmarshal([]byte(goldJSON), &js)
+	require.NoError(t, err)
+
+	content, err := state.Encode(&js)
+	require.NoError(t, err)
+
+	var cs1, cs2 state.State
+
+	err = state.Decode(content, nil, &cs1)
+	require.NoError(t, err)
+
+	err = state.Decode([]byte(goldEncoding), nil, &cs2)
+	require.NoError(t, err)
+
+	require.Equal(t, cs1, cs2)
+}
+
+// Test simple upgrade functions when reading in state.
+func TestUpgradeFuncs(t *testing.T) {
+	t.Parallel()
+
+	funcs := state.UpgradeFuncs{
+		func(lines []string) ([]string, error) {
+			for i, line := range lines {
+				if strings.HasPrefix(line, "OS.Name") {
+					lines[i] = "OS.Name: My Test OS"
+				}
+			}
+
+			return lines, nil
+		},
+		func(lines []string) ([]string, error) {
+			for i, line := range lines {
+				if strings.HasPrefix(line, "System.Network.Config.Interfaces[0].Addresses[1]") {
+					lines[i] = "System.Network.Config.Interfaces[0].Addresses[1]: dhcp6"
+				}
+			}
+
+			return lines, nil
+		},
+	}
+
+	var s state.State
+
+	err := state.Decode([]byte(goldEncoding), funcs, &s)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, s.StateVersion)
+	require.Equal(t, "My Test OS", s.OS.Name)
+	require.Equal(t, "dhcp4", s.System.Network.Config.Interfaces[0].Addresses[0])
+	require.Equal(t, "dhcp6", s.System.Network.Config.Interfaces[0].Addresses[1])
+}

--- a/incus-osd/internal/state/struct.go
+++ b/incus-osd/internal/state/struct.go
@@ -31,6 +31,8 @@ type OS struct {
 type State struct {
 	path string
 
+	StateVersion int `json:"-"`
+
 	ShouldPerformInstall bool `json:"-"`
 	RebootRequired       bool `json:"-"`
 


### PR DESCRIPTION
Switch from json to a custom key/value serialization of state. Hopefully this will make it easier to make breaking changes to the state struct down the road while still being able to read in old state files.

I'd like to grab a few more complicated json state dumps from different IncusOS installs before merging, just to make sure there's not some edge case that I might have missed.

Closes #146