### PR TITLE
Fix bringing default network online

### DIFF
--- a/incus-osd/internal/seed/network.go
+++ b/incus-osd/internal/seed/network.go
@@ -103,10 +103,14 @@ func getDefaultNetworkConfig() (*api.SystemNetworkConfig, error) {
 			continue
 		}
 
+		// Auto-generated interfaces set RequiredForOnline to "no", and we rely
+		// on the DNS check after interface configuration to indicate when there's
+		// good network connectivity.
 		ret.Interfaces = append(ret.Interfaces, api.SystemNetworkInterface{
-			Name:      i.Name,
-			Hwaddr:    i.HardwareAddr.String(),
-			Addresses: []string{"dhcp4", "slaac"},
+			Name:              i.Name,
+			Hwaddr:            i.HardwareAddr.String(),
+			Addresses:         []string{"dhcp4", "slaac"},
+			RequiredForOnline: "no",
 		})
 	}
 


### PR DESCRIPTION
When no network seed is provided, don't require any auto-generated interfaces to be online, but rather rely on DNS resolution to indicate when the network is up.

Closes #207