### PR TITLE
System security status updates

### DIFF
--- a/incus-osd/internal/rest/api_system_security.go
+++ b/incus-osd/internal/rest/api_system_security.go
@@ -21,13 +21,8 @@ func (s *Server) apiSystemSecurity(w http.ResponseWriter, r *http.Request) {
 		// Mark that the keys have been retrieved via the API.
 		s.state.System.Security.State.EncryptionRecoveryKeysRetrieved = true
 
-		// Get the state of each encrypted volume.
-		s.state.System.Security.State.EncryptedVolumes, err = systemd.ListEncryptedVolumes(r.Context())
-		if err != nil {
-			_ = response.BadRequest(err).Render(w)
-
-			return
-		}
+		// s.state.System.Security.State.EncryptedVolumes is pre-cached, because
+		// getting the state of the LUKS volumes can be slow.
 
 		// Get Secure Boot state (we always expect this to be true).
 		s.state.System.Security.State.SecureBootEnabled, err = secureboot.Enabled()

--- a/incus-osd/internal/secureboot/secureboot.go
+++ b/incus-osd/internal/secureboot/secureboot.go
@@ -821,6 +821,10 @@ func efiVariableToFilename(variableName string) (string, error) {
 	switch variableName {
 	case "SecureBoot":
 		return "/sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c", nil
+	case "SetupMode":
+		return "/sys/firmware/efi/efivars/SetupMode-8be4df61-93ca-11d2-aa0d-00e098032b8c", nil
+	case "DeployedMode":
+		return "/sys/firmware/efi/efivars/DeployedMode-8be4df61-93ca-11d2-aa0d-00e098032b8c", nil
 	case "PK":
 		return "/sys/firmware/efi/efivars/PK-8be4df61-93ca-11d2-aa0d-00e098032b8c", nil
 	case "KEK":

--- a/incus-osd/internal/systemd/sysupdate.go
+++ b/incus-osd/internal/systemd/sysupdate.go
@@ -105,8 +105,10 @@ func ApplySystemUpdate(ctx context.Context, luksPassword string, version string,
 		return err
 	}
 
-	// Wait 10s to allow time for the system to reboot.
-	time.Sleep(10 * time.Second)
+	if reboot {
+		// Wait 10s to allow time for the system to reboot.
+		time.Sleep(10 * time.Second)
+	}
 
 	return nil
 }


### PR DESCRIPTION
* Cache the state of auto-unlocked LUKS volumes
* Add `SetupMode` and `DeployedMode` to list of recognized EFI variables
* Only sleep after apply OS update if we'll be restarting