### PR TITLE
incus-osd/services: Order services based on dependencies

### DIFF
--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -186,8 +186,11 @@ func shutdown(ctx context.Context, s *state.State, t *tui.TUI) error {
 		}
 	}
 
-	// Run services shutdown actions.
-	for _, srvName := range services.ValidNames {
+	// Run services shutdown actions (reverse order from startup).
+	serviceNames := slices.Clone(services.Supported)
+	slices.Reverse(serviceNames)
+
+	for _, srvName := range serviceNames {
 		srv, err := services.Load(ctx, s, srvName)
 		if err != nil {
 			return err
@@ -344,7 +347,7 @@ func startup(ctx context.Context, s *state.State, t *tui.TUI) error {
 	}
 
 	// Run services startup actions.
-	for _, srvName := range services.ValidNames {
+	for _, srvName := range services.Supported {
 		srv, err := services.Load(ctx, s, srvName)
 		if err != nil {
 			return err

--- a/incus-osd/internal/rest/api_services.go
+++ b/incus-osd/internal/rest/api_services.go
@@ -19,8 +19,11 @@ func (*Server) apiServices(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the list of services.
+	names := slices.Clone(services.Supported)
+	slices.Sort(names)
+
 	urls := []string{}
-	for _, service := range services.ValidNames {
+	for _, service := range names {
 		urls = append(urls, "/1.0/services/"+service)
 	}
 
@@ -33,7 +36,7 @@ func (s *Server) apiServicesEndpoint(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 
 	// Check if the service is valid.
-	if !slices.Contains(services.ValidNames, name) {
+	if !slices.Contains(services.Supported, name) {
 		_ = response.NotFound(nil).Render(w)
 
 		return

--- a/incus-osd/internal/services/load.go
+++ b/incus-osd/internal/services/load.go
@@ -7,8 +7,9 @@ import (
 	"github.com/lxc/incus-os/incus-osd/internal/state"
 )
 
-// ValidNames contains the list of all valid services.
-var ValidNames = []string{"iscsi", "lvm", "nvme", "multipath", "ovn", "usbip"}
+// Supported contains the list of all valid services.
+// The list is sorted in recommended startup order to handle service dependencies.
+var Supported = []string{"iscsi", "nvme", "multipath", "lvm", "ovn", "usbip"}
 
 // Load returns a handler for the given system service.
 func Load(ctx context.Context, s *state.State, name string) (Service, error) {


### PR DESCRIPTION
All the remote storage services must be started prior to LVM. Use the reverse order on shutdown.