### PR TITLE
mkosi: Use Debian stable for all parts of the build

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -1,4 +1,6 @@
 [Build]
+ToolsTreeDistribution=debian
+ToolsTreeRelease=trixie
 History=yes
 ToolsTree=default
 CacheDirectory=mkosi.cache


### PR DESCRIPTION
I noticed some parts of the build were still fetching things from testing. Turns out we also need to specify a specific release for the tools tree, otherwise it defaults to testing which works at the moment, but we don't want that randomly shifting under us.