### PR TITLE
Add a startup free disk space check

### DIFF
--- a/incus-osd/internal/storage/storage.go
+++ b/incus-osd/internal/storage/storage.go
@@ -158,6 +158,18 @@ func GetUnderlyingDevice() (string, error) {
 	return "", errors.New("unable to determine underlying device")
 }
 
+// GetFreeSpaceInGiB returns the amount of free space in GiB for the underlying filesystem of the given path.
+func GetFreeSpaceInGiB(path string) (float64, error) {
+	var s unix.Statfs_t
+
+	err := unix.Statfs(path, &s)
+	if err != nil {
+		return 0.0, err
+	}
+
+	return float64(s.Bsize*int64(s.Bfree)) / 1024.0 / 1024.0 / 1024.0, nil //nolint:gosec
+}
+
 // DeviceToID takes a device path like /dev/sda and determines its "by-id" mapping, for example /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root.
 func DeviceToID(ctx context.Context, device string) (string, error) {
 	if device == "" {


### PR DESCRIPTION
IncusOS seems pretty resilient to startup failures when `/` is full. Not until I got down to KiB free and `systemd-sysusers` failed did it have issues.

This adds a warning when less than 5GiB of free space remains, and at 1GiB attempts to reclaim space by clearing old journal entries and wiping `/var/cache/`.

Closes #233