### PR TITLE
Remove swap encryption migration logic

### DIFF
--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -292,22 +292,6 @@ func startup(ctx context.Context, s *state.State, t *tui.TUI) error {
 		}
 	}
 
-	// Temporary migration logic for pre-existing IncusOS installs that don't have a recovery key set for their swap partition.
-	// This should be removed by the end of August, 2025.
-	needsSwapKey, err := systemd.SwapNeedsRecoveryKeySet(ctx)
-	if err != nil {
-		return err
-	}
-
-	if needsSwapKey {
-		slog.InfoContext(ctx, "Setting encryption recovery key for swap partition, this may take a few seconds")
-
-		err := systemd.SwapSetRecoveryKey(ctx, s.System.Security.Config.EncryptionRecoveryKeys[0])
-		if err != nil {
-			return err
-		}
-	}
-
 	slog.InfoContext(ctx, "System is starting up", "mode", mode, "release", s.OS.RunningRelease)
 
 	// Display a warning if we're running from the backup image.

--- a/incus-osd/internal/systemd/cryptenroll.go
+++ b/incus-osd/internal/systemd/cryptenroll.go
@@ -168,28 +168,3 @@ func ListEncryptedVolumes(ctx context.Context) ([]api.SystemSecurityEncryptedVol
 
 	return ret, nil
 }
-
-// SwapNeedsRecoveryKeySet checks if the swap partition has a recovery key set or not. This
-// is needed to properly upgrade older installs of IncusOS that only have the recovery key
-// set on the root partition. If the swap volume is missing the recovery key, attempts to update
-// Secure Boot keys will fail.
-//
-// This should be removed by the end of August, 2025.
-func SwapNeedsRecoveryKeySet(ctx context.Context) (bool, error) {
-	output, err := subprocess.RunCommandContext(ctx, "systemd-cryptenroll", "/dev/disk/by-partlabel/swap")
-	if err != nil {
-		return false, err
-	}
-
-	return !strings.Contains(output, "password"), nil
-}
-
-// SwapSetRecoveryKey adds the specified recovery password to the swap volume.
-//
-// This should be removed by the end of August, 2025.
-func SwapSetRecoveryKey(ctx context.Context, recoveryPassword string) error {
-	// Need to pass to systemd-cryptenroll via NEWPASSWORD environment variable.
-	_, _, err := subprocess.RunCommandSplit(ctx, append(os.Environ(), "NEWPASSWORD="+recoveryPassword), nil, "systemd-cryptenroll", "--unlock-tpm2-device", "auto", "--password", "/dev/disk/by-partlabel/swap")
-
-	return err
-}


### PR DESCRIPTION
It's been two months since #175 was merged; any existing IncusOS installs should have had plenty of time to upgrade to one of the numerous updates since that time.