### PR TITLE
Remove VLAN field from Interface and Bond structs

### DIFF
--- a/incus-osd/api/system_network.go
+++ b/incus-osd/api/system_network.go
@@ -40,7 +40,6 @@ type SystemNetworkConfig struct {
 type SystemNetworkInterface struct {
 	Name              string               `json:"name"                          yaml:"name"`
 	MTU               int                  `json:"mtu,omitempty"                 yaml:"mtu,omitempty"`
-	VLAN              int                  `json:"vlan,omitempty"                yaml:"vlan,omitempty"`
 	VLANTags          []int                `json:"vlan_tags,omitempty"           yaml:"vlan_tags,omitempty"`
 	Addresses         []string             `json:"addresses,omitempty"           yaml:"addresses,omitempty"`
 	RequiredForOnline string               `json:"required_for_online,omitempty" yaml:"required_for_online,omitempty"`
@@ -55,7 +54,6 @@ type SystemNetworkBond struct {
 	Name              string               `json:"name"                          yaml:"name"`
 	Mode              string               `json:"mode"                          yaml:"mode"`
 	MTU               int                  `json:"mtu,omitempty"                 yaml:"mtu,omitempty"`
-	VLAN              int                  `json:"vlan,omitempty"                yaml:"vlan,omitempty"`
 	VLANTags          []int                `json:"vlan_tags,omitempty"           yaml:"vlan_tags,omitempty"`
 	Addresses         []string             `json:"addresses,omitempty"           yaml:"addresses,omitempty"`
 	RequiredForOnline string               `json:"required_for_online,omitempty" yaml:"required_for_online,omitempty"`

--- a/incus-osd/internal/systemd/networkd_test.go
+++ b/incus-osd/internal/systemd/networkd_test.go
@@ -35,7 +35,6 @@ bonds:
   - name: management
     mode: 802.3ad
     mtu: 9000
-    vlan: 1234
     vlan_tags:
       - 100
     addresses:
@@ -120,7 +119,6 @@ bonds:
    hwaddr: "aa:bb:cc:dd:ee:e1"
    lldp: true
    mtu: 9000
-   vlan: 10
    members:
     - "aa:bb:cc:dd:ee:e1"
     - "aa:bb:cc:dd:ee:e2"

--- a/incus-osd/internal/systemd/networkd_validate.go
+++ b/incus-osd/internal/systemd/networkd_validate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/lxc/incus-os/incus-osd/api"
 )
 
-func validateInterfaces(interfaces []api.SystemNetworkInterface, vlans []api.SystemNetworkVLAN, requireValidMAC bool) error {
+func validateInterfaces(interfaces []api.SystemNetworkInterface, requireValidMAC bool) error {
 	for index, iface := range interfaces {
 		err := validateName(iface.Name)
 		if err != nil {
@@ -25,13 +25,6 @@ func validateInterfaces(interfaces []api.SystemNetworkInterface, vlans []api.Sys
 		err = validateRoles(iface.Roles)
 		if err != nil {
 			return fmt.Errorf("interface %d %s", index, err.Error())
-		}
-
-		if iface.VLAN != 0 {
-			err := validateVLAN(iface.VLAN, vlans)
-			if err != nil {
-				return fmt.Errorf("interface %d %s", index, err.Error())
-			}
 		}
 
 		for addressIndex, address := range iface.Addresses {
@@ -67,7 +60,7 @@ func validateInterfaces(interfaces []api.SystemNetworkInterface, vlans []api.Sys
 	return nil
 }
 
-func validateBonds(bonds []api.SystemNetworkBond, vlans []api.SystemNetworkVLAN, requireValidMAC bool) error {
+func validateBonds(bonds []api.SystemNetworkBond, requireValidMAC bool) error {
 	for index, bond := range bonds {
 		err := validateName(bond.Name)
 		if err != nil {
@@ -87,13 +80,6 @@ func validateBonds(bonds []api.SystemNetworkBond, vlans []api.SystemNetworkVLAN,
 		err = validateRoles(bond.Roles)
 		if err != nil {
 			return fmt.Errorf("bond %d %s", index, err.Error())
-		}
-
-		if bond.VLAN != 0 {
-			err := validateVLAN(bond.VLAN, vlans)
-			if err != nil {
-				return fmt.Errorf("bond %d %s", index, err.Error())
-			}
 		}
 
 		for addressIndex, address := range bond.Addresses {
@@ -275,24 +261,6 @@ func validateRoles(roles []string) error {
 func validateMTU(mtu int) error {
 	if mtu < 0 || mtu > 9000 {
 		return errors.New("MTU out of range")
-	}
-
-	return nil
-}
-
-func validateVLAN(vlan int, vlans []api.SystemNetworkVLAN) error {
-	foundVLAN := false
-
-	for _, v := range vlans {
-		if v.ID == vlan {
-			foundVLAN = true
-
-			break
-		}
-	}
-
-	if !foundVLAN {
-		return fmt.Errorf("no vlan %d defined", vlan)
 	}
 
 	return nil


### PR DESCRIPTION
This removes the `VLAN` field from the network configuration. When generating vlan-specific config, rather than relying on the interface/bond telling us what vlan it "owns", instead get it from the vlan's parent definition and add appropriate configuration to the interface/bond.

Closes #252