### PR TITLE
Cleanup logging of system requirement errors

### DIFF
--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -132,7 +132,6 @@ func run(ctx context.Context, s *state.State, t *tui.TUI) error {
 	if err != nil {
 		modal := t.AddModal(s.OS.Name)
 		modal.Update("System check error: [red]" + err.Error() + "[white]\n" + s.OS.Name + " is unable to run until the problem is resolved.")
-		slog.ErrorContext(ctx, err.Error())
 
 		// If we fail the system requirement check, we'll enter a startup loop with the systemd service
 		// constantly trying to restart the daemon. Rather than doing that, just sleep here for an hour


### PR DESCRIPTION
We're already displaying the error in a modal dialog, so don't bother to also log the error since no one will ever read the journal.