### PR TITLE
Add Operations Center application layer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,7 +100,8 @@ jobs:
             efitools \
             make \
             pipx \
-            qemu-utils
+            qemu-utils \
+            yarnpkg
 
       - name: Setup Incus
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -10,11 +10,12 @@ certs/
 mkosi.images/base/mkosi.extra/boot/EFI/
 mkosi.images/base/mkosi.extra/usr/local/bin/
 
+app-build/
+
 incus-osd/flasher-tool
 incus-osd/image-customizer
 incus-osd/image-publisher
 incus-osd/incus-osd
-incus-osd/kpx
 
 mkosi.packages/initrd-tmpfs-root*
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ certs/
 
 mkosi.images/base/mkosi.extra/boot/EFI/
 mkosi.images/base/mkosi.extra/usr/local/bin/
+mkosi.images/operations-center/mkosi.extra/
 
 app-build/
 

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,14 @@ endif
 	cp incus-osd/incus-osd mkosi.images/base/mkosi.extra/usr/local/bin/
 	cp app-build/kpx/kpx mkosi.images/base/mkosi.extra/usr/local/bin/
 
+	mkdir -p mkosi.images/operations-center/mkosi.extra/usr/local/bin/
+	mkdir -p mkosi.images/operations-center/mkosi.extra/usr/share/operations-center/ui/
+	mkdir -p mkosi.images/operations-center/mkosi.extra/usr/share/terraform/plugins/registry.opentofu.org/
+	cp app-build/opentofu/tofu mkosi.images/operations-center/mkosi.extra/usr/local/bin/
+	cp app-build/operations-center/operations-centerd mkosi.images/operations-center/mkosi.extra/usr/local/bin/
+	cp -r app-build/operations-center/ui/dist/* mkosi.images/operations-center/mkosi.extra/usr/share/operations-center/ui/
+	cp -r app-build/terraform-provider-incus/lxc/ mkosi.images/operations-center/mkosi.extra/usr/share/terraform/plugins/registry.opentofu.org/
+
 	sudo rm -Rf mkosi.output/base* mkosi.output/debug* mkosi.output/incus*
 	sudo -E $(shell command -v mkosi) --cache-dir .cache/ build
 	sudo chown $(shell id -u):$(shell id -g) mkosi.output

--- a/app-build/build-applications.sh
+++ b/app-build/build-applications.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+### Versions ###
+KPX_VERSION=1.12.1
+
+### kpx ###
+if [ -d kpx ]; then
+    pushd kpx
+    git reset --hard && git fetch --depth 1 origin "v${KPX_VERSION}:refs/tags/v${KPX_VERSION}" && git checkout "v${KPX_VERSION}"
+    popd
+else
+    git clone https://github.com/momiji/kpx.git kpx --depth 1 -b "v${KPX_VERSION}"
+fi
+
+    pushd kpx
+    patch -p1 < ../../patches/kpx-0001-Enable-IPv6-support.patch
+
+    go build -o kpx -ldflags="s -w -X github.com/momiji/kpx.AppVersion=${KPX_VERSION}" ./cli
+    strip kpx
+    popd

--- a/app-build/build-applications.sh
+++ b/app-build/build-applications.sh
@@ -3,7 +3,38 @@
 set -e
 
 ### Versions ###
+INCUS_TERRAFORM_VERSION=0.5.0
 KPX_VERSION=1.12.1
+OPENTOFU_VERSION=1.10.6
+OPERATIONS_CENTER_VERSION=main
+
+### Incus terraform/tofu plugin ###
+if [ -d terraform-provider-incus ]; then
+    pushd terraform-provider-incus
+    git reset --hard && git fetch --depth 1 origin "v${INCUS_TERRAFORM_VERSION}:refs/tags/v${INCUS_TERRAFORM_VERSION}" && git checkout "v${INCUS_TERRAFORM_VERSION}"
+    popd
+else
+    git clone https://github.com/lxc/terraform-provider-incus.git terraform-provider-incus --depth 1 -b "v${INCUS_TERRAFORM_VERSION}"
+fi
+
+    pushd terraform-provider-incus
+    go build .
+    strip terraform-provider-incus
+
+    # tofu expects the provider to be in a versioned path. To make the copy logic easier in the Makefile, construct the versioned path here.
+    ARCH=$(uname -m)
+    if [ "${ARCH}" = "aarch64" ]; then
+        ARCH="arm64"
+    elif [ "${ARCH}" = "x86_64" ]; then
+        ARCH="amd64"
+    else
+        die "Unsupported architecture: ${ARCH}"
+    fi
+
+    rm -rf lxc/
+    mkdir -p "lxc/incus/${INCUS_TERRAFORM_VERSION}/linux_${ARCH}"
+    mv terraform-provider-incus "lxc/incus/${INCUS_TERRAFORM_VERSION}/linux_${ARCH}/terraform-provider-incus_v${INCUS_TERRAFORM_VERSION}"
+    popd
 
 ### kpx ###
 if [ -d kpx ]; then
@@ -19,4 +50,37 @@ fi
 
     go build -o kpx -ldflags="s -w -X github.com/momiji/kpx.AppVersion=${KPX_VERSION}" ./cli
     strip kpx
+    popd
+
+### opentofu ###
+if [ -d opentofu ]; then
+    pushd opentofu
+    git reset --hard && git fetch --depth 1 origin "v${OPENTOFU_VERSION}:refs/tags/v${OPENTOFU_VERSION}" && git checkout "v${OPENTOFU_VERSION}"
+    popd
+else
+    git clone https://github.com/opentofu/opentofu.git opentofu --depth 1 -b "v${OPENTOFU_VERSION}"
+fi
+
+    pushd opentofu
+    go build -o tofu ./cmd/tofu
+    strip tofu
+    popd
+
+### Operations Center ###
+if [ -d operations-center ]; then
+    pushd operations-center
+    git reset --hard && git pull
+    popd
+else
+    git clone https://github.com/FuturFusion/operations-center.git operations-center --depth 1 -b "${OPERATIONS_CENTER_VERSION}"
+fi
+
+    pushd operations-center
+    go build -o operations-centerd ./cmd/operations-centerd
+    strip operations-centerd
+
+    pushd ui
+    YARN_ENABLE_HARDENED_MODE=0 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarnpkg install && yarnpkg build
+    popd
+
     popd

--- a/doc/install-seed.md
+++ b/doc/install-seed.md
@@ -38,7 +38,7 @@ running.
 The structure is defined in [api/seed/applications.go](https://github.com/lxc/incus-os/blob/main/incus-osd/api/seed/applications.go):
 
   * `Applications`: Holds an array of applications to install. Currently the
-  only supported application is "incus".
+  only supported application are "incus" and "operations-center".
 
 ### `incus.{json,yml,yaml}`
 This file provides preseed information for Incus.
@@ -58,6 +58,12 @@ boots. If not specified, Incus OS will attempt automatic DHCP/SLAAC
 configuration on each network interface.
 
 The structure used is the [network API struct](https://github.com/lxc/incus-os/blob/main/incus-osd/api/system_network.go).
+
+### `operations-center.{json,yml,yaml}`
+This file provides preseed information for Operations Center.
+
+The structure is defined in [api/seed/operations_center.go](https://github.com/lxc/incus-os/blob/main/incus-osd/api/seed/operations_center.go)
+and references Operations Center's [`system` API](https://github.com/FuturFusion/operations-center/blob/main/shared/api/system.go).
 
 ### `provider.{json,yml,yaml}`
 This file provides preseed information to configure a given provider, which is used

--- a/incus-osd/api/seed/operations_center.go
+++ b/incus-osd/api/seed/operations_center.go
@@ -1,0 +1,19 @@
+package seed
+
+import (
+	"github.com/FuturFusion/operations-center/shared/api"
+)
+
+// OperationsCenter represents an Operations Center seed file.
+type OperationsCenter struct {
+	// A list of PEM-encoded trusted client certificates. The SHA256 fingerprint of
+	// each certificate will be added to the list of any SHA256 fingerprints provided
+	// in SystemSecurity.TrustedTLSClientCertFingerprints.
+	TrustedClientCertificates []string `json:"trusted_client_certificates,omitempty" yaml:"trusted_client_certificates,omitempty"`
+
+	// Seed configuration from Operations Center.
+	SystemCertificate *api.SystemCertificatePost `json:"system_certificate,omitempty" yaml:"system_certificate,omitempty"`
+	SystemNetwork     *api.SystemNetworkPut      `json:"system_network,omitempty"     yaml:"system_network,omitempty"`
+	SystemSecurity    *api.SystemSecurityPut     `json:"system_security,omitempty"    yaml:"system_security,omitempty"`
+	SystemUpdates     *api.SystemUpdatesPut      `json:"system_updates,omitempty"     yaml:"system_updates,omitempty"`
+}

--- a/incus-osd/go.mod
+++ b/incus-osd/go.mod
@@ -1,8 +1,9 @@
 module github.com/lxc/incus-os/incus-osd
 
-go 1.24.0
+go 1.24.7
 
 require (
+	github.com/FuturFusion/operations-center v0.0.0-20250911165554-7c9380da30f9
 	github.com/gdamore/tcell/v2 v2.9.0
 	github.com/google/go-eventlog v0.0.3-0.20250422210130-7c3cc8ffe6c4
 	github.com/google/go-github/v72 v72.0.0

--- a/incus-osd/go.sum
+++ b/incus-osd/go.sum
@@ -1,6 +1,8 @@
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/FuturFusion/operations-center v0.0.0-20250911165554-7c9380da30f9 h1:rEcCzynFeI9qo6lQS79kx7hABD8ohaJwycO+ESTI00M=
+github.com/FuturFusion/operations-center v0.0.0-20250911165554-7c9380da30f9/go.mod h1:KZMd6+Uby35mfghW0MjfD7t0wnhnhRMlIwxoFSCTz7A=
 github.com/apex/log v1.9.0 h1:FHtw/xuaM8AgmvDDTI9fiwoAL25Sq2cxojnZICUU8l0=
 github.com/apex/log v1.9.0/go.mod h1:m82fZlWIuiWzWP04XCTXmnX0xRkYYbCdYn8jbJeLBEA=
 github.com/apex/logs v1.0.0/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=

--- a/incus-osd/internal/applications/app_common.go
+++ b/incus-osd/internal/applications/app_common.go
@@ -2,6 +2,12 @@ package applications
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"time"
 )
 
 type common struct{}
@@ -29,4 +35,62 @@ func (*common) Update(_ context.Context, _ string) error {
 // IsRunning reports if the application is currently running.
 func (*common) IsRunning(_ context.Context) bool {
 	return true
+}
+
+// Common helper to construct an HTTP client using the provided local Unix socket.
+func unixHTTPClient(socketPath string) (*http.Client, error) {
+	// Setup a Unix socket dialer
+	unixDial := func(_ context.Context, _ string, _ string) (net.Conn, error) {
+		raddr, err := net.ResolveUnixAddr("unix", socketPath)
+		if err != nil {
+			return nil, err
+		}
+
+		return net.DialUnix("unix", nil, raddr)
+	}
+
+	// Define the http transport
+	transport := &http.Transport{
+		DialContext:           unixDial,
+		DisableKeepAlives:     true,
+		ExpectContinueTimeout: time.Second * 30,
+		ResponseHeaderTimeout: time.Second * 3600,
+		TLSHandshakeTimeout:   time.Second * 5,
+	}
+
+	// Define the http client
+	client := &http.Client{}
+
+	client.Transport = transport
+
+	// Setup redirect policy
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		// Replicate the headers
+		req.Header = via[len(via)-1].Header
+
+		return nil
+	}
+
+	return client, nil
+}
+
+// Common helper to grab error message from return json data.
+func getErrorMessage(reader io.Reader) error {
+	type resp struct {
+		ErrorCode int    `json:"error_code"`
+		Error     string `json:"error"`
+	}
+
+	r := &resp{}
+
+	err := json.NewDecoder(reader).Decode(r)
+	if err != nil {
+		return err
+	}
+
+	if r.ErrorCode == 200 {
+		return nil
+	}
+
+	return errors.New(r.Error)
 }

--- a/incus-osd/internal/applications/app_operations_center.go
+++ b/incus-osd/internal/applications/app_operations_center.go
@@ -1,0 +1,199 @@
+package applications
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/FuturFusion/operations-center/shared/api"
+
+	"github.com/lxc/incus-os/incus-osd/internal/seed"
+	"github.com/lxc/incus-os/incus-osd/internal/systemd"
+)
+
+type operationsCenter struct{}
+
+// Start starts the systemd unit.
+func (*operationsCenter) Start(ctx context.Context, _ string) error {
+	// Start the unit.
+	return systemd.EnableUnit(ctx, true, "operations-center.service")
+}
+
+// Stop stops the systemd unit.
+func (*operationsCenter) Stop(ctx context.Context, _ string) error {
+	// Stop the unit.
+	return systemd.StopUnit(ctx, "operations-center.service")
+}
+
+// Update triggers restart after an application update.
+func (*operationsCenter) Update(ctx context.Context, _ string) error {
+	// Reload the systemd daemon to pickup any service definition changes.
+	err := systemd.ReloadDaemon(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Restart the unit.
+	return systemd.RestartUnit(ctx, "operations-center.service")
+}
+
+// Initialize runs first time initialization.
+func (*operationsCenter) Initialize(ctx context.Context) error {
+	// Get the preseed from the seed partition.
+	ocSeed, err := seed.GetOperationsCenter(ctx, seed.SeedPartitionPath)
+	if err != nil && !seed.IsMissing(err) {
+		return err
+	}
+
+	// Return if no seed was provided.
+	if ocSeed == nil {
+		return nil
+	}
+
+	// Wait for Operations Center to begin accepting connections.
+	count := 0
+
+	for {
+		err := doOCRequest(ctx, "http://localhost/1.0", http.MethodGet, nil)
+		if err == nil {
+			break
+		}
+
+		count++
+
+		if count > 10 {
+			return errors.New("failed to connect to Operations Center via local socket")
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	// Apply SystemCertificate, if any.
+	if ocSeed.SystemCertificate != nil {
+		contentJSON, err := json.Marshal(ocSeed.SystemCertificate)
+		if err != nil {
+			return err
+		}
+
+		err = doOCRequest(ctx, "http://localhost/1.0/system/certificate", http.MethodPost, contentJSON)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Apply SystemNetwork, if any.
+	if ocSeed.SystemNetwork == nil {
+		ocSeed.SystemNetwork = new(api.SystemNetworkPut)
+	}
+
+	{
+		// If no IP address is provided, default to listening on all addresses with the default port.
+		if ocSeed.SystemNetwork.OperationsCenterAddress == "" && ocSeed.SystemNetwork.RestServerAddress == "" {
+			ocSeed.SystemNetwork.OperationsCenterAddress = "https://[::]:0"
+			ocSeed.SystemNetwork.RestServerAddress = "[::]:0"
+		}
+
+		contentJSON, err := json.Marshal(ocSeed.SystemNetwork)
+		if err != nil {
+			return err
+		}
+
+		err = doOCRequest(ctx, "http://localhost/1.0/system/network", http.MethodPut, contentJSON)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Apply SystemSecurity, if any.
+	if ocSeed.SystemSecurity == nil && len(ocSeed.TrustedClientCertificates) > 0 {
+		ocSeed.SystemSecurity = new(api.SystemSecurityPut)
+	}
+
+	if ocSeed.SystemSecurity != nil {
+		// Compute fingerprints for any user-provided client certificates and add to the
+		// list of trusted TLS client certificates.
+		for i, certString := range ocSeed.TrustedClientCertificates {
+			certBlock, _ := pem.Decode([]byte(certString))
+			if certBlock == nil {
+				return fmt.Errorf("cannot parse client certificate PEM in seed (index %d)", i)
+			}
+
+			cert, err := x509.ParseCertificate(certBlock.Bytes)
+			if err != nil {
+				return fmt.Errorf("invalid client certificate in seed (index %d): %w", i, err)
+			}
+
+			rawFp := sha256.Sum256(cert.Raw)
+			fp := hex.EncodeToString(rawFp[:])
+
+			if !slices.Contains(ocSeed.SystemSecurity.TrustedTLSClientCertFingerprints, fp) {
+				ocSeed.SystemSecurity.TrustedTLSClientCertFingerprints = append(ocSeed.SystemSecurity.TrustedTLSClientCertFingerprints, fp)
+			}
+		}
+
+		contentJSON, err := json.Marshal(ocSeed.SystemSecurity)
+		if err != nil {
+			return err
+		}
+
+		err = doOCRequest(ctx, "http://localhost/1.0/system/security", http.MethodPut, contentJSON)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Apply SystemUpdates, if any.
+	if ocSeed.SystemUpdates != nil {
+		contentJSON, err := json.Marshal(ocSeed.SystemUpdates)
+		if err != nil {
+			return err
+		}
+
+		err = doOCRequest(ctx, "http://localhost/1.0/system/updates", http.MethodPut, contentJSON)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Restart the service to ensure any seed settings are properly applied.
+	return systemd.RestartUnit(ctx, "operations-center.service")
+}
+
+// IsRunning reports if the application is currently running.
+func (*operationsCenter) IsRunning(ctx context.Context) bool {
+	return systemd.IsActive(ctx, "operations-center.service")
+}
+
+// Operations Center specific helper to interact with the REST API.
+func doOCRequest(ctx context.Context, url string, method string, body []byte) error {
+	client, err := unixHTTPClient("/run/operations-center/unix.socket")
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return getErrorMessage(resp.Body)
+	}
+
+	return nil
+}

--- a/incus-osd/internal/applications/load.go
+++ b/incus-osd/internal/applications/load.go
@@ -11,6 +11,8 @@ func Load(_ context.Context, name string) (Application, error) {
 	switch name {
 	case "incus":
 		app = &incus{}
+	case "operations-center":
+		app = &operationsCenter{}
 	default:
 		app = &common{}
 	}

--- a/incus-osd/internal/seed/operations_center.go
+++ b/incus-osd/internal/seed/operations_center.go
@@ -1,0 +1,20 @@
+package seed
+
+import (
+	"context"
+
+	apiseed "github.com/lxc/incus-os/incus-osd/api/seed"
+)
+
+// GetOperationsCenter extracts the Operations Center preseed from the seed data.
+func GetOperationsCenter(_ context.Context, partition string) (*apiseed.OperationsCenter, error) {
+	// Get the preseed.
+	var preseed apiseed.OperationsCenter
+
+	err := parseFileContents(partition, "operations-center", &preseed)
+	if err != nil {
+		return nil, err
+	}
+
+	return &preseed, nil
+}

--- a/mkosi.images/operations-center/mkosi.conf
+++ b/mkosi.images/operations-center/mkosi.conf
@@ -1,0 +1,11 @@
+[Config]
+Dependencies=base
+
+[Output]
+Format=sysext
+Overlay=yes
+ManifestFormat=json
+ImageVersion=
+
+[Content]
+BaseTrees=%O/base

--- a/mkosi.images/operations-center/mkosi.extra/usr/lib/systemd/system/operations-center.service
+++ b/mkosi.images/operations-center/mkosi.extra/usr/lib/systemd/system/operations-center.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Operations Center
+Documentation=https://github.com/FuturFusion/operations-center
+
+[Service]
+ExecStart=/usr/local/bin/operations-centerd
+KillMode=process
+Restart=on-failure


### PR DESCRIPTION
Add an Operations Center application layer. A local OpenFGA service will be available via another application layer, if needed.

Running `tofu init` picks up the local incus provider rather than attempting to download it.

Closes #214