### PR TITLE
Pin systemd version

### DIFF
--- a/mkosi.sandbox/etc/apt/preferences.d/10-trixie-systemd-257.8-1.pref
+++ b/mkosi.sandbox/etc/apt/preferences.d/10-trixie-systemd-257.8-1.pref
@@ -1,0 +1,3 @@
+Package: src:systemd
+Pin: version 257.8-1~deb13u1
+Pin-Priority: -1

--- a/mkosi.sandbox/etc/apt/sources.list.d/debian-snapshot-systemd.sources
+++ b/mkosi.sandbox/etc/apt/sources.list.d/debian-snapshot-systemd.sources
@@ -1,0 +1,6 @@
+Enabled: yes
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/20250831T024403Z/
+Suites: trixie
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg


### PR DESCRIPTION
As reported in Debian bug #1112535, systemd-networkd in 257.8-1~deb13u1 breaks VLAN+Bridge setups, which we heavily use. For now, use pinning and the snapshot.debian.org archive to install the prior version of systemd packages.