### PR TITLE
Only allow one OS/application/SecureBoot update to run at a time

### DIFF
--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -714,6 +714,9 @@ func updateChecker(ctx context.Context, s *state.State, t *tui.TUI, p providers.
 }
 
 func checkDoOSUpdate(ctx context.Context, s *state.State, t *tui.TUI, p providers.Provider, isStartupCheck bool) (string, error) {
+	s.UpdateMutex.Lock()
+	defer s.UpdateMutex.Unlock()
+
 	slog.DebugContext(ctx, "Checking for OS updates")
 
 	if s.System.Update.State.NeedsReboot {
@@ -798,6 +801,9 @@ func checkDoOSUpdate(ctx context.Context, s *state.State, t *tui.TUI, p provider
 }
 
 func checkDoAppUpdate(ctx context.Context, s *state.State, t *tui.TUI, p providers.Provider, appName string, isStartupCheck bool) (string, error) {
+	s.UpdateMutex.Lock()
+	defer s.UpdateMutex.Unlock()
+
 	slog.DebugContext(ctx, "Checking for application updates")
 
 	app, err := p.GetApplication(ctx, appName)
@@ -851,6 +857,9 @@ func checkDoAppUpdate(ctx context.Context, s *state.State, t *tui.TUI, p provide
 }
 
 func checkDoSecureBootCertUpdate(ctx context.Context, s *state.State, t *tui.TUI, p providers.Provider, isStartupCheck bool) error {
+	s.UpdateMutex.Lock()
+	defer s.UpdateMutex.Unlock()
+
 	slog.DebugContext(ctx, "Checking for Secure Boot key updates")
 
 	if s.System.Update.State.NeedsReboot {

--- a/incus-osd/internal/state/struct.go
+++ b/incus-osd/internal/state/struct.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/lxc/incus-os/incus-osd/api"
 )
@@ -29,6 +30,8 @@ type State struct {
 	StateVersion int `json:"-"`
 
 	ShouldPerformInstall bool `json:"-"`
+
+	UpdateMutex sync.Mutex `json:"-"`
 
 	// Triggers for daemon actions.
 	TriggerReboot   chan error `json:"-"`


### PR DESCRIPTION
On a test system, we observed two concurrent OS updates running at the same time. This messed up the sysext update, which required manual intervention to fix.

Guard against this happening again by introducing a shared mutex for the update methods to guarantee that only one can ever run at a given time.