### PR TITLE
Detect proxy when returning API endpoints

### DIFF
--- a/incus-osd/internal/rest/api_applications.go
+++ b/incus-osd/internal/rest/api_applications.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"net/http"
+	"net/url"
 	"slices"
 
 	"github.com/lxc/incus-os/incus-osd/internal/rest/response"
@@ -25,9 +26,13 @@ func (s *Server) apiApplications(w http.ResponseWriter, r *http.Request) {
 
 	slices.Sort(names)
 
+	endpoint, _ := url.JoinPath(getAPIRoot(r), "applications")
+
 	urls := []string{}
+
 	for _, application := range names {
-		urls = append(urls, "/1.0/applications/"+application)
+		appURL, _ := url.JoinPath(endpoint, application)
+		urls = append(urls, appURL)
 	}
 
 	_ = response.SyncResponse(true, urls).Render(w)

--- a/incus-osd/internal/rest/api_debug.go
+++ b/incus-osd/internal/rest/api_debug.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/lxc/incus/v6/shared/subprocess"
@@ -19,7 +20,9 @@ func (*Server) apiDebug(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = response.SyncResponse(true, []string{"/1.0/debug/log"}).Render(w)
+	endpoint, _ := url.JoinPath(getAPIRoot(r), "debug/log")
+
+	_ = response.SyncResponse(true, []string{endpoint}).Render(w)
 }
 
 func (*Server) apiDebugLog(w http.ResponseWriter, r *http.Request) {

--- a/incus-osd/internal/rest/api_root.go
+++ b/incus-osd/internal/rest/api_root.go
@@ -2,9 +2,27 @@ package rest
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/lxc/incus-os/incus-osd/internal/rest/response"
 )
+
+// If the request contains a X-IncusOS-Proxy header, prepend that to
+// the API root that's returned to the user.
+func getAPIRoot(r *http.Request) string {
+	if r == nil {
+		return "/1.0"
+	}
+
+	prefix := r.Header.Get("X-IncusOS-Proxy")
+	if prefix == "" {
+		prefix = "/"
+	}
+
+	ret, _ := url.JoinPath(prefix, "1.0")
+
+	return ret
+}
 
 func (*Server) apiRoot(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
@@ -21,7 +39,7 @@ func (*Server) apiRoot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = response.SyncResponse(true, []string{"/1.0"}).Render(w)
+	_ = response.SyncResponse(true, []string{getAPIRoot(r)}).Render(w)
 }
 
 func (s *Server) apiRoot10(w http.ResponseWriter, r *http.Request) {

--- a/incus-osd/internal/rest/api_services.go
+++ b/incus-osd/internal/rest/api_services.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"slices"
 
 	"github.com/lxc/incus-os/incus-osd/internal/rest/response"
@@ -22,9 +23,13 @@ func (*Server) apiServices(w http.ResponseWriter, r *http.Request) {
 	names := slices.Clone(services.Supported)
 	slices.Sort(names)
 
+	endpoint, _ := url.JoinPath(getAPIRoot(r), "services")
+
 	urls := []string{}
+
 	for _, service := range names {
-		urls = append(urls, "/1.0/services/"+service)
+		serviceURL, _ := url.JoinPath(endpoint, service)
+		urls = append(urls, serviceURL)
 	}
 
 	_ = response.SyncResponse(true, urls).Render(w)


### PR DESCRIPTION
If we receive a request with the "X-IncusOS-Proxy" header set to a non-empty string, prefix all returned API endpoints with that string.