### PR TITLE
Support external seed data

### DIFF
--- a/doc/install-seed.md
+++ b/doc/install-seed.md
@@ -12,6 +12,16 @@ partition of the install image. At runtime, Incus OS will attempt to read the
 install seed from the second partition and use any data present during the
 install process.
 
+Alternatively, a user-provided seed partition may be provided independent of
+the install image. The partition label must be `SEED_DATA` on either a USB
+drive formatted as vfat or an ISO image. Rather than reading a tar archive,
+the install logic will attempt to directly read the json/yaml configuration
+files from the mounted file system. Upon completion of the install, it is up
+to the user to disconnect their seed device from the machine, otherwise Incus
+OS will become confused when it starts up and detects that seed data is still
+present. (The install process wipes the seed data tar archive from the final
+install, but we cannot do this with a user-provided seed.)
+
 ## Seed contents
 The following configuration files are currently recognized:
 

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -317,7 +317,7 @@ func startup(ctx context.Context, s *state.State, t *tui.TUI) error {
 
 	// If there's no network configuration in the state, attempt to fetch from the seed info.
 	if s.System.Network.Config == nil {
-		s.System.Network.Config, err = seed.GetNetwork(ctx, seed.SeedPartitionPath)
+		s.System.Network.Config, err = seed.GetNetwork(ctx, seed.GetSeedPath())
 		if err != nil && !seed.IsMissing(err) {
 			return err
 		}
@@ -356,7 +356,7 @@ func startup(ctx context.Context, s *state.State, t *tui.TUI) error {
 		provider = s.System.Provider.Config.Name
 		providerConfig = s.System.Provider.Config.Config
 	} else {
-		providerSeed, err := seed.GetProvider(ctx, seed.SeedPartitionPath)
+		providerSeed, err := seed.GetProvider(ctx, seed.GetSeedPath())
 		if err != nil && !seed.IsMissing(err) {
 			return err
 		}
@@ -582,7 +582,7 @@ func updateChecker(ctx context.Context, s *state.State, t *tui.TUI, p providers.
 
 		if len(s.Applications) == 0 && (isStartupCheck || isUserRequested) {
 			// Assume first start of the daemon.
-			apps, err := seed.GetApplications(ctx, seed.SeedPartitionPath)
+			apps, err := seed.GetApplications(ctx, seed.GetSeedPath())
 			if err != nil && !seed.IsMissing(err) {
 				s.System.Update.State.UpdateStatus = "Failed to get application list"
 				slog.ErrorContext(ctx, s.System.Update.State.UpdateStatus, "err", err.Error())

--- a/incus-osd/internal/applications/app_incus.go
+++ b/incus-osd/internal/applications/app_incus.go
@@ -70,7 +70,7 @@ func (*incus) Update(ctx context.Context, _ string) error {
 // Initialize runs first time initialization.
 func (a *incus) Initialize(ctx context.Context) error {
 	// Get the preseed from the seed partition.
-	incusSeed, err := seed.GetIncus(ctx, seed.SeedPartitionPath)
+	incusSeed, err := seed.GetIncus(ctx, seed.GetSeedPath())
 	if err != nil && !seed.IsMissing(err) {
 		return err
 	}

--- a/incus-osd/internal/applications/app_migration_manager.go
+++ b/incus-osd/internal/applications/app_migration_manager.go
@@ -49,7 +49,7 @@ func (*migrationManager) Update(ctx context.Context, _ string) error {
 // Initialize runs first time initialization.
 func (*migrationManager) Initialize(ctx context.Context) error {
 	// Get the preseed from the seed partition.
-	mmSeed, err := seed.GetMigrationManager(ctx, seed.SeedPartitionPath)
+	mmSeed, err := seed.GetMigrationManager(ctx, seed.GetSeedPath())
 	if err != nil && !seed.IsMissing(err) {
 		return err
 	}

--- a/incus-osd/internal/applications/app_operations_center.go
+++ b/incus-osd/internal/applications/app_operations_center.go
@@ -49,7 +49,7 @@ func (*operationsCenter) Update(ctx context.Context, _ string) error {
 // Initialize runs first time initialization.
 func (*operationsCenter) Initialize(ctx context.Context) error {
 	// Get the preseed from the seed partition.
-	ocSeed, err := seed.GetOperationsCenter(ctx, seed.SeedPartitionPath)
+	ocSeed, err := seed.GetOperationsCenter(ctx, seed.GetSeedPath())
 	if err != nil && !seed.IsMissing(err) {
 		return err
 	}

--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -74,7 +74,7 @@ func CheckSystemRequirements(ctx context.Context) error {
 			return errors.New("unable to get list of potential target devices: " + err.Error())
 		}
 
-		config, err := seed.GetInstall(seed.SeedPartitionPath)
+		config, err := seed.GetInstall(seed.GetSeedPath())
 		if err != nil && !errors.Is(err, io.EOF) {
 			return errors.New("unable to get seed config: " + err.Error())
 		}
@@ -83,7 +83,7 @@ func CheckSystemRequirements(ctx context.Context) error {
 		// device. If not, there are at least two IncusOS drives present, the installed system and an install media.
 		// This will result in a weird environment, so raise an error telling the user to remove the install device.
 		if !runningFromCDROM() {
-			seedLink, err := os.Readlink(seed.SeedPartitionPath)
+			seedLink, err := os.Readlink(seed.GetSeedPath())
 			if err != nil {
 				return err
 			}
@@ -116,7 +116,7 @@ func CheckSystemRequirements(ctx context.Context) error {
 // ShouldPerformInstall checks for the presence of an install.{json,yaml} file in the
 // seed partition to indicate if we should attempt to install incus-osd to a local disk.
 func ShouldPerformInstall() bool {
-	_, err := seed.GetInstall(seed.SeedPartitionPath)
+	_, err := seed.GetInstall(seed.GetSeedPath())
 
 	// If we have any empty install file, that should still trigger an install.
 	if errors.Is(err, io.EOF) {
@@ -134,7 +134,7 @@ func NewInstall(t *tui.TUI) (*Install, error) {
 
 	var err error
 
-	ret.config, err = seed.GetInstall(seed.SeedPartitionPath)
+	ret.config, err = seed.GetInstall(seed.GetSeedPath())
 	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}

--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -79,11 +79,15 @@ func CheckSystemRequirements(ctx context.Context) error {
 			return errors.New("unable to get seed config: " + err.Error())
 		}
 
-		// Sanity check: if we're not running from a CDROM, ensure that the seed partition in use exists on the source
-		// device. If not, there are at least two IncusOS drives present, the installed system and an install media.
-		// This will result in a weird environment, so raise an error telling the user to remove the install device.
+		// Sanity check: if we're not running from a CDROM, ensure that the default install media seed partition
+		// exists on the source device. If not, there are at least two IncusOS drives present, the installed system
+		// and an install media. This will result in a weird environment, so raise an error telling the user to
+		// remove the install device.
+		//
+		// This won't catch the case when an external user-provided seed partition is present, and we rely on the
+		// user properly removing their seed device post-install.
 		if !runningFromCDROM() {
-			seedLink, err := os.Readlink(seed.GetSeedPath())
+			seedLink, err := os.Readlink("/dev/disk/by-partlabel/seed-data")
 			if err != nil {
 				return err
 			}

--- a/incus-osd/internal/seed/parse.go
+++ b/incus-osd/internal/seed/parse.go
@@ -12,6 +12,3 @@ var ErrNoSeedData = errors.New("no seed data present in the partition")
 
 // ErrNoSeedSection is returned when the seed data is available but the requested section/file couldn't be found.
 var ErrNoSeedSection = errors.New("requested seed section couldn't be found")
-
-// SeedPartitionPath defines the path to the expected seed partition.
-const SeedPartitionPath = "/dev/disk/by-partlabel/seed-data"

--- a/incus-osd/internal/seed/seed.go
+++ b/incus-osd/internal/seed/seed.go
@@ -11,6 +11,23 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// GetSeedPath defines the path to the expected seed configuration. It will first search for any
+// disk with a "SEED_DATA" label, which would be externally provided by the user. If not found,
+// defaults to the "seed-data" partition that exists on install media.
+func GetSeedPath() string {
+	_, err := os.Stat("/dev/disk/by-partlabel/SEED_DATA")
+	if err == nil {
+		return "/dev/disk/by-partlabel/SEED_DATA"
+	}
+
+	_, err = os.Stat("/dev/disk/by-label/SEED_DATA")
+	if err == nil {
+		return "/dev/disk/by-label/SEED_DATA"
+	}
+
+	return "/dev/disk/by-partlabel/seed-data"
+}
+
 // IsMissing checks whether the provided error is an expected error for missing seed data.
 func IsMissing(e error) bool {
 	for _, entry := range []error{ErrNoSeedPartition, ErrNoSeedData, ErrNoSeedSection} {


### PR DESCRIPTION
Extend the install logic to prioritize reading seed data from a user-provided external drive with a partition labeled `SEED_DATA`. If found, any seed data on the install media will be ignored.

The user must remove their seed device before IncusOS boots post-install, otherwise it will re-detect the seed data and attempt to begin the install again. Because the user's seed data exists on a different device from the install media, we cannot easily differentiate between an expected install or a fresh install on first boot.

Closes #325