### PR TITLE
Add hashicorp terraform providers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,9 @@ endif
 	cp app-build/opentofu/tofu mkosi.images/operations-center/mkosi.extra/usr/local/bin/
 	cp app-build/operations-center/operations-centerd mkosi.images/operations-center/mkosi.extra/usr/local/bin/
 	cp -r app-build/operations-center/ui/dist/* mkosi.images/operations-center/mkosi.extra/usr/share/operations-center/ui/
+	cp -r app-build/terraform-provider-null/hashicorp/ mkosi.images/operations-center/mkosi.extra/usr/share/terraform/plugins/registry.opentofu.org/
+	cp -r app-build/terraform-provider-random/hashicorp/ mkosi.images/operations-center/mkosi.extra/usr/share/terraform/plugins/registry.opentofu.org/
+	cp -r app-build/terraform-provider-time/hashicorp/ mkosi.images/operations-center/mkosi.extra/usr/share/terraform/plugins/registry.opentofu.org/
 	cp -r app-build/terraform-provider-incus/lxc/ mkosi.images/operations-center/mkosi.extra/usr/share/terraform/plugins/registry.opentofu.org/
 
 	sudo rm -Rf mkosi.output/base* mkosi.output/debug* mkosi.output/incus*

--- a/app-build/build-applications.sh
+++ b/app-build/build-applications.sh
@@ -3,11 +3,81 @@
 set -e
 
 ### Versions ###
-INCUS_TERRAFORM_VERSION=0.5.0
+HASHICORP_TERRAFORM_NULL_VERSION=3.2.4
+HASHICORP_TERRAFORM_RANDOM_VERSION=3.7.2
+HASHICORP_TERRAFORM_TIME_VERSION=0.13.1
+INCUS_TERRAFORM_VERSION=0.5.1
 MIGRATION_MANAGER_VERSION=main
-KPX_VERSION=1.12.1
+KPX_VERSION=1.12.2
 OPENTOFU_VERSION=1.10.6
 OPERATIONS_CENTER_VERSION=main
+
+### Detect architecture string for tofu providers ###
+ARCH=$(uname -m)
+if [ "${ARCH}" = "aarch64" ]; then
+    ARCH="arm64"
+elif [ "${ARCH}" = "x86_64" ]; then
+    ARCH="amd64"
+else
+    die "Unsupported architecture: ${ARCH}"
+fi
+
+### Hashicorp terraform/tofu null plugin ###
+if [ -d terraform-provider-null ]; then
+    pushd terraform-provider-null
+    git reset --hard && git fetch --depth 1 origin "v${HASHICORP_TERRAFORM_NULL_VERSION}:refs/tags/v${HASHICORP_TERRAFORM_NULL_VERSION}" && git checkout "v${HASHICORP_TERRAFORM_NULL_VERSION}"
+    popd
+else
+    git clone https://github.com/hashicorp/terraform-provider-null.git terraform-provider-null --depth 1 -b "v${HASHICORP_TERRAFORM_NULL_VERSION}"
+fi
+
+pushd terraform-provider-null
+go build .
+strip terraform-provider-null
+
+# tofu expects the provider to be in a versioned path. To make the copy logic easier in the Makefile, construct the versioned path here.
+rm -rf hashicorp/
+mkdir -p "hashicorp/null/${HASHICORP_TERRAFORM_NULL_VERSION}/linux_${ARCH}"
+mv terraform-provider-null "hashicorp/null/${HASHICORP_TERRAFORM_NULL_VERSION}/linux_${ARCH}/terraform-provider-null_v${HASHICORP_TERRAFORM_NULL_VERSION}"
+popd
+
+### Hashicorp terraform/tofu random plugin ###
+if [ -d terraform-provider-random ]; then
+    pushd terraform-provider-random
+    git reset --hard && git fetch --depth 1 origin "v${HASHICORP_TERRAFORM_RANDOM_VERSION}:refs/tags/v${HASHICORP_TERRAFORM_RANDOM_VERSION}" && git checkout "v${HASHICORP_TERRAFORM_RANDOM_VERSION}"
+    popd
+else
+    git clone https://github.com/hashicorp/terraform-provider-random.git terraform-provider-random --depth 1 -b "v${HASHICORP_TERRAFORM_RANDOM_VERSION}"
+fi
+
+pushd terraform-provider-random
+go build .
+strip terraform-provider-random
+
+# tofu expects the provider to be in a versioned path. To make the copy logic easier in the Makefile, construct the versioned path here.
+rm -rf hashicorp/
+mkdir -p "hashicorp/random/${HASHICORP_TERRAFORM_RANDOM_VERSION}/linux_${ARCH}"
+mv terraform-provider-random "hashicorp/random/${HASHICORP_TERRAFORM_RANDOM_VERSION}/linux_${ARCH}/terraform-provider-random_v${HASHICORP_TERRAFORM_RANDOM_VERSION}"
+popd
+
+### Hashicorp terraform/tofu time plugin ###
+if [ -d terraform-provider-time ]; then
+    pushd terraform-provider-time
+    git reset --hard && git fetch --depth 1 origin "v${HASHICORP_TERRAFORM_TIME_VERSION}:refs/tags/v${HASHICORP_TERRAFORM_TIME_VERSION}" && git checkout "v${HASHICORP_TERRAFORM_TIME_VERSION}"
+    popd
+else
+    git clone https://github.com/hashicorp/terraform-provider-time.git terraform-provider-time --depth 1 -b "v${HASHICORP_TERRAFORM_TIME_VERSION}"
+fi
+
+pushd terraform-provider-time
+go build .
+strip terraform-provider-time
+
+# tofu expects the provider to be in a versioned path. To make the copy logic easier in the Makefile, construct the versioned path here.
+rm -rf hashicorp/
+mkdir -p "hashicorp/time/${HASHICORP_TERRAFORM_TIME_VERSION}/linux_${ARCH}"
+mv terraform-provider-time "hashicorp/time/${HASHICORP_TERRAFORM_TIME_VERSION}/linux_${ARCH}/terraform-provider-time_v${HASHICORP_TERRAFORM_TIME_VERSION}"
+popd
 
 ### Incus terraform/tofu plugin ###
 if [ -d terraform-provider-incus ]; then
@@ -23,15 +93,6 @@ go build .
 strip terraform-provider-incus
 
 # tofu expects the provider to be in a versioned path. To make the copy logic easier in the Makefile, construct the versioned path here.
-ARCH=$(uname -m)
-if [ "${ARCH}" = "aarch64" ]; then
-    ARCH="arm64"
-elif [ "${ARCH}" = "x86_64" ]; then
-    ARCH="amd64"
-else
-    die "Unsupported architecture: ${ARCH}"
-fi
-
 rm -rf lxc/
 mkdir -p "lxc/incus/${INCUS_TERRAFORM_VERSION}/linux_${ARCH}"
 mv terraform-provider-incus "lxc/incus/${INCUS_TERRAFORM_VERSION}/linux_${ARCH}/terraform-provider-incus_v${INCUS_TERRAFORM_VERSION}"

--- a/app-build/build-applications.sh
+++ b/app-build/build-applications.sh
@@ -18,24 +18,24 @@ else
     git clone https://github.com/lxc/terraform-provider-incus.git terraform-provider-incus --depth 1 -b "v${INCUS_TERRAFORM_VERSION}"
 fi
 
-    pushd terraform-provider-incus
-    go build .
-    strip terraform-provider-incus
+pushd terraform-provider-incus
+go build .
+strip terraform-provider-incus
 
-    # tofu expects the provider to be in a versioned path. To make the copy logic easier in the Makefile, construct the versioned path here.
-    ARCH=$(uname -m)
-    if [ "${ARCH}" = "aarch64" ]; then
-        ARCH="arm64"
-    elif [ "${ARCH}" = "x86_64" ]; then
-        ARCH="amd64"
-    else
-        die "Unsupported architecture: ${ARCH}"
-    fi
+# tofu expects the provider to be in a versioned path. To make the copy logic easier in the Makefile, construct the versioned path here.
+ARCH=$(uname -m)
+if [ "${ARCH}" = "aarch64" ]; then
+    ARCH="arm64"
+elif [ "${ARCH}" = "x86_64" ]; then
+    ARCH="amd64"
+else
+    die "Unsupported architecture: ${ARCH}"
+fi
 
-    rm -rf lxc/
-    mkdir -p "lxc/incus/${INCUS_TERRAFORM_VERSION}/linux_${ARCH}"
-    mv terraform-provider-incus "lxc/incus/${INCUS_TERRAFORM_VERSION}/linux_${ARCH}/terraform-provider-incus_v${INCUS_TERRAFORM_VERSION}"
-    popd
+rm -rf lxc/
+mkdir -p "lxc/incus/${INCUS_TERRAFORM_VERSION}/linux_${ARCH}"
+mv terraform-provider-incus "lxc/incus/${INCUS_TERRAFORM_VERSION}/linux_${ARCH}/terraform-provider-incus_v${INCUS_TERRAFORM_VERSION}"
+popd
 
 ### kpx ###
 if [ -d kpx ]; then
@@ -46,12 +46,12 @@ else
     git clone https://github.com/momiji/kpx.git kpx --depth 1 -b "v${KPX_VERSION}"
 fi
 
-    pushd kpx
-    patch -p1 < ../../patches/kpx-0001-Enable-IPv6-support.patch
+pushd kpx
+patch -p1 < ../../patches/kpx-0001-Enable-IPv6-support.patch
 
-    go build -o kpx -ldflags="s -w -X github.com/momiji/kpx.AppVersion=${KPX_VERSION}" ./cli
-    strip kpx
-    popd
+go build -o kpx -ldflags="s -w -X github.com/momiji/kpx.AppVersion=${KPX_VERSION}" ./cli
+strip kpx
+popd
 
 ### Migration Manager ###
 if [ -d migration-manager ]; then
@@ -62,16 +62,16 @@ else
     git clone https://github.com/FuturFusion/migration-manager.git migration-manager --depth 1 -b "${MIGRATION_MANAGER_VERSION}"
 fi
 
-    pushd migration-manager
-    go build -o migration-managerd ./cmd/migration-managerd
-    go build -o migration-manager-worker ./cmd/migration-manager-worker
-    strip migration-managerd migration-manager-worker
+pushd migration-manager
+go build -o migration-managerd ./cmd/migration-managerd
+go build -o migration-manager-worker ./cmd/migration-manager-worker
+strip migration-managerd migration-manager-worker
 
-    pushd ui
-    YARN_ENABLE_HARDENED_MODE=0 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarnpkg install && yarnpkg build
-    popd
+pushd ui
+YARN_ENABLE_HARDENED_MODE=0 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarnpkg install && yarnpkg build
+popd
 
-    popd
+popd
 
 ### opentofu ###
 if [ -d opentofu ]; then
@@ -82,10 +82,10 @@ else
     git clone https://github.com/opentofu/opentofu.git opentofu --depth 1 -b "v${OPENTOFU_VERSION}"
 fi
 
-    pushd opentofu
-    go build -o tofu ./cmd/tofu
-    strip tofu
-    popd
+pushd opentofu
+go build -o tofu ./cmd/tofu
+strip tofu
+popd
 
 ### Operations Center ###
 if [ -d operations-center ]; then
@@ -96,12 +96,12 @@ else
     git clone https://github.com/FuturFusion/operations-center.git operations-center --depth 1 -b "${OPERATIONS_CENTER_VERSION}"
 fi
 
-    pushd operations-center
-    go build -o operations-centerd ./cmd/operations-centerd
-    strip operations-centerd
+pushd operations-center
+go build -o operations-centerd ./cmd/operations-centerd
+strip operations-centerd
 
-    pushd ui
-    YARN_ENABLE_HARDENED_MODE=0 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarnpkg install && yarnpkg build
-    popd
+pushd ui
+YARN_ENABLE_HARDENED_MODE=0 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarnpkg install && yarnpkg build
+popd
 
-    popd
+popd


### PR DESCRIPTION
This adds three hashicorp terraform providers to the Operations Center image:

- `null`
- `random`
- `time`

With a simple `main.tf`:

```
terraform {
  required_providers {
    incus = {
      source = "lxc/incus"
    }
    null = {
      source = "hashicorp/null"
    }
    random = {
      source = "hashicorp/random"
    }
    time = {
      source = "hashicorp/time"
    }
  }
}
```

running `tofu init` correctly picks up the local providers:

```
Initializing the backend...

Initializing provider plugins...
- Finding latest version of hashicorp/random...
- Finding latest version of hashicorp/time...
- Finding latest version of lxc/incus...
- Finding latest version of hashicorp/null...
- Installing lxc/incus v0.5.1...
- Installed lxc/incus v0.5.1 (unauthenticated)
- Installing hashicorp/null v3.2.4...
- Installed hashicorp/null v3.2.4 (unauthenticated)
- Installing hashicorp/random v3.7.2...
- Installed hashicorp/random v3.7.2 (unauthenticated)
- Installing hashicorp/time v0.13.1...
- Installed hashicorp/time v0.13.1 (unauthenticated)

OpenTofu has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that OpenTofu can guarantee to make the same selections by default when
you run "tofu init" in the future.

╷
│ Warning: Incomplete lock file information for providers
│ 
│ Due to your customized provider installation methods, OpenTofu was forced to calculate lock file checksums locally for the following providers:
│   - hashicorp/null
│   - hashicorp/random
│   - hashicorp/time
│   - lxc/incus
│ 
│ The current .terraform.lock.hcl file only includes checksums for linux_amd64, so OpenTofu running on another platform will fail to install these providers.
│ 
│ To calculate additional checksums for another platform, run:
│   tofu providers lock -platform=linux_amd64
│ (where linux_amd64 is the platform to generate)
╵

OpenTofu has been successfully initialized!
```

(Tested both with and without setting garbage http/https proxy environment variables to ensure it works without needing any Internet access.)

Closes #326 