### PR TITLE
Add logic to uninstall an application

### DIFF
--- a/incus-osd/api/application.go
+++ b/incus-osd/api/application.go
@@ -9,3 +9,8 @@ type Application struct {
 
 	Config struct{} `json:"config" yaml:"config"`
 }
+
+// ApplicationDelete defines a struct with parameters used when uninstalling an application.
+type ApplicationDelete struct {
+	RemoveUserData bool `json:"remove_user_data" yaml:"remove_user_data"`
+}

--- a/incus-osd/internal/applications/app_common.go
+++ b/incus-osd/internal/applications/app_common.go
@@ -37,6 +37,11 @@ func (*common) IsRunning(_ context.Context) bool {
 	return true
 }
 
+// Uninstall uninstalls the application, and optionally removes any local user data.
+func (*common) Uninstall(_ context.Context, _ bool) error {
+	return nil
+}
+
 // Common helper to construct an HTTP client using the provided local Unix socket.
 func unixHTTPClient(socketPath string) (*http.Client, error) {
 	// Setup a Unix socket dialer

--- a/incus-osd/internal/applications/struct.go
+++ b/incus-osd/internal/applications/struct.go
@@ -11,4 +11,5 @@ type Application interface {
 	Initialize(ctx context.Context) error
 	Update(ctx context.Context, version string) error
 	IsRunning(ctx context.Context) bool
+	Uninstall(ctx context.Context, removeUserData bool) error
 }

--- a/incus-osd/internal/rest/api_applications.go
+++ b/incus-osd/internal/rest/api_applications.go
@@ -1,10 +1,15 @@
 package rest
 
 import (
+	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/url"
 	"slices"
 
+	"github.com/lxc/incus-os/incus-osd/api"
+	"github.com/lxc/incus-os/incus-osd/internal/applications"
 	"github.com/lxc/incus-os/incus-osd/internal/rest/response"
 )
 
@@ -41,12 +46,6 @@ func (s *Server) apiApplications(w http.ResponseWriter, r *http.Request) {
 func (s *Server) apiApplicationsEndpoint(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	if r.Method != http.MethodGet {
-		_ = response.NotImplemented(nil).Render(w)
-
-		return
-	}
-
 	name := r.PathValue("name")
 
 	// Check if the application is valid.
@@ -57,6 +56,61 @@ func (s *Server) apiApplicationsEndpoint(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Handle the request.
-	_ = response.SyncResponse(true, app).Render(w)
+	switch r.Method {
+	case http.MethodGet:
+		// Handle the request.
+		_ = response.SyncResponse(true, app).Render(w)
+	case http.MethodDelete:
+		// Uninstall the application.
+		if r.ContentLength <= 0 {
+			_ = response.BadRequest(errors.New("no uninstall parameters provided")).Render(w)
+
+			return
+		}
+
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			_ = response.BadRequest(err).Render(w)
+
+			return
+		}
+
+		deleteStruct := api.ApplicationDelete{}
+
+		err = json.Unmarshal(b, &deleteStruct)
+		if err != nil {
+			_ = response.BadRequest(err).Render(w)
+
+			return
+		}
+
+		actualApp, err := applications.Load(r.Context(), name)
+		if err != nil {
+			_ = response.BadRequest(err).Render(w)
+
+			return
+		}
+
+		err = actualApp.Uninstall(r.Context(), deleteStruct.RemoveUserData)
+		if err != nil {
+			_ = response.BadRequest(err).Render(w)
+
+			return
+		}
+
+		// Remove the application from state and then write to disk.
+		delete(s.state.Applications, name)
+
+		err = s.state.Save(r.Context())
+		if err != nil {
+			_ = response.BadRequest(err).Render(w)
+
+			return
+		}
+
+		_ = response.EmptySyncResponse.Render(w)
+	default:
+		// If none of the supported methods, return NotImplemented.
+		_ = response.NotImplemented(nil).Render(w)
+	}
 }


### PR DESCRIPTION
Add logic to uninstall an application, optionally also removing all relevant user data as well. Extends the `/applications/{name}` endpoint to accept a `DELETE` request to trigger the removal.