### PR TITLE
Implement OS-level factory reset

### DIFF
--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -50,7 +50,13 @@ are not backwards compatible.
     `PATCH`: Update the current network configuration
     
     `PUT`: Replace the current network configuration
+
+  * `/1.0/system/reset`
   
+    `POST`: Perform a complete factory reset of the system and immediately reboot. An
+    optional number of seed configurations may also be provided, which will be used
+    when the system starts up into its fresh state.
+    
   * `/1.0/system/resources`
   
     `GET`: Returns a detailed low-level dump of the system's resources

--- a/incus-osd/api/system_reset.go
+++ b/incus-osd/api/system_reset.go
@@ -1,0 +1,10 @@
+package api
+
+import (
+	"encoding/json"
+)
+
+// SystemReset defines a struct that takes an optional map of seed data to set as part of the factory reset.
+type SystemReset struct {
+	Seed map[string]json.RawMessage `json:"seed" yaml:"seed"`
+}

--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -486,8 +486,8 @@ func (i *Install) performInstall(ctx context.Context, modal *tui.Modal, sourceDe
 	}
 
 	// Get partition prefixes, if needed.
-	sourcePartitionPrefix := getPartitionPrefix(sourceDevice)
-	targetPartitionPrefix := getPartitionPrefix(targetDevice)
+	sourcePartitionPrefix := GetPartitionPrefix(sourceDevice)
+	targetPartitionPrefix := GetPartitionPrefix(targetDevice)
 
 	// Format the target ESP partition and manually copy any files from the source.
 	// This is a speed optimization since we don't care about copying any unused data
@@ -712,7 +712,7 @@ func doCopy(ctx context.Context, modal *tui.Modal, sourceDevice string, sourcePa
 // rebootUponDeviceRemoval waits for the given device to disappear from /dev/, and once it does
 // it will reboot the system. If ForceReoot is true in the config, the system will reboot immediately.
 func (i *Install) rebootUponDeviceRemoval(_ context.Context, device string) error {
-	partition := fmt.Sprintf("%s%s1", device, getPartitionPrefix(device))
+	partition := fmt.Sprintf("%s%s1", device, GetPartitionPrefix(device))
 
 	// If we're running from a CDROM, adjust the device we watch for removal.
 	if device == cdromMappedDevice {
@@ -739,9 +739,9 @@ func (i *Install) rebootUponDeviceRemoval(_ context.Context, device string) erro
 	return os.WriteFile("/proc/sysrq-trigger", []byte("b"), 0o600)
 }
 
-// getPartitionPrefix returns the necessary partition prefix, if any, for a give device.
+// GetPartitionPrefix returns the necessary partition prefix, if any, for a give device.
 // nvme devices have partitions named "pN", while traditional disk partitions are just "N".
-func getPartitionPrefix(device string) string {
+func GetPartitionPrefix(device string) string {
 	cdromMatched, _ := regexp.MatchString(`/mapper/sr\d+`, device)
 
 	if strings.Contains(device, "/nvme") || cdromMatched {

--- a/incus-osd/internal/reset/doc.go
+++ b/incus-osd/internal/reset/doc.go
@@ -1,0 +1,2 @@
+// Package reset is used to perform application and/or OS-level factory resets.
+package reset

--- a/incus-osd/internal/reset/reest.go
+++ b/incus-osd/internal/reset/reest.go
@@ -1,0 +1,107 @@
+package reset
+
+import (
+	"archive/tar"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+
+	"github.com/lxc/incus/v6/shared/subprocess"
+
+	"github.com/lxc/incus-os/incus-osd/api"
+	"github.com/lxc/incus-os/incus-osd/internal/install"
+	"github.com/lxc/incus-os/incus-osd/internal/storage"
+	"github.com/lxc/incus-os/incus-osd/internal/systemd"
+)
+
+// PerformOSFactoryReset performs an OS-level factory reset.
+// !!! THIS WILL RESULT IN THE DESTRUCTION OF ALL DATA CREATED BY !!!
+// !!! IncusOS, ANY APPLICATIONS, AND ANY ZFS DATASETS CREATED IN !!!
+// !!! THE "local" POOL.                                          !!!
+func PerformOSFactoryReset(ctx context.Context, resetSeed *api.SystemReset) error {
+	// systemd v258 introduced the factory-reset.target, which in
+	// theory should automate the following steps. However, trixie
+	// shipped with systemd v257. Potentially we could use a backported
+	// version eventually.
+
+	// The version of systemd-repart in v257 does support a "factory
+	// reset" mode; however, it doesn't appear to work properly
+	// in our use case. Triggering it via EFI variable causes the
+	// initrd-parse-etc service to fail in early boot, and triggering
+	// via `systemd-repart --factory-reset=yes --dry-run=no` then
+	// rebooting causes dev-gpt\x2dauto\x2droot.device to timeout.
+
+	// Get the underlying device.
+	underlyingDevice, err := storage.GetUnderlyingDevice()
+	if err != nil {
+		return err
+	}
+
+	// Verify any provided seed data is valid json.
+	type empty struct{}
+
+	for seed, seedData := range resetSeed.Seed {
+		if seedData == nil {
+			return errors.New("seed data for '" + seed + "' is not defined")
+		}
+
+		tmp := empty{}
+
+		err := json.Unmarshal(seedData, &tmp)
+		if err != nil {
+			return err
+		}
+	}
+
+	// First, wipe the TPM.
+	_, err = subprocess.RunCommandContext(ctx, "tpm2_clear")
+	if err != nil {
+		return err
+	}
+
+	// Second, wipe system partitions (swap, root, and local-data).
+	for _, partitionIndex := range []string{"9", "10", "11"} {
+		_, err := subprocess.RunCommandContext(ctx, "sgdisk", "-d", partitionIndex, underlyingDevice)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Third, write the seed data.
+	partitionPrefix := install.GetPartitionPrefix(underlyingDevice)
+	// #nosec G304
+	f, err := os.Create(underlyingDevice + partitionPrefix + "2")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	tw := tar.NewWriter(f)
+
+	for seed, seedData := range resetSeed.Seed {
+		header := &tar.Header{
+			Name: seed + ".json",
+			Mode: 0o600,
+			Size: int64(len(seedData)),
+		}
+
+		err := tw.WriteHeader(header)
+		if err != nil {
+			return err
+		}
+
+		_, err = tw.Write(seedData)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = tw.Close()
+	if err != nil {
+		return err
+	}
+
+	// Finally, immediately reboot the system.
+	return systemd.SystemReboot(ctx)
+}

--- a/incus-osd/internal/rest/api_system_reset.go
+++ b/incus-osd/internal/rest/api_system_reset.go
@@ -1,0 +1,41 @@
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/lxc/incus-os/incus-osd/api"
+	"github.com/lxc/incus-os/incus-osd/internal/reset"
+	"github.com/lxc/incus-os/incus-osd/internal/rest/response"
+)
+
+func (*Server) apiSystemReset(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method != http.MethodPost {
+		_ = response.NotImplemented(nil).Render(w)
+
+		return
+	}
+
+	resetData := &api.SystemReset{}
+
+	if r.ContentLength > 0 {
+		err := json.NewDecoder(r.Body).Decode(resetData)
+		if err != nil {
+			_ = response.BadRequest(err).Render(w)
+
+			return
+		}
+	}
+
+	err := reset.PerformOSFactoryReset(r.Context(), resetData)
+	if err != nil {
+		_ = response.BadRequest(err).Render(w)
+
+		return
+	}
+
+	// Will never actually reach here, since the system will auto-reboot.
+	_ = response.EmptySyncResponse.Render(w)
+}

--- a/incus-osd/internal/rest/server.go
+++ b/incus-osd/internal/rest/server.go
@@ -58,6 +58,7 @@ func (s *Server) Serve(ctx context.Context) error {
 	router.HandleFunc("/1.0/services/{name}", s.apiServicesEndpoint)
 	router.HandleFunc("/1.0/system", s.apiSystem)
 	router.HandleFunc("/1.0/system/network", s.apiSystemNetwork)
+	router.HandleFunc("/1.0/system/reset", s.apiSystemReset)
 	router.HandleFunc("/1.0/system/resources", s.apiSystemResources)
 	router.HandleFunc("/1.0/system/security", s.apiSystemSecurity)
 	router.HandleFunc("/1.0/system/storage", s.apiSystemStorage)


### PR DESCRIPTION
systemd v258 introduced a nice [factory reset](https://systemd.io/FACTORY_RESET/); we don't yet have easy access to that. I did try making a local backport for trixie using the package from testing, but the resulting images wouldn't boot for some reason.

`systemd-repart` in v257 also supports some factory reset options, but triggering via EFI variables and manually via command line both resulted in subsequent boot errors.

For now, rely on `tpm2_clear` and manual nuking of swap, root, and local-data partitions to perform a full OS-level factory reset.