### PR TITLE
incus-osd/api: Don't fail parsing unknown values

### DIFF
--- a/incus-osd/api/images/update_file_architecture.go
+++ b/incus-osd/api/images/update_file_architecture.go
@@ -1,9 +1,5 @@
 package images
 
-import (
-	"fmt"
-)
-
 // UpdateFileArchitecture represents the architecture for a given file.
 type UpdateFileArchitecture string
 
@@ -18,7 +14,8 @@ const (
 	UpdateFileArchitecture64BitARM UpdateFileArchitecture = "aarch64"
 )
 
-var architecture = map[UpdateFileArchitecture]struct{}{
+// UpdateFileArchitectures is a map of the supported file architectures.
+var UpdateFileArchitectures = map[UpdateFileArchitecture]struct{}{
 	UpdateFileArchitectureUndefined: {},
 	UpdateFileArchitecture64BitX86:  {},
 	UpdateFileArchitecture64BitARM:  {},
@@ -35,11 +32,6 @@ func (u *UpdateFileArchitecture) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (u *UpdateFileArchitecture) UnmarshalText(text []byte) error {
-	_, ok := architecture[UpdateFileArchitecture(text)]
-	if !ok {
-		return fmt.Errorf("%q is not a valid update file type", string(text))
-	}
-
 	*u = UpdateFileArchitecture(text)
 
 	return nil

--- a/incus-osd/api/images/update_file_component.go
+++ b/incus-osd/api/images/update_file_component.go
@@ -1,9 +1,5 @@
 package images
 
-import (
-	"fmt"
-)
-
 // UpdateFileComponent represents the component affected by an update.
 type UpdateFileComponent string
 
@@ -24,7 +20,8 @@ const (
 	UpdateFileComponentDebug UpdateFileComponent = "debug"
 )
 
-var updateFileComponents = map[UpdateFileComponent]struct{}{
+// UpdateFileComponents is a map of the supported update file components.
+var UpdateFileComponents = map[UpdateFileComponent]struct{}{
 	UpdateFileComponentOS:               {},
 	UpdateFileComponentIncus:            {},
 	UpdateFileComponentMigrationManager: {},
@@ -43,11 +40,6 @@ func (u *UpdateFileComponent) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (u *UpdateFileComponent) UnmarshalText(text []byte) error {
-	_, ok := updateFileComponents[UpdateFileComponent(text)]
-	if !ok {
-		return fmt.Errorf("%q is not a valid update file component", string(text))
-	}
-
 	*u = UpdateFileComponent(text)
 
 	return nil

--- a/incus-osd/api/images/update_file_type.go
+++ b/incus-osd/api/images/update_file_type.go
@@ -1,9 +1,5 @@
 package images
 
-import (
-	"fmt"
-)
-
 // UpdateFileType represents the type in an update file.
 type UpdateFileType string
 
@@ -36,7 +32,8 @@ const (
 	UpdateFileTypeApplication UpdateFileType = "application"
 )
 
-var updateFileType = map[UpdateFileType]struct{}{
+// UpdateFileTypes is a map of the supported update file types.
+var UpdateFileTypes = map[UpdateFileType]struct{}{
 	UpdateFileTypeUndefined:                {},
 	UpdateFileTypeImageRaw:                 {},
 	UpdateFileTypeImageISO:                 {},
@@ -59,11 +56,6 @@ func (u *UpdateFileType) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (u *UpdateFileType) UnmarshalText(text []byte) error {
-	_, ok := updateFileType[UpdateFileType(text)]
-	if !ok {
-		return fmt.Errorf("%q is not a valid update file type", string(text))
-	}
-
 	*u = UpdateFileType(text)
 
 	return nil

--- a/incus-osd/api/images/update_severity.go
+++ b/incus-osd/api/images/update_severity.go
@@ -1,9 +1,5 @@
 package images
 
-import (
-	"fmt"
-)
-
 // UpdateSeverity represents the severity field in an update.
 type UpdateSeverity string
 
@@ -24,7 +20,8 @@ const (
 	UpdateSeverityCritical UpdateSeverity = "critical"
 )
 
-var updateSeverities = map[UpdateSeverity]struct{}{
+// UpdateSeverities is a map of the supported update severities.
+var UpdateSeverities = map[UpdateSeverity]struct{}{
 	UpdateSeverityNone:     {},
 	UpdateSeverityLow:      {},
 	UpdateSeverityMedium:   {},
@@ -43,11 +40,6 @@ func (u *UpdateSeverity) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (u *UpdateSeverity) UnmarshalText(text []byte) error {
-	_, ok := updateSeverities[UpdateSeverity(text)]
-	if !ok {
-		return fmt.Errorf("%q is not a valid update severity", string(text))
-	}
-
 	*u = UpdateSeverity(text)
 
 	return nil


### PR DESCRIPTION
We may have to introduce new file types, architectures, components, ...

Having an immediate parsing failure will prevent us from rolling out new logic to older systems.