### PR TITLE
Avoid incus-osd registration failure on first attempt

### DIFF
--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -426,6 +426,13 @@ func startup(ctx context.Context, s *state.State, t *tui.TUI) error {
 
 	// Handle registration.
 	if !s.System.Provider.State.Registered {
+		// Reload the provider following application startup (so it can fetch the certificate).
+		p, err = providers.Load(ctx, s, provider, providerConfig)
+		if err != nil {
+			return err
+		}
+
+		// Register with the provider.
 		err = p.Register(ctx)
 		if err != nil && !errors.Is(err, providers.ErrRegistrationUnsupported) {
 			return err

--- a/incus-osd/internal/providers/provider_operations_center.go
+++ b/incus-osd/internal/providers/provider_operations_center.go
@@ -338,6 +338,10 @@ func (p *operationsCenter) apiRequest(ctx context.Context, method string, path s
 
 	// Quick validation.
 	if apiResp.Type != "sync" || apiResp.StatusCode != http.StatusOK {
+		if apiResp.Type == "error" {
+			return nil, fmt.Errorf("error from operations center: %s", apiResp.Error)
+		}
+
 		return nil, errors.New("bad response from operations center")
 	}
 


### PR DESCRIPTION
Without this change, incus-osd hits the registration code without a primary application being tied to the provider. This then causes Operations Center to refuse registration (missing client certificate), incus-osd then crashes and restarts, at which point registration goes through.

This cleans up that logic so that registration can happen properly on the first go.