### PR TITLE
Add OpenFGA app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ mkosi.images/base/mkosi.extra/usr/lib/firmware/
 mkosi.images/base/mkosi.extra/usr/lib/verity.d/
 mkosi.images/gpu-support/mkosi.extra/usr/lib/firmware/
 mkosi.images/migration-manager/mkosi.extra/
+mkosi.images/openfga/mkosi.extra/
 mkosi.images/operations-center/mkosi.extra/
 
 app-build/

--- a/app-build/applications.json
+++ b/app-build/applications.json
@@ -185,6 +185,26 @@
             "usr/local/bin/netbird"
         ]
     },
+    "openfga": {
+        "version": "v1.17.1",
+        "repo": "https://github.com/openfga/openfga.git",
+        "build_targets": [
+            [
+                "-ldflags",
+                "-X github.com/openfga/openfga/internal/build.Version=@VERSION@",
+                "./cmd/openfga"
+            ]
+        ],
+        "install_targets": [
+            [
+                "openfga",
+                "usr/local/bin/"
+            ]
+        ],
+        "clean_targets": [
+            "usr/local/bin/openfga"
+        ]
+    },
     "opentofu": {
         "version": "v1.12.1",
         "repo": "https://github.com/opentofu/opentofu.git",

--- a/app-build/build-applications.py
+++ b/app-build/build-applications.py
@@ -31,6 +31,7 @@ images = [
         "lego",
         "migration-manager"]
     ],
+    ["openfga", ["openfga"]],
     ["operations-center", [
         "lego",
         "opentofu",

--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -86,6 +86,7 @@ NVMe
 OCI
 oddlama
 OEM
+OpenFGA
 OVMF
 OVN
 OVS

--- a/doc/reference/applications/non-primary.md
+++ b/doc/reference/applications/non-primary.md
@@ -15,4 +15,5 @@ Debug </reference/applications/debug>
 GPU Support </reference/applications/gpu-support>
 Incus-Ceph </reference/applications/incus-ceph>
 Incus-Linstor </reference/applications/incus-linstor>
+OpenFGA </reference/applications/openfga>
 ```

--- a/doc/reference/applications/openfga.md
+++ b/doc/reference/applications/openfga.md
@@ -1,0 +1,15 @@
+# OpenFGA
+
+The OpenFGA (`openfga`) application installs a local OpenFGA service for use by other IncusOS applications, such
+as [Operations Center](./operations-center.md).
+
+```{note}
+This OpenFGA service is not intended for general-purpose use. By default, it only allows configuring shared
+authentication keys, and only the local `sqlite` storage engine is supported.
+```
+
+On first start, the `openfga` application will generate a random shared authentication key that can be retrieved
+via the application's API as part of its configuration. Additional authentication keys can be set if desired.
+
+The OpenFGA service will automatically use the TLS certificate configured for the primary application to provide a
+TLS-secured HTTPS API endpoint on port 8444.

--- a/incus-osd/api/application_openfga.go
+++ b/incus-osd/api/application_openfga.go
@@ -1,0 +1,20 @@
+package api
+
+// ApplicationOpenFGAConfig represents additional configuration for the openfga application.
+type ApplicationOpenFGAConfig struct {
+	ApplicationConfig
+
+	APITokens []string `json:"api_tokens" yaml:"api_tokens"`
+}
+
+// ApplicationOpenFGAState represents the state of the openfga application.
+type ApplicationOpenFGAState struct {
+	ApplicationState
+}
+
+// ApplicationOpenFGA represents the state and configuration of the openfga application.
+type ApplicationOpenFGA struct {
+	State ApplicationOpenFGAState `json:"state" yaml:"state"`
+
+	Config ApplicationOpenFGAConfig `json:"config" yaml:"config"`
+}

--- a/incus-osd/api/images/update_file_component.go
+++ b/incus-osd/api/images/update_file_component.go
@@ -25,6 +25,9 @@ const (
 	// UpdateFileComponentMigrationManager represents a Migration Manager application update.
 	UpdateFileComponentMigrationManager UpdateFileComponent = "migration-manager"
 
+	// UpdateFileComponentOpenFGA represents an OpenFGA application update.
+	UpdateFileComponentOpenFGA UpdateFileComponent = "openfga"
+
 	// UpdateFileComponentOperationsCenter represents an Operations Center application update.
 	UpdateFileComponentOperationsCenter UpdateFileComponent = "operations-center"
 )
@@ -38,6 +41,7 @@ var UpdateFileComponents = map[UpdateFileComponent]struct{}{
 	UpdateFileComponentIncusCeph:        {},
 	UpdateFileComponentIncusLinstor:     {},
 	UpdateFileComponentMigrationManager: {},
+	UpdateFileComponentOpenFGA:          {},
 	UpdateFileComponentOperationsCenter: {},
 }
 

--- a/incus-osd/cmd/image-publisher/main_sync.go
+++ b/incus-osd/cmd/image-publisher/main_sync.go
@@ -362,6 +362,9 @@ func (*cmdSync) downloadImage(ctx context.Context, archName string, releaseURL *
 		case assetName == "migration-manager.raw.gz":
 			assetComponent = apiupdate.UpdateFileComponentMigrationManager
 			assetType = apiupdate.UpdateFileTypeApplication
+		case assetName == "openfga.raw.gz":
+			assetComponent = apiupdate.UpdateFileComponentOpenFGA
+			assetType = apiupdate.UpdateFileTypeApplication
 		case assetName == "operations-center.raw.gz":
 			assetComponent = apiupdate.UpdateFileComponentOperationsCenter
 			assetType = apiupdate.UpdateFileTypeApplication
@@ -406,6 +409,9 @@ func (*cmdSync) downloadImage(ctx context.Context, archName string, releaseURL *
 			assetType = apiupdate.UpdateFileTypeImageManifest
 		case strings.HasSuffix(assetName, "migration-manager.manifest.json.gz"):
 			assetComponent = apiupdate.UpdateFileComponentMigrationManager
+			assetType = apiupdate.UpdateFileTypeImageManifest
+		case strings.HasSuffix(assetName, "openfga.manifest.json.gz"):
+			assetComponent = apiupdate.UpdateFileComponentOpenFGA
 			assetType = apiupdate.UpdateFileTypeImageManifest
 		case strings.HasSuffix(assetName, "operations-center.manifest.json.gz"):
 			assetComponent = apiupdate.UpdateFileComponentOperationsCenter

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -797,27 +797,43 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 	}
 
 	// Run application startup actions. Must be done after storage pools are loaded.
+	// Begin by starting the primary application before any other installed applications.
+	// When configured with the "debug" provider, allow this check to fail, as when the
+	// system initially boots no applications may yet be available to the system.
+	primaryApp, err := applications.GetPrimary(ctx, s, false)
+	if err != nil && (!errors.Is(err, applications.ErrNoPrimary) || s.System.Provider.Config.Name != "debug") {
+		return err
+	}
+
+	if primaryApp != nil {
+		err := applications.StartInitialize(ctx, s, primaryApp.Name())
+		if err != nil {
+			slog.ErrorContext(ctx, err.Error())
+
+			// If not running from the backup image, which automatically starts the fallback HTTPS listener,
+			// attempt to start it when the primary application has failed to start.
+			if !s.OS.RunningFromBackup() {
+				slog.WarnContext(ctx, "Primary application "+primaryApp.Name()+" failed to start; attempting to enable fallback HTTPS server for basic connectivity")
+
+				s.TriggerFallbackListener <- true
+			}
+		}
+	}
+
+	// Start any non-primary applications.
 	apps, err := applications.GetInstalled(ctx, s)
 	if err != nil {
 		return err
 	}
 
 	for _, app := range apps {
+		if app.IsPrimary() {
+			continue
+		}
+
 		err := applications.StartInitialize(ctx, s, app.Name())
 		if err != nil {
-			if !app.IsPrimary() {
-				return err
-			}
-
-			slog.ErrorContext(ctx, err.Error())
-
-			// If not running from the backup image, which automatically starts the fallback HTTPS listener,
-			// attempt to start it when the primary application has failed to start.
-			if !s.OS.RunningFromBackup() {
-				slog.WarnContext(ctx, "Primary application "+app.Name()+" failed to start; attempting to enable fallback HTTPS server for basic connectivity")
-
-				s.TriggerFallbackListener <- true
-			}
+			return err
 		}
 	}
 

--- a/incus-osd/internal/applications/app_openfga.go
+++ b/incus-osd/internal/applications/app_openfga.go
@@ -1,0 +1,443 @@
+package applications
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"time"
+
+	"github.com/lxc/incus/v7/shared/subprocess"
+	"go.yaml.in/yaml/v4"
+	"golang.org/x/sys/unix"
+
+	"github.com/lxc/incus-os/incus-osd/api"
+	"github.com/lxc/incus-os/incus-osd/internal/systemd"
+	"github.com/lxc/incus-os/incus-osd/internal/zfs"
+)
+
+type openfga struct {
+	common
+}
+
+type openfgaConfig struct {
+	Authn openfgaConfigAuthn `yaml:"authn"`
+	Grpc  openfgaConfigGrpc  `yaml:"grpc"`
+	HTTP  openfgaConfigHTTP  `yaml:"http"`
+}
+
+type openfgaConfigAuthn struct {
+	Method    string                      `yaml:"method"`
+	Preshared openfgaConfigAuthnPreshared `yaml:"preshared"`
+}
+
+type openfgaConfigAuthnPreshared struct {
+	Keys []string `yaml:"keys"`
+}
+
+type openfgaConfigGrpc struct {
+	Addr string           `yaml:"addr"`
+	TLS  openfgaConfigTLS `yaml:"tls"`
+}
+
+type openfgaConfigHTTP struct {
+	Addr string           `yaml:"addr"`
+	TLS  openfgaConfigTLS `yaml:"tls"`
+}
+
+type openfgaConfigTLS struct {
+	Enabled bool   `yaml:"enabled"`
+	Cert    string `yaml:"cert"`
+	Key     string `yaml:"key"`
+}
+
+// ConfigureLocalStorage configures local storage for the application.
+func (o *openfga) ConfigureLocalStorage(ctx context.Context) error {
+	// If the application isn't initialized, create a ZFS dataset for it to use.
+	if !o.IsInitialized() {
+		err := zfs.CreateApplicationDataset(ctx, "openfga")
+		if err != nil {
+			return err
+		}
+	} else {
+		err := zfs.MountApplicationDataset(ctx, "openfga")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// FactoryReset performs a full factory reset of the application.
+func (o *openfga) FactoryReset(ctx context.Context) error {
+	// Stop the application.
+	err := o.Stop(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Wipe local configuration.
+	err = o.WipeLocalData(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Start the application.
+	err = o.Start(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Perform first start initialization.
+	return o.Initialize(ctx)
+}
+
+func (o *openfga) Get(_ context.Context) (any, error) {
+	return o.state.Applications.OpenFGA, nil
+}
+
+// GetBackup returns a tar archive backup of the application's configuration and/or state.
+func (*openfga) GetBackup(archive io.Writer, _ bool) error {
+	return createTarArchive("/var/lib/openfga/", nil, archive)
+}
+
+// GetDependencies returns a list of other applications this application depends on.
+func (*openfga) GetDependencies() []string {
+	return nil
+}
+
+// Initialize runs first time initialization.
+func (o *openfga) Initialize(ctx context.Context) error {
+	// Ensure the default configuration directory exists.
+	err := os.Mkdir("/etc/openfga/", 0o755)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	// Set an initial random authentication token.
+	initialToken := &api.ApplicationOpenFGA{
+		Config: api.ApplicationOpenFGAConfig{
+			APITokens: []string{rand.Text()},
+		},
+	}
+
+	// Mark application as initialized.
+	o.appState.Initialized = true
+
+	// Apply the configuration and restart the service.
+	return o.UpdateConfig(ctx, initialToken)
+}
+
+// IsInstalled reports whether the application has been installed.
+func (o *openfga) IsInstalled() bool {
+	if o.appState.Version == "" {
+		return false
+	}
+
+	return sysextImageExists(o.Name(), o.appState.Version)
+}
+
+// IsPrimary reports if the application is a primary application.
+func (*openfga) IsPrimary() bool {
+	return false
+}
+
+// IsRunning reports if the application is currently running.
+func (*openfga) IsRunning(ctx context.Context) bool {
+	return systemd.IsActive(ctx, "openfga.service")
+}
+
+func (*openfga) Name() string {
+	return "openfga"
+}
+
+// NeedsLateUpdateCheck reports if the application depends on a delayed provider update check.
+func (*openfga) NeedsLateUpdateCheck() bool {
+	return false
+}
+
+// Restart restarts the main systemd unit.
+func (*openfga) Restart(ctx context.Context) error {
+	return systemd.RestartUnit(ctx, "openfga.service")
+}
+
+// RestoreBackup restores a tar archive backup of the application's configuration and/or state.
+func (o *openfga) RestoreBackup(archive io.Reader) error {
+	err := extractTarArchive("/var/lib/openfga/", []string{"openfga.service"}, archive)
+	if err != nil {
+		return err
+	}
+
+	// Restore any configured trust tokens to application state.
+	contents, err := os.ReadFile("/var/lib/openfga/config.yaml")
+	if err != nil {
+		return err
+	}
+
+	cfg := openfgaConfig{}
+
+	err = yaml.Load(contents, &cfg)
+	if err != nil {
+		return err
+	}
+
+	o.state.Applications.OpenFGA.Config.APITokens = cfg.Authn.Preshared.Keys
+
+	// Ensure the default configuration directory exists.
+	err = os.Mkdir("/etc/openfga/", 0o755)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	// Ensure a symlinked configuration file exists where openfga will look for it.
+	_, err = os.Lstat("/etc/openfga/config.yaml")
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+
+		err := os.Symlink("/var/lib/openfga/config.yaml", "/etc/openfga/config.yaml")
+		if err != nil {
+			return err
+		}
+	}
+
+	// Record when the application was restored.
+	now := time.Now()
+	o.appState.LastRestored = &now
+
+	return nil
+}
+
+// SetFriendlyVersion records the friendly version.
+func (o *openfga) SetFriendlyVersion(ctx context.Context) error {
+	_, stderr, err := subprocess.RunCommandSplit(ctx, nil, nil, "openfga", "version")
+	if err != nil {
+		return err
+	}
+
+	versionRegex := regexp.MustCompile("OpenFGA version `(.+)` build from")
+	versionGroup := versionRegex.FindStringSubmatch(stderr)
+
+	if len(versionGroup) != 2 {
+		return errors.New("unable to determine OpenFGA version")
+	}
+
+	o.appState.FriendlyVersion = versionGroup[1] + " [" + o.appState.Version + "]"
+
+	return nil
+}
+
+// Start starts the systemd unit.
+func (o *openfga) Start(ctx context.Context) error {
+	// Ensure local storage for OpenFGA is configured before doing anything else.
+	err := o.ConfigureLocalStorage(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Each time OpenFGA starts, grab a copy of the primary application's TLS certificate and
+	// key so OpenFGA can use the same TLS certificate when serving requests. This also simplifies
+	// handling of TLS certificate rotation, as OpenFGA only needs to be restarted to pickup the change.
+	primaryApp, err := GetPrimary(ctx, o.state, true)
+	if err != nil {
+		return err
+	}
+
+	tlsCert, err := primaryApp.GetServerCertificate()
+	if err != nil {
+		return err
+	}
+
+	err = writeCerts(tlsCert)
+	if err != nil {
+		return err
+	}
+
+	// Start the unit.
+	return systemd.StartUnit(ctx, "openfga.service")
+}
+
+func writeCerts(tlsCert *tls.Certificate) error {
+	var buf bytes.Buffer
+
+	privKeyBytes, err := x509.MarshalPKCS8PrivateKey(tlsCert.PrivateKey)
+	if err != nil {
+		return err
+	}
+
+	block := pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: privKeyBytes,
+	}
+
+	err = pem.Encode(&buf, &block)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile("/var/lib/openfga/server.key", buf.Bytes(), 0o400)
+	if err != nil {
+		return err
+	}
+
+	buf.Reset()
+
+	for _, cert := range tlsCert.Certificate {
+		block := pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: cert,
+		}
+
+		err := pem.Encode(&buf, &block)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = os.WriteFile("/var/lib/openfga/server.crt", buf.Bytes(), 0o644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Stop stops the systemd unit.
+func (*openfga) Stop(ctx context.Context) error {
+	// Stop the unit.
+	return systemd.StopUnit(ctx, "openfga.service")
+}
+
+func (*openfga) Struct() any {
+	return &api.ApplicationOpenFGA{}
+}
+
+// Update triggers restart after an application update.
+func (*openfga) Update(ctx context.Context) error {
+	// Reload the systemd daemon to pickup any service definition changes.
+	err := systemd.ReloadDaemon(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Restart the unit.
+	return systemd.RestartUnit(ctx, "openfga.service")
+}
+
+func (o *openfga) UpdateConfig(ctx context.Context, req any) error {
+	newState, ok := req.(*api.ApplicationOpenFGA)
+	if !ok {
+		return fmt.Errorf("request type \"%T\" isn't expected ApplicationOpenFGA", req)
+	}
+
+	if len(newState.Config.APITokens) == 0 {
+		return errors.New("at least one API token must be specified")
+	}
+
+	// Update the configuration.
+	o.state.Applications.OpenFGA.Config = newState.Config
+
+	// Remove any existing configuration.
+	err := os.Remove("/var/lib/openfga/config.yaml")
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	cfg := openfgaConfig{
+		Authn: openfgaConfigAuthn{
+			Method: "preshared",
+			Preshared: openfgaConfigAuthnPreshared{
+				Keys: o.state.Applications.OpenFGA.Config.APITokens,
+			},
+		},
+		Grpc: openfgaConfigGrpc{
+			Addr: "localhost:55123", // Since we can't disable the gRPC service, bind to localhost only on a high port.
+			TLS: openfgaConfigTLS{
+				Enabled: true,
+				Cert:    "/var/lib/openfga/server.crt",
+				Key:     "/var/lib/openfga/server.key",
+			},
+		},
+		HTTP: openfgaConfigHTTP{
+			Addr: ":8444",
+			TLS: openfgaConfigTLS{
+				Enabled: true,
+				Cert:    "/var/lib/openfga/server.crt",
+				Key:     "/var/lib/openfga/server.key",
+			},
+		},
+	}
+
+	// Dump configuration to yaml.
+	contents, err := yaml.Dump(&cfg, yaml.WithV2Defaults())
+	if err != nil {
+		return err
+	}
+
+	// Write the new configuration file.
+	err = os.WriteFile("/var/lib/openfga/config.yaml", contents, 0o600)
+	if err != nil {
+		return err
+	}
+
+	// Ensure a symlinked configuration file exists where openfga will look for it.
+	_, err = os.Lstat("/etc/openfga/config.yaml")
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+
+		err := os.Symlink("/var/lib/openfga/config.yaml", "/etc/openfga/config.yaml")
+		if err != nil {
+			return err
+		}
+	}
+
+	// Save the state.
+	err = o.state.Save()
+	if err != nil {
+		return err
+	}
+
+	// Restart the application.
+	return o.Update(ctx)
+}
+
+// WipeLocalData removes local data created by the application.
+func (*openfga) WipeLocalData(ctx context.Context) error {
+	// Remove configuration file symlink.
+	err := os.Remove("/etc/openfga/config.yaml")
+	if err != nil {
+		return err
+	}
+
+	// Unmount the dataset.
+	err = unix.Unmount("/var/lib/openfga/", 0)
+	if err != nil {
+		return err
+	}
+
+	// Destroy the dataset.
+	err = zfs.DestroyDataset(ctx, "local", "openfga", false)
+	if err != nil {
+		return err
+	}
+
+	// For good measure, remove the mount point.
+	err = os.RemoveAll("/var/lib/openfga/")
+	if err != nil {
+		return err
+	}
+
+	// Create a fresh dataset for the application.
+	return zfs.CreateApplicationDataset(ctx, "openfga")
+}

--- a/incus-osd/internal/applications/helpers.go
+++ b/incus-osd/internal/applications/helpers.go
@@ -74,6 +74,8 @@ func UninstallApplication(ctx context.Context, s *state.State, name string) erro
 		s.Applications.IncusLinstor = api.Application{}
 	case "migration-manager":
 		s.Applications.MigrationManager = api.Application{}
+	case "openfga":
+		s.Applications.OpenFGA = api.ApplicationOpenFGA{}
 	case "operations-center":
 		s.Applications.OperationsCenter = api.Application{}
 	default:

--- a/incus-osd/internal/applications/load.go
+++ b/incus-osd/internal/applications/load.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Supported lists all supported applications.
-var Supported = []string{"debug", "gpu-support", incusVersionStable, incusVersionLTS70, "incus-ceph", "incus-linstor", "migration-manager", "operations-center"}
+var Supported = []string{"debug", "gpu-support", incusVersionStable, incusVersionLTS70, "incus-ceph", "incus-linstor", "migration-manager", "openfga", "operations-center"}
 
 // ErrNoPrimary is returned when the system doesn't yet have a primary application.
 var ErrNoPrimary = errors.New("no primary application")
@@ -43,6 +43,8 @@ func Load(_ context.Context, s *state.State, name string) (Application, error) {
 		app = &incusLinstor{common: common{state: s, appState: &s.Applications.IncusLinstor.State}}
 	case "migration-manager":
 		app = &migrationManager{common: common{state: s, appState: &s.Applications.MigrationManager.State}}
+	case "openfga":
+		app = &openfga{common: common{state: s, appState: &s.Applications.OpenFGA.State.ApplicationState}}
 	case "operations-center":
 		app = &operationsCenter{common: common{state: s, appState: &s.Applications.OperationsCenter.State}}
 	default:

--- a/incus-osd/internal/state/struct.go
+++ b/incus-osd/internal/state/struct.go
@@ -54,13 +54,14 @@ type State struct {
 	FullAgentEnabled   bool       `json:"full_agent_enabled"`
 
 	Applications struct {
-		Debug            api.Application      `json:"debug"`
-		GPUSupport       api.Application      `json:"gpu_support"`
-		Incus            api.ApplicationIncus `json:"incus"`
-		IncusCeph        api.Application      `json:"incus_ceph"`
-		IncusLinstor     api.Application      `json:"incus_linstor"`
-		MigrationManager api.Application      `json:"migration_manager"`
-		OperationsCenter api.Application      `json:"operations_center"`
+		Debug            api.Application        `json:"debug"`
+		GPUSupport       api.Application        `json:"gpu_support"`
+		Incus            api.ApplicationIncus   `json:"incus"`
+		IncusCeph        api.Application        `json:"incus_ceph"`
+		IncusLinstor     api.Application        `json:"incus_linstor"`
+		MigrationManager api.Application        `json:"migration_manager"`
+		OpenFGA          api.ApplicationOpenFGA `json:"openfga"`
+		OperationsCenter api.Application        `json:"operations_center"`
 	}
 
 	OS OS `json:"os"`

--- a/mkosi.images/openfga/mkosi.conf
+++ b/mkosi.images/openfga/mkosi.conf
@@ -1,0 +1,11 @@
+[Config]
+Dependencies=base
+
+[Output]
+Format=sysext
+Overlay=yes
+ManifestFormat=json
+ImageVersion=
+
+[Content]
+BaseTrees=%O/base

--- a/mkosi.images/openfga/mkosi.extra/usr/lib/systemd/system/openfga.service
+++ b/mkosi.images/openfga/mkosi.extra/usr/lib/systemd/system/openfga.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=OpenFGA
+Documentation=https://github.com/openfga/openfga
+
+[Service]
+ExecStartPre=mkdir -p /var/lib/openfga/
+ExecStartPre=/usr/local/bin/openfga migrate --datastore-engine=sqlite --datastore-uri=file:///var/lib/openfga/openfga.sqlite
+ExecStart=/usr/local/bin/openfga run --playground-enabled=false --metrics-enabled=false --datastore-engine=sqlite --datastore-uri=file:///var/lib/openfga/openfga.sqlite
+KillMode=process
+Restart=on-failure

--- a/scripts/prepare-upload.sh
+++ b/scripts/prepare-upload.sh
@@ -22,6 +22,7 @@ cp mkosi.output/incus-lts-7.0.raw upload/
 cp mkosi.output/incus-ceph.raw upload/
 cp mkosi.output/incus-linstor.raw upload/
 cp mkosi.output/migration-manager.raw upload/
+cp mkosi.output/openfga.raw upload/
 cp mkosi.output/operations-center.raw upload/
 
 OSNAME=$(grep "ImageId=" mkosi.conf | cut -d '=' -f 2)


### PR DESCRIPTION
When initializing, the application will generate an initial random authentication token. Authentication tokens can be changed via the application configuration API.

The `openfga` service will start its HTTPS listener on port 8444.

Each time the application starts, it will grab a copy of the primary application's TLS certificate/key and use those to secure the OpenFGA API endpoints. When the primary application TLS certificate changes, just restart the OpenFGA application to pickup the new certificate.

```
bash-5.2# curl --unix-socket /run/incus-os/unix.socket http://localhost/1.0/applications/openfga | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   337  100   337    0     0   209k      0 --:--:-- --:--:-- --:--:--  329k
{
  "type": "sync",
  "status": "Success",
  "status_code": 200,
  "operation": "",
  "error_code": 0,
  "error": "",
  "metadata": {
    "state": {
      "initialized": true,
      "friendly_version": "1.17.1 [202606111508]",
      "version": "202606111508",
      "available_versions": [
        "202606111508"
      ]
    },
    "config": {
      "api_tokens": [
        "45DWOCMJSTFXGV4BJBON7CVOSB"
      ]
    }
  }
}
```

Closes #354