### PR TITLE
Build Migration Manager worker image and include in application layer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,12 @@ endif
 
 	mkdir -p mkosi.images/migration-manager/mkosi.extra/usr/local/bin/
 	mkdir -p mkosi.images/migration-manager/mkosi.extra/usr/lib/migration-manager/
+	mkdir -p mkosi.images/migration-manager/mkosi.extra/usr/share/migration-manager/images/
 	mkdir -p mkosi.images/migration-manager/mkosi.extra/usr/share/migration-manager/ui/
 	cp app-build/migration-manager/migration-managerd mkosi.images/migration-manager/mkosi.extra/usr/local/bin/
 	cp app-build/migration-manager/migration-manager mkosi.images/migration-manager/mkosi.extra/usr/local/bin/
 	cp app-build/migration-manager/migration-manager-worker mkosi.images/migration-manager/mkosi.extra/usr/lib/migration-manager/
+	cp app-build/migration-manager/worker/mkosi.output/migration-manager-worker.raw mkosi.images/migration-manager/mkosi.extra/usr/share/migration-manager/images/worker-$$(uname -m).img
 	cp -r app-build/migration-manager/ui/dist/* mkosi.images/migration-manager/mkosi.extra/usr/share/migration-manager/ui/
 
 	mkdir -p mkosi.images/operations-center/mkosi.extra/usr/local/bin/

--- a/app-build/build-applications.sh
+++ b/app-build/build-applications.sh
@@ -129,6 +129,10 @@ go build -o migration-manager ./cmd/migration-manager
 go build -o migration-manager-worker ./cmd/migration-manager-worker
 strip migration-managerd migration-manager migration-manager-worker
 
+pushd worker
+make build
+popd
+
 pushd ui
 YARN_ENABLE_HARDENED_MODE=0 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarnpkg install && yarnpkg build
 popd


### PR DESCRIPTION
Adds the Migration Manager worker image to the application layer. Within the IncusOS environment, the image will be available at `/usr/share/migration-manager/images/worker-${arch}.img`.

@masnax