### PR TITLE
Limit building of the Migration Manager worker image to amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,13 +67,16 @@ endif
 
 	mkdir -p mkosi.images/migration-manager/mkosi.extra/usr/local/bin/
 	mkdir -p mkosi.images/migration-manager/mkosi.extra/usr/lib/migration-manager/
-	mkdir -p mkosi.images/migration-manager/mkosi.extra/usr/share/migration-manager/images/
 	mkdir -p mkosi.images/migration-manager/mkosi.extra/usr/share/migration-manager/ui/
 	cp app-build/migration-manager/migration-managerd mkosi.images/migration-manager/mkosi.extra/usr/local/bin/
 	cp app-build/migration-manager/migration-manager mkosi.images/migration-manager/mkosi.extra/usr/local/bin/
 	cp app-build/migration-manager/migration-manager-worker mkosi.images/migration-manager/mkosi.extra/usr/lib/migration-manager/
-	cp app-build/migration-manager/worker/mkosi.output/migration-manager-worker.raw mkosi.images/migration-manager/mkosi.extra/usr/share/migration-manager/images/worker-$$(uname -m).img
+
 	cp -r app-build/migration-manager/ui/dist/* mkosi.images/migration-manager/mkosi.extra/usr/share/migration-manager/ui/
+
+	# Allow copy of the migration manager worker image to fail, since it only exists for amd64 at the moment.
+	mkdir -p mkosi.images/migration-manager/mkosi.extra/usr/share/migration-manager/images/
+	-cp app-build/migration-manager/worker/mkosi.output/migration-manager-worker.raw mkosi.images/migration-manager/mkosi.extra/usr/share/migration-manager/images/worker-$$(uname -m).img
 
 	mkdir -p mkosi.images/operations-center/mkosi.extra/usr/local/bin/
 	mkdir -p mkosi.images/operations-center/mkosi.extra/usr/share/operations-center/ui/

--- a/app-build/build-applications.sh
+++ b/app-build/build-applications.sh
@@ -129,9 +129,12 @@ go build -o migration-manager ./cmd/migration-manager
 go build -o migration-manager-worker ./cmd/migration-manager-worker
 strip migration-managerd migration-manager migration-manager-worker
 
-pushd worker
-make build
-popd
+# Limit building of the Migration Manager worker image to amd64, since the vmware vddk isn't available for arm64.
+if [ "${ARCH}" = "amd64" ]; then
+    pushd worker
+    make build
+    popd
+fi
 
 pushd ui
 YARN_ENABLE_HARDENED_MODE=0 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarnpkg install && yarnpkg build


### PR DESCRIPTION
The vmware vddk isn't available for arm64, so only build the image for amd64.