### PR TITLE
incus-osd/applications/operations-center: Don't restart the service d…

### DIFF
--- a/incus-osd/internal/applications/app_operations_center.go
+++ b/incus-osd/internal/applications/app_operations_center.go
@@ -165,8 +165,7 @@ func (oc *operationsCenter) Initialize(ctx context.Context) error {
 		}
 	}
 
-	// Restart the service to ensure any seed settings are properly applied.
-	return systemd.RestartUnit(ctx, "operations-center.service")
+	return nil
 }
 
 // IsRunning reports if the application is currently running.


### PR DESCRIPTION
…uring initialization

We don't actually need the restart and it's been causing some issues when updates are being downloaded.