### PR TITLE
Robustify SecureBoot certificate injection script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
             devscripts \
             libnbd-dev \
             make \
+            mtools \
             parted \
             pkgconf \
             pipx \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,6 +100,7 @@ jobs:
             efitools \
             libnbd-dev \
             make \
+            mtools \
             pkgconf \
             pipx \
             qemu-utils \


### PR DESCRIPTION
Loop-mounting the raw image to inject our own SecureBoot certificates is failing in CI runs more often than I'd like to see. So, switch to using mtools to directly manipulate the ESP partition since it's formatted as vfat.