### PR TITLE
Fix bug in IsRemoteDevice() when given a partition

### DIFF
--- a/incus-osd/internal/storage/storage.go
+++ b/incus-osd/internal/storage/storage.go
@@ -543,6 +543,15 @@ func IsRemoteDevice(deviceName string) (bool, error) {
 
 	device := filepath.Base(deviceName)
 
+	// Check if we have been given a partition; if so, get the device it belongs to.
+	_, err = os.Stat("/sys/class/block/" + device + "/partition")
+	if err == nil {
+		symlink, err := os.Readlink("/sys/class/block/" + device)
+		if err == nil {
+			device = filepath.Base(filepath.Join(symlink, ".."))
+		}
+	}
+
 	// SATA or FC.
 	if strings.HasPrefix(device, "sd") {
 		link, err := os.Readlink("/sys/class/block/" + device)


### PR DESCRIPTION
Adding logic to handle resolving a symlink if provided exposed a bug where we would fail if the device was a partition and not an entire block device. This commit adds some simple logic to attempt to detect if the device is a partition, and if so, then get the actual device it belongs to.

Closes #429