### PR TITLE
Fix incus app backup restore

### DIFF
--- a/incus-osd/internal/applications/app_incus.go
+++ b/incus-osd/internal/applications/app_incus.go
@@ -233,8 +233,8 @@ func (*incus) GetBackup(archive io.Writer, _ bool) error {
 }
 
 // RestoreBackup restores a tar archive backup of the application's configuration and/or state.
-func (*incus) RestoreBackup(archive io.Reader) error {
-	return extractTarArchive("/var/lib/incus/", archive)
+func (*incus) RestoreBackup(ctx context.Context, archive io.Reader) error {
+	return extractTarArchive(ctx, "/var/lib/incus/", []string{"incus-startup.service", "incus.socket", "incus.service", "incus-lxcfs.service"}, archive)
 }
 
 func (*incus) applyDefaults(ctx context.Context, c incusclient.InstanceServer) error {

--- a/incus-osd/internal/applications/app_migration_manager.go
+++ b/incus-osd/internal/applications/app_migration_manager.go
@@ -282,6 +282,6 @@ func (*migrationManager) GetBackup(archive io.Writer, complete bool) error {
 }
 
 // RestoreBackup restores a tar archive backup of the application's configuration and/or state.
-func (*migrationManager) RestoreBackup(archive io.Reader) error {
-	return extractTarArchive("/var/lib/migration-manager/", archive)
+func (*migrationManager) RestoreBackup(ctx context.Context, archive io.Reader) error {
+	return extractTarArchive(ctx, "/var/lib/migration-manager/", []string{"migration-manager.service"}, archive)
 }

--- a/incus-osd/internal/applications/app_operations_center.go
+++ b/incus-osd/internal/applications/app_operations_center.go
@@ -297,6 +297,6 @@ func (*operationsCenter) GetBackup(archive io.Writer, complete bool) error {
 }
 
 // RestoreBackup restores a tar archive backup of the application's configuration and/or state.
-func (*operationsCenter) RestoreBackup(archive io.Reader) error {
-	return extractTarArchive("/var/lib/operations-center/", archive)
+func (*operationsCenter) RestoreBackup(ctx context.Context, archive io.Reader) error {
+	return extractTarArchive(ctx, "/var/lib/operations-center/", []string{"operations-center.service"}, archive)
 }

--- a/incus-osd/internal/applications/struct.go
+++ b/incus-osd/internal/applications/struct.go
@@ -15,7 +15,7 @@ type Application interface { //nolint:interfacebloat
 	Initialize(ctx context.Context) error
 	IsPrimary() bool
 	IsRunning(ctx context.Context) bool
-	RestoreBackup(archive io.Reader) error
+	RestoreBackup(ctx context.Context, archive io.Reader) error
 	Restart(ctx context.Context, version string) error
 	Start(ctx context.Context, version string) error
 	Stop(ctx context.Context, version string) error

--- a/incus-osd/internal/rest/api_applications.go
+++ b/incus-osd/internal/rest/api_applications.go
@@ -223,22 +223,7 @@ func (s *Server) apiApplicationsRestore(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Restore the application's backup.
-	err = app.RestoreBackup(r.Body)
-	if err != nil {
-		_ = response.BadRequest(err).Render(w)
-
-		return
-	}
-
-	// Restart the application.
-	err = app.Stop(r.Context(), "")
-	if err != nil {
-		_ = response.BadRequest(err).Render(w)
-
-		return
-	}
-
-	err = app.Start(r.Context(), "")
+	err = app.RestoreBackup(r.Context(), r.Body)
 	if err != nil {
 		_ = response.BadRequest(err).Render(w)
 


### PR DESCRIPTION
* When extracting an application backup, do so into a new directory and rename it at the end instead of renaming the existing directory and then extracting
* Move restarting of application into the restore method

Closes #427