### PR TITLE
Gracefully handle unrecognized state fields

### DIFF
--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -134,6 +134,15 @@ func run(ctx context.Context, s *state.State, t *tui.TUI) error {
 		os.Exit(1) //nolint:revive
 	}
 
+	// Warn the user if we failed to read any configuration fields from state.
+	if len(s.UnrecognizedFields) > 0 {
+		slog.ErrorContext(ctx, "Failed to fully parse existing state; no changes will be written to disk")
+	}
+
+	for _, field := range s.UnrecognizedFields {
+		slog.WarnContext(ctx, "Failed to parse state field '"+field+"', skipping")
+	}
+
 	// Check if we should try to install to a local disk.
 	if s.ShouldPerformInstall {
 		inst, err := install.NewInstall(t)

--- a/incus-osd/internal/state/file.go
+++ b/incus-osd/internal/state/file.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"log/slog"
 	"os"
 
 	"github.com/lxc/incus-os/incus-osd/api"
@@ -47,6 +48,13 @@ func LoadOrCreate(path string) (*State, error) {
 
 // Save writes out the current state struct into its on-disk storage.
 func (s *State) Save() error {
+	// If we failed to fully load the existing state, refuse to save any changes to prevent accidental data loss.
+	if len(s.UnrecognizedFields) > 0 {
+		slog.Error("Refusing to save state because we previously failed to properly load the existing state")
+
+		return nil
+	}
+
 	body, err := Encode(s)
 	if err != nil {
 		return err

--- a/incus-osd/internal/state/state_test.go
+++ b/incus-osd/internal/state/state_test.go
@@ -165,6 +165,28 @@ System.Update.Config.Channel: stable
 System.Update.Config.CheckFrequency: 6h0m0s
 `
 
+var unrecognizedFieldConfig = `#Version: 5
+Applications[incus].State.Initialized: true
+Applications[incus].State.Version: 202506241635
+OS.Name: IncusOS
+OS.RunningRelease: 202506241635
+OS.NextRelease: 202506241635
+System.Security.Config.FooBar: BizBaz
+`
+
+// Test decoding state with an unrecognized field.
+func TestUnrecognizedField(t *testing.T) {
+	t.Parallel()
+
+	var s state.State
+
+	err := state.Decode([]byte(unrecognizedFieldConfig), nil, &s)
+	require.NoError(t, err)
+
+	require.Len(t, s.UnrecognizedFields, 1)
+	require.Equal(t, "System.Security.Config.FooBar", s.UnrecognizedFields[0])
+}
+
 // Test basic custom decoding/encoding of state.
 func TestCustomEncoding(t *testing.T) {
 	t.Parallel()

--- a/incus-osd/internal/state/struct.go
+++ b/incus-osd/internal/state/struct.go
@@ -28,7 +28,8 @@ type OS struct {
 type State struct {
 	path string
 
-	StateVersion int `json:"-"`
+	StateVersion       int      `json:"-"`
+	UnrecognizedFields []string `json:"-"`
 
 	ShouldPerformInstall bool `json:"-"`
 


### PR DESCRIPTION
Rather than erroring out if we encounter an unrecognized configuration field, instead report those fields to the user and refuse to save any state updates.

Closes #459