### PR TITLE
incus-osd/providers: Return more informative error messages

### DIFF
--- a/incus-osd/internal/providers/provider_images.go
+++ b/incus-osd/internal/providers/provider_images.go
@@ -283,7 +283,7 @@ func (*images) tryRequest(req *http.Request) (*http.Response, error) {
 		time.Sleep(time.Second)
 	}
 
-	return nil, err
+	return nil, errors.New("http request timed out after five seconds: %s" + err.Error())
 }
 
 // An application from the images provider.
@@ -325,7 +325,7 @@ func (a *imagesApplication) Download(ctx context.Context, targetPath string, pro
 		// Download the application.
 		err = downloadAsset(ctx, http.DefaultClient, fileURL, file.Sha256, filepath.Join(targetPath, targetName), progressFunc)
 		if err != nil {
-			return err
+			return fmt.Errorf("while downloading %s, got error '%s'", fileURL, err.Error())
 		}
 	}
 
@@ -372,7 +372,7 @@ func (o *imagesOSUpdate) DownloadUpdate(ctx context.Context, targetPath string, 
 		// Download the application.
 		err = downloadAsset(ctx, http.DefaultClient, fileURL, file.Sha256, filepath.Join(targetPath, targetName), progressFunc)
 		if err != nil {
-			return err
+			return fmt.Errorf("while downloading %s, got error '%s'", fileURL, err.Error())
 		}
 	}
 
@@ -448,7 +448,7 @@ func (o *imagesSecureBootCertUpdate) Download(ctx context.Context, targetPath st
 		// Download the application.
 		err = downloadAsset(ctx, http.DefaultClient, fileURL, file.Sha256, filepath.Join(targetPath, o.GetFilename()), nil)
 		if err != nil {
-			return err
+			return fmt.Errorf("while downloading %s, got error '%s'", fileURL, err.Error())
 		}
 	}
 

--- a/incus-osd/internal/providers/provider_operations_center.go
+++ b/incus-osd/internal/providers/provider_operations_center.go
@@ -518,7 +518,7 @@ func (a *operationsCenterApplication) Download(ctx context.Context, targetPath s
 		// Download the application.
 		err = downloadAsset(ctx, a.provider.client, file.url, file.Sha256, filepath.Join(targetPath, targetName), progressFunc)
 		if err != nil {
-			return err
+			return fmt.Errorf("while downloading %s, got error '%s'", file.url, err.Error())
 		}
 	}
 
@@ -564,7 +564,7 @@ func (o *operationsCenterOSUpdate) DownloadUpdate(ctx context.Context, targetPat
 		// Download the application.
 		err = downloadAsset(ctx, o.provider.client, file.url, file.Sha256, filepath.Join(targetPath, targetName), progressFunc)
 		if err != nil {
-			return err
+			return fmt.Errorf("while downloading %s, got error '%s'", file.url, err.Error())
 		}
 	}
 
@@ -637,7 +637,7 @@ func (o *operationsCenterSecureBootCertUpdate) Download(ctx context.Context, tar
 		// Download the application.
 		err = downloadAsset(ctx, o.provider.client, file.url, file.Sha256, filepath.Join(targetPath, o.GetFilename()), nil)
 		if err != nil {
-			return err
+			return fmt.Errorf("while downloading %s, got error '%s'", file.url, err.Error())
 		}
 	}
 


### PR DESCRIPTION
Partially addresses #526 by making the errors more informative to help track down where things go wrong.