### PR TITLE
If the incus-osd service fails, dump its journal entries to the console

### DIFF
--- a/mkosi.images/base/mkosi.extra/usr/lib/systemd/system/incus-osd.service
+++ b/mkosi.images/base/mkosi.extra/usr/lib/systemd/system/incus-osd.service
@@ -4,6 +4,7 @@ Documentation=https://github.com/lxc/incus-os/
 After=systemd-udevd.service
 Before=network-pre.target
 Wants=network-pre.target
+OnFailure=print-incus-osd-journal-errors.service
 
 [Service]
 ExecStart=/usr/local/bin/incus-osd

--- a/mkosi.images/base/mkosi.extra/usr/lib/systemd/system/print-incus-osd-journal-errors.service
+++ b/mkosi.images/base/mkosi.extra/usr/lib/systemd/system/print-incus-osd-journal-errors.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Print incus-osd journal errors
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+
+Environment=MSG="IncusOS failed to start. journal contents follow:"
+Environment=TTYS="/dev/tty1 /dev/ttyS0"
+
+ExecStart=/bin/sh -c "for TTY in $TTYS; do echo $MSG > $TTY || true; journalctl -b 0 -u incus-osd > $TTY || true; done"


### PR DESCRIPTION
This should help us debug start up issues caused by incus-osd crashing.