### PR TITLE
Include underlying error when we cannot read an EFI variable

### DIFF
--- a/incus-osd/internal/secureboot/efi_vars.go
+++ b/incus-osd/internal/secureboot/efi_vars.go
@@ -131,7 +131,7 @@ func UpdateSecureBootCerts(ctx context.Context, tarArchive string) (bool, error)
 func applySecureBootUpdates(ctx context.Context, varName string, newCerts map[string][]byte) (bool, error) {
 	existingCerts, err := GetCertificatesFromVar(varName)
 	if err != nil {
-		return false, fmt.Errorf("failed to read EFI variable '%s'", varName)
+		return false, fmt.Errorf("failed to read EFI variable %q: %w", varName, err)
 	}
 
 	for certFingerprint, certContents := range newCerts {


### PR DESCRIPTION
Will help debugging issues like #559.