### PR TITLE
Add script to show hardware information if IncusOS fails to start

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -49,5 +49,7 @@ KernelModulesInitrdInclude=default
                            vmd
 InitrdPackages=initrd-tmpfs-root
                kpartx
+               pciutils
+               usbutils
 RemoveFiles=/boot/*zabbly*
             /boot/EFI/mkosi.der

--- a/mkosi.packages/initrd-tmpfs-root/debian/initrd-tmpfs-root.install
+++ b/mkosi.packages/initrd-tmpfs-root/debian/initrd-tmpfs-root.install
@@ -5,4 +5,6 @@ initrd-tmpfs-root.service usr/lib/systemd/system/
 
 00-device-timeout.conf usr/lib/systemd/system.conf.d/
 
-initrd-message.service  usr/lib/systemd/system/
+initrd-message.service usr/lib/systemd/system/
+initrd-show-devices.service usr/lib/systemd/system/
+initrd-show-devices.sh usr/bin/

--- a/mkosi.packages/initrd-tmpfs-root/debian/initrd-tmpfs-root.links
+++ b/mkosi.packages/initrd-tmpfs-root/debian/initrd-tmpfs-root.links
@@ -1,1 +1,2 @@
 usr/lib/systemd/system/initrd-message.service usr/lib/systemd/system/veritysetup.target.wants/initrd-message.service
+usr/lib/systemd/system/initrd-show-devices.service usr/lib/systemd/system/emergency.target.wants/initrd-show-devices.service

--- a/mkosi.packages/initrd-tmpfs-root/initrd-show-devices.service
+++ b/mkosi.packages/initrd-tmpfs-root/initrd-show-devices.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Show system devices
+After=emergency.target
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+
+Environment=TTYS="/dev/tty1 /dev/ttyS0"
+
+ExecStart=/usr/bin/initrd-show-devices.sh
+
+[Install]
+WantedBy=emergency.target

--- a/mkosi.packages/initrd-tmpfs-root/initrd-show-devices.sh
+++ b/mkosi.packages/initrd-tmpfs-root/initrd-show-devices.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# shellcheck disable=SC3000-SC4000
+
+while true; do
+    for TTY in $TTYS; do
+        echo -e "\033cIncusOS failed to start. Debug information follows." > "$TTY" || true
+        echo "$ lsblk" > "$TTY" || true
+        lsblk > "$TTY" || true
+    done
+    sleep 10
+
+    for TTY in $TTYS; do
+        echo -e "\033cIncusOS failed to start. Debug information follows." > "$TTY" || true
+        echo "$ lscpi" > "$TTY" || true
+        lspci > "$TTY" || true
+    done
+    sleep 10
+
+    for TTY in $TTYS; do
+        echo -e "\033cIncusOS failed to start. Debug information follows." > "$TTY" || true
+        echo "$ lsusb" > "$TTY" || true
+        lsusb > "$TTY" || true
+    done
+    sleep 10
+
+    for TTY in $TTYS; do
+        echo -e "\033cIncusOS failed to start. Debug information follows." > "$TTY" || true
+        echo "$ ls -lh /sys/class/block/*/device/driver" > "$TTY" || true
+        ls -lh /sys/class/block/*/device/driver > "$TTY" || true
+    done
+    sleep 10
+done


### PR DESCRIPTION
If the initrd fails to properly boot and we reach the systemd `emergency.target`, trigger a script that will print information about the system's hardware that should help to debug things.

The script rotates between running `lsblk`, `lspci`, `lsusb`, and `ls -lh /sys/class/block/*/device/driver` with a ten second pause between. Hopefully that's long enough for people to easily screenshot/take a photo, while also not taking forever to cycle through the information.

<img width="2650" height="2001" alt="image" src="https://github.com/user-attachments/assets/e872b558-3986-4e76-be19-5647bf38c104" />

<img width="2650" height="2001" alt="image" src="https://github.com/user-attachments/assets/c591da67-8c33-44b9-ac09-47863fe22c43" />

Closes #583