### PR TITLE
base: Add FibreChannel controllers to early boot

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -38,11 +38,15 @@ KernelCommandLine=rw vt.handoff=1 iommu=pt intel_iommu=on amd_iommu=on quiet log
 KernelModulesInitrd=true
 KernelModulesInitrdExclude=.*
 KernelModulesInitrdInclude=default
-                           /hid.ko
+                           bfa
                            hid-generic
+                           /hid.ko
                            hv_storvsc
                            isofs
+                           lpfc
                            megaraid_sas
+                           mptfc
+                           qla2xxx
                            uas
                            usbhid
                            usb-storage


### PR DESCRIPTION
Rationale for those is that some folks have servers (mostly very dense blades) that boot from a SAN, so having FC early during boot is useful.