### PR TITLE
incus-osd/applications: Don't create Incus storage pool if "local" pool isn't present

### DIFF
--- a/incus-osd/internal/applications/app_incus.go
+++ b/incus-osd/internal/applications/app_incus.go
@@ -300,7 +300,7 @@ func (*incus) applyDefaults(ctx context.Context, c incusclient.InstanceServer) e
 	}
 
 	// Create storage pools.
-	if len(storagePools) == 0 && !storage.DatasetExists(ctx, "local/incus") {
+	if len(storagePools) == 0 && storage.PoolExists(ctx, "local") && !storage.DatasetExists(ctx, "local/incus") {
 		// Create the local pool.
 		err = c.CreateStoragePool(incusapi.StoragePoolsPost{
 			Name:   "local",


### PR DESCRIPTION
The "local" pool may not be present if it was configured as RAID1 and the system is performing first boot actions after a fresh reinstall. The pool will be recovered, but we no longer import it until the user can provide the required encryption key via API.