### PR TITLE
flasher-tool: migrate to Cobra and add flags

### DIFF
--- a/incus-osd/cmd/flasher-tool/utils.go
+++ b/incus-osd/cmd/flasher-tool/utils.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"strings"
+)
+
+// formatSection properly indents a text section.
+func formatSection(header string, content string) string {
+	var out strings.Builder
+
+	// Add section header
+	if header != "" {
+		_, _ = out.WriteString(header + ":\n")
+	}
+
+	// Indent the content
+	for line := range strings.SplitSeq(content, "\n") {
+		if line != "" {
+			_, _ = out.WriteString("  ")
+		}
+
+		_, _ = out.WriteString(line + "\n")
+	}
+
+	if header != "" {
+		// Section separator (when rendering a full section
+		_, _ = out.WriteString("\n")
+
+		return out.String()
+	}
+
+	// Remove last newline when rendering partial section
+	return strings.TrimSuffix(out.String(), "\n")
+}


### PR DESCRIPTION
Closes #473 

## Changes

- Migrate `flasher-tool` to use cobra 
- Convert environment variables to CLI flags:
  - `--image` / `-i` (replaces `INCUSOS_IMAGE`)
  - `--format` / `-f` (replaces `INCUSOS_IMAGE_FORMAT`)
  - `--seed` / `-s` (replaces `INCUSOS_SEED_TAR`)
- Add `--channel` / `-c` flag to select update channel (defaults to `stable`)
- Add `--version` / `-v` flag
- Add `--help` / `-h` flag

Signed-off-by: Leonardo Triiltz Siqueira <leotrilltz@gmail.com>