### PR TITLE
feat(image-customizer): select release channel

### DIFF
--- a/incus-osd/cmd/image-customizer/html/index.html
+++ b/incus-osd/cmd/image-customizer/html/index.html
@@ -202,30 +202,52 @@
 
                     <div id="panelAdvanced" class="accordion-collapse collapse">
                         <div class="accordion-body">
-                            <h3>Network configuration</h3>
+                            <div class="mb-3">
+                                <h3>Network configuration</h3>
 
-                            <p>
-                                By default IncusOS will run both DHCPv4
-                                and SLAAC on every interface it can find
-                                on the system, hoping that one of them
-                                will provide enough connectivity to
-                                allow the user to connect and apply the
-                                final network configuration.
-                            </p>
+                                <p>
+                                    By default IncusOS will run both DHCPv4
+                                    and SLAAC on every interface it can find
+                                    on the system, hoping that one of them
+                                    will provide enough connectivity to
+                                    allow the user to connect and apply the
+                                    final network configuration.
+                                </p>
 
-                            <p>
-                                For cases where this approach doesn't
-                                work, such as environments requiring
-                                static IP addresses, the use of a
-                                proxy server or using link aggregation
-                                or VLANs, a full network configuration
-                                can be provided instead.
-                            </p>
+                                <p>
+                                    For cases where this approach doesn't
+                                    work, such as environments requiring
+                                    static IP addresses, the use of a
+                                    proxy server or using link aggregation
+                                    or VLANs, a full network configuration
+                                    can be provided instead.
+                                </p>
 
-                            <p>Supported options and examples can be <a href="https://linuxcontainers.org/incus-os/docs/main/reference/system/network/" target="_blank">found here</a>.</p>
+                                <p>
+                                    Supported options and examples can be <a href="https://linuxcontainers.org/incus-os/docs/main/reference/system/network/" target="_blank">found here</a>.
+                                </p>
+
+                                <textarea class="form-control" id="networkConfiguration" rows="12" placeholder='{&#10;  "interfaces": [&#10;    {&#10;      "name": "management",&#10;      "hwaddr": "00:11:22:33:44:55",&#10;      "addresses": [&#10;        "dhcp4",&#10;        "slaac"&#10;      ]&#10;    }&#10;  ]&#10;}'></textarea>
+                            </div>
 
                             <div class="mb-3">
-                                <textarea class="form-control" id="networkConfiguration" rows="12" placeholder='{&#10;  "interfaces": [&#10;    {&#10;      "name": "management",&#10;      "hwaddr": "00:11:22:33:44:55",&#10;      "addresses": [&#10;        "dhcp4",&#10;        "slaac"&#10;      ]&#10;    }&#10;  ]&#10;}'></textarea>
+                                <h3>Alternative image channel</h3>
+
+                                <p>
+                                    Images are normally downloaded from
+                                    the "stable" update channel.<br>Other
+                                    channels may be available for various
+                                    reasons, for example for image
+                                    validation and testing ("testing" channel).
+                                </p>
+
+                                <p>
+                                    Only the "stable" channel is
+                                    supported, use other image channels
+                                    at your own risk.
+                                </p>
+
+                                <input type="text" class="form-control" id="imageChannel" placeholder="stable">
                             </div>
                         </div>
                     </div>
@@ -247,13 +269,12 @@
                     <div class="modal-body">
                         <p>
                             Three files have been generated and downloaded for you:
-                            <br>
-                            <ul>
-                                <li><code>client.crt</code> is a PEM encoded client certificate (can be placed as <code>~/.config/incus/client.crt</code>)</li>
-                                <li><code>client.key</code> is a PEM encoded client key (can be placed as <code>~/.config/incus/client.key</code>)</li>
-                                <li><code>client.pfx</code> is a PPKCS#12 certificate that can be imported in your web browser (password is <b>IncusOS</b>)</li>
-                            </ul>
                         </p>
+                        <ul>
+                           <li><code>client.crt</code> is a PEM encoded client certificate (can be placed as <code>~/.config/incus/client.crt</code>)</li>
+                           <li><code>client.key</code> is a PEM encoded client key (can be placed as <code>~/.config/incus/client.key</code>)</li>
+                           <li><code>client.pfx</code> is a PPKCS#12 certificate that can be imported in your web browser (password is <b>IncusOS</b>)</li>
+                        </ul>
                         <br>
                         <p>
                             <b>NOTE:</b> This certificate was generated server-side.

--- a/incus-osd/cmd/image-customizer/html/js/local.js
+++ b/incus-osd/cmd/image-customizer/html/js/local.js
@@ -85,6 +85,11 @@ function download() {
         return;
     }
 
+    // Validate release channel.
+    if (document.getElementById("imageChannel").value != "") {
+        req.channel = document.getElementById("imageChannel").value;
+    }
+
     // Validate client certificate.
     if (document.getElementById("applicationClientCertificate").value == "") {
         alert("Missing client certificate");

--- a/incus-osd/cmd/image-customizer/main.go
+++ b/incus-osd/cmd/image-customizer/main.go
@@ -65,6 +65,7 @@ type apiImagesPost struct {
 	Architecture string             `json:"architecture" yaml:"architecture"`
 	Type         string             `json:"type"         yaml:"type"`
 	Seeds        apiImagesPostSeeds `json:"seeds"        yaml:"seeds"`
+	Channel      string             `json:"channel"      yaml:"channel"`
 }
 
 type apiImagesPostSeeds struct {
@@ -295,6 +296,11 @@ func apiImages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Set default values.
+	if req.Channel == "" {
+		req.Channel = "stable"
+	}
+
 	// Store the request.
 	imagesMu.Lock()
 	defer imagesMu.Unlock()
@@ -313,7 +319,7 @@ func apiImages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("image request: created", "client", clientAddress(r), "type", req.Type, "architecture", req.Architecture)
+	slog.Info("image request: created", "client", clientAddress(r), "type", req.Type, "architecture", req.Architecture, "channel", req.Channel)
 }
 
 func apiImage(w http.ResponseWriter, r *http.Request) {
@@ -393,7 +399,7 @@ func apiImage(w http.ResponseWriter, r *http.Request) {
 	var imageFilePath string
 
 	for _, update := range metaIndex.Updates {
-		if !slices.Contains(update.Channels, "stable") {
+		if !slices.Contains(update.Channels, req.Channel) {
 			continue
 		}
 


### PR DESCRIPTION
Add a way to select between the `testing` and the `stable` release channel, while keeping the `stable` channel selected by default for the IncusOS image downloader: https://incusos-customizer.linuxcontainers.org/ui/

<img width="348" height="185" alt="image" src="https://github.com/user-attachments/assets/3c81530c-0d6b-4e86-8480-b70448ed41fe" />

(tested with `go run main.go "~/Downloads/incus"`)
