### PR TITLE
Handle invalid Secure Boot certificates

### DIFF
--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -1,3 +1,5 @@
+//go:debug x509negativeserial=1
+
 // Package main is used for the incus-osd daemon.
 package main
 


### PR DESCRIPTION
Make IncusOS more resilient to bad OEM Secure Boot certificates:
  * Allow negative serial numbers
  * Warn about RSA keys larger than 2048 bits
  * Warn about non-RSA keys

Ideally these invalid certificates could be purged from the system, but sometimes they are required for hardware to work.

<img width="2255" height="461" alt="image" src="https://github.com/user-attachments/assets/c6e7ebcb-7a3a-4c6c-8231-7847d6e766b3" />
