### PR TITLE
incus-osd: Pause 15 seconds when exiting with an error

### DIFF
--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -121,8 +121,8 @@ func main() {
 	if err != nil {
 		slog.ErrorContext(ctx, err.Error())
 
-		// Sleep for a second to allow output buffers to flush.
-		time.Sleep(1 * time.Second)
+		// Allow time for the error message to be read before the daemon restarts.
+		time.Sleep(15 * time.Second)
 
 		os.Exit(1)
 	}

--- a/incus-osd/internal/tui/tui.go
+++ b/incus-osd/internal/tui/tui.go
@@ -415,8 +415,8 @@ func EarlyError(msg string) {
 		_ = tview.NewApplication().SetScreen(screen).SetRoot(textView, true).Run()
 	}()
 
-	// Give the error a chance to render.
-	time.Sleep(1 * time.Second)
+	// Allow time for the error message to be read before the daemon restarts.
+	time.Sleep(15 * time.Second)
 }
 
 func getMachineInfo(r *api.Resources) string {


### PR DESCRIPTION
This should make reading error messages a bit easier before the `incus-osd` daemon restarts and clears the screen.