### PR TITLE
Adds initrd modules to support PERC H965i

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -46,8 +46,10 @@ KernelModulesInitrdInclude=default
                            isofs
                            lpfc
                            megaraid_sas
+                           mpi3mr
                            mptfc
                            qla2xxx
+                           scsi_transport_sas
                            tpm_vtpm_proxy
                            uas
                            usbhid


### PR DESCRIPTION
Adds module `mpi3mr` and its dependency, `scsci_transport_sas`, to support PERC H965i cards (used by Dell PowerEdge).

Signed-off-by: Gaël Donval <github.com@umessage.me>