### PR TITLE
incus-osd/state: Fix json tag in SuccessfulBoot

### DIFF
--- a/incus-osd/internal/state/struct.go
+++ b/incus-osd/internal/state/struct.go
@@ -21,7 +21,7 @@ type OS struct {
 	Name           string `json:"name"`
 	RunningRelease string `json:"running_release"`
 	NextRelease    string `json:"next_release"`
-	SuccessfulBoot bool   `jsno:"successful_boot"`
+	SuccessfulBoot bool   `json:"successful_boot"`
 }
 
 // State represents the on-disk persistent state.


### PR DESCRIPTION
Noticed what I believe is a typo in this JSON struct tag while working in another feature.
