### PR TITLE
incus-osd/install: Add `--graceful` flag to bootctl install

### DIFF
--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -595,7 +595,7 @@ func (i *Install) performInstall(ctx context.Context, modal *tui.Modal, sourceDe
 	}
 
 	// Finally, run `bootctl install`.
-	_, err = subprocess.RunCommandContext(ctx, "bootctl", "install")
+	_, err = subprocess.RunCommandContext(ctx, "bootctl", "--graceful", "install")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We've had a report of bootctl failing to properly write the LoaderSystemToken EFI variable when installing. Based on upstream systemd bug reports, this should be alright as affected systems should ignore the EFI variable error at the expense of not having a pre-boot random seed initialization.