### PR TITLE
incus-osd: Refactor GetStorageInfo to return only the state

### DIFF
--- a/incus-osd/internal/rest/api_system_storage.go
+++ b/incus-osd/internal/rest/api_system_storage.go
@@ -85,15 +85,17 @@ func (s *Server) apiSystemStorage(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodGet:
-		ret, err := storage.GetStorageInfo(r.Context())
+		info, err := storage.GetStorageInfo(r.Context())
 		if err != nil {
 			_ = response.InternalError(err).Render(w)
 
 			return
 		}
 
-		// Populate config with the current system config.
-		ret.Config = s.state.System.Storage.Config
+		ret := api.SystemStorage{
+			State:  info,
+			Config: s.state.System.Storage.Config,
+		}
 
 		// Return the current system storage state.
 		_ = response.SyncResponse(true, ret).Render(w)
@@ -101,20 +103,12 @@ func (s *Server) apiSystemStorage(w http.ResponseWriter, r *http.Request) {
 		// Ensure any state updates are persisted.
 		defer s.state.Save()
 
-		// Get the current configuration.
-		current, err := storage.GetStorageInfo(r.Context())
-		if err != nil {
-			_ = response.InternalError(err).Render(w)
-
-			return
-		}
-
 		// Read the new config.
 		storageStruct := &api.SystemStorage{}
 
 		counter := &countWrapper{ReadCloser: r.Body}
 
-		err = json.NewDecoder(counter).Decode(storageStruct)
+		err := json.NewDecoder(counter).Decode(storageStruct)
 		if err != nil && counter.n > 0 {
 			_ = response.BadRequest(err).Render(w)
 
@@ -140,13 +134,7 @@ func (s *Server) apiSystemStorage(w http.ResponseWriter, r *http.Request) {
 
 		// Create or update a pool.
 		if len(storageStruct.Config.Pools) == 0 {
-			if len(current.Config.Pools) == 0 {
-				_ = response.EmptySyncResponse.Render(w)
-
-				return
-			}
-
-			_ = response.BadRequest(errors.New("no pool configuration provided")).Render(w)
+			_ = response.EmptySyncResponse.Render(w)
 
 			return
 		}

--- a/incus-osd/internal/storage/storage.go
+++ b/incus-osd/internal/storage/storage.go
@@ -503,8 +503,8 @@ func calculateScrubProgress(stats zpoolScanStats) string {
 }
 
 // GetStorageInfo returns current SMART data for each drive and the status of each local zpool.
-func GetStorageInfo(ctx context.Context) (api.SystemStorage, error) {
-	ret := api.SystemStorage{}
+func GetStorageInfo(ctx context.Context) (api.SystemStorageState, error) {
+	ret := api.SystemStorageState{}
 
 	type zpoolStatusRaw struct {
 		Pools map[string]json.RawMessage `json:"pools"`
@@ -530,7 +530,7 @@ func GetStorageInfo(ctx context.Context) (api.SystemStorage, error) {
 			return ret, err
 		}
 
-		ret.State.Pools = append(ret.State.Pools, poolConfig)
+		ret.Pools = append(ret.Pools, poolConfig)
 	}
 
 	// Get a list of all local drives.
@@ -672,7 +672,7 @@ func GetStorageInfo(ctx context.Context) (api.SystemStorage, error) {
 			smartStatus = nil
 		}
 
-		ret.State.Drives = append(ret.State.Drives, api.SystemStorageDrive{
+		ret.Drives = append(ret.Drives, api.SystemStorageDrive{
 			ID:              deviceID,
 			ModelFamily:     modelFamily,
 			ModelName:       modelName,
@@ -690,7 +690,7 @@ func GetStorageInfo(ctx context.Context) (api.SystemStorage, error) {
 
 	// Sort the list of returned drives by the device's ID. This ensures a
 	// consistent ordering, which is useful for some tests.
-	slices.SortFunc(ret.State.Drives, func(a, b api.SystemStorageDrive) int {
+	slices.SortFunc(ret.Drives, func(a, b api.SystemStorageDrive) int {
 		return strings.Compare(a.ID, b.ID)
 	})
 
@@ -797,7 +797,7 @@ func WipeDrive(ctx context.Context, drive string) error {
 		return err
 	}
 
-	for _, d := range drives.State.Drives {
+	for _, d := range drives.Drives {
 		if d.ID == drive {
 			if d.Boot {
 				return errors.New("cannot wipe boot drive")

--- a/incus-osd/internal/zfs/zfs.go
+++ b/incus-osd/internal/zfs/zfs.go
@@ -852,7 +852,7 @@ func ScrubZpool(ctx context.Context, poolName string) error {
 
 	pool := api.SystemStoragePool{}
 
-	for _, p := range info.State.Pools {
+	for _, p := range info.Pools {
 		if p.Name == poolName {
 			pool = p
 		}
@@ -879,7 +879,7 @@ func ScrubAllPools(ctx context.Context) error {
 	}
 
 	// Scrub every pool sequentially.
-	for _, pool := range info.State.Pools {
+	for _, pool := range info.Pools {
 		slog.InfoContext(ctx, "Scrubbing pool", slog.String("pool", pool.Name))
 
 		// If a scrub is already in progress for a pool, skip it.
@@ -902,7 +902,7 @@ func ScrubAllPools(ctx context.Context) error {
 
 			latestPoolInfo := api.SystemStoragePool{}
 
-			for _, p := range latestInfo.State.Pools {
+			for _, p := range latestInfo.Pools {
 				if p.Name == pool.Name {
 					latestPoolInfo = p
 				}


### PR DESCRIPTION
# Description

As discussed in [this comment](https://github.com/lxc/incus-os/pull/739#discussion_r2659104977), the `storage.GetStorageInfo` should return `storage.SystemStorageState` instead of `storage.SystemStorage`.

I've done the changes in a single commit to keep the refactoring atomic. If it is required, I can split the changes in a set of commits per package while making sure all of them compile.

This should be a pure refactor: no changes in external behavior.