### PR TITLE
base: Blacklist nvidiafb kernel module

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -34,7 +34,7 @@ Bootable=true
 BaseTrees=%O/base
 UnifiedKernelImages=true
 UnifiedKernelImageFormat=%i_%v
-KernelCommandLine=rw vt.handoff=1 iommu=pt intel_iommu=on amd_iommu=on quiet loglevel=0 systemd.show_status=0 rootflags=noexec,nodev,nosuid rd.systemd.mount-extra=/dev/disk/by-partlabel/esp:/boot:vfat:rw
+KernelCommandLine=rw vt.handoff=1 iommu=pt intel_iommu=on amd_iommu=on quiet loglevel=0 systemd.show_status=0 rootflags=noexec,nodev,nosuid rd.systemd.mount-extra=/dev/disk/by-partlabel/esp:/boot:vfat:rw modprobe.blacklist=nvidiafb
 KernelModulesInitrd=true
 KernelModulesInitrdExclude=.*
 KernelModulesInitrdInclude=default


### PR DESCRIPTION
On a physical machine with an old Nvidia GeForce GTX 670 graphics card, the kernel boot process hangs after the following line is printed by the kernel:

    nvidiafb: Device ID: 10de1189

This is after the IncusOS boot message is displayed, but before systemd can begin executing so the system will hang forever. We've seen at least [one other similar bug report](https://discuss.linuxcontainers.org/t/incusos-got-stuck-while-trying-to-install/25430/5) on the community forum regarding a hung boot with an old Nvidia GPU.

I'm not sure what's attempting to load this module, as it's not included in the initrd. To work around this issue, let's blacklist the module on the kernel command line. Since we won't want GPU drivers loaded anyways if the GPU is passed through to a VM, I don't think the blacklisting should cause any other issues.

I did try adding the blacklist to the initrd's /etc/modprobe.d/ since that would be a cleaner approach, but it didn't work for some reason.