### PR TITLE
incus-osd/tests: Run tests in parallel

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -14,8 +14,8 @@ jobs:
     timeout-minutes: 600
     runs-on:
       - self-hosted
-      - cpu-4
-      - mem-8G
+      - cpu-8
+      - mem-32G
       - disk-100G
       - arch-amd64
       - image-debian-13

--- a/incus-osd/tests/api-tests.py
+++ b/incus-osd/tests/api-tests.py
@@ -70,7 +70,7 @@ num_pass = 0
 num_fail = 0
 
 # Run the tests
-with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
     tests = IncusOSTests(prior_image_img, current_image_img, current_image_iso)
     futures = {executor.submit(fn, image): name for name,fn,image in tests.GetTests()}
 


### PR DESCRIPTION
Now that we've got faster hardware, let's try running the daily tests in parallel so the job doesn't take so long to finish.