### PR TITLE
incus-osd/recovery: Fix handling on first system boot

### DIFF
--- a/incus-osd/internal/recovery/recovery.go
+++ b/incus-osd/internal/recovery/recovery.go
@@ -66,6 +66,13 @@ func CheckRunRecovery(ctx context.Context, s *state.State) error {
 	}
 	defer unix.Unmount(mountDir, 0)
 
+	// Workaround for recovery running on first boot when no provider has been set yet.
+	if s.System.Provider.Config.Name == "" {
+		s.System.Provider.Config.Name = "images"
+
+		defer func() { s.System.Provider.Config.Name = "" }()
+	}
+
 	// Get the expected CA certificate to validate the update metadata.
 	p, err := providers.Load(ctx, s)
 	if err != nil {


### PR DESCRIPTION
When using the recovery logic to bootstrap an offline system, we'll have the logic be run prior to the providers config having been applied.

In such a situation, assume the images provider as that will provide us with a signing key, then revert back to empty afterwards to allow the normal first boot logic to perform the configuration.