### PR TITLE
github/workflows/daily: Increase CPU and disk limits

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -15,9 +15,9 @@ jobs:
     timeout-minutes: 600
     runs-on:
       - self-hosted
-      - cpu-8
+      - cpu-16
       - mem-32G
-      - disk-100G
+      - disk-200G
       - arch-amd64
       - image-debian-13
     steps:


### PR DESCRIPTION
The daily tests seem to still be struggling to run in parallel, so let's see if bumping the CPU and disk limits helps.