### PR TITLE
Clarify the expected WWN format.

### DIFF
--- a/doc/reference/services/multipath.md
+++ b/doc/reference/services/multipath.md
@@ -10,4 +10,4 @@ The following configuration options can be set:
 
 * `enabled`: If `true`, enable the Multipath service.
 
-* `wwns`: An array of {abbr}`WWN (World Wide Name)`s to configure for multipath.
+* `wwns`: An array of storage device {abbr}`WWN (World Wide Name)`s to configure for multipath. These should be lowercase hexadecimal strings with no colon separators and are typically prefixed with a `3`. The correct format is seen in the output of `incus admin os system storage show` under the `id` field, for example `/dev/disk/by-id/scsi-<wwn>`.


### PR DESCRIPTION
From testing, `multipath` will only detect the provided WWN values if they match exactly with the `/dev/disk/by-id/scsi-abc` device names.

For example, to multipath this device:
- `/dev/disk/by-id/scsi-350014ee20ce3848a`

The config should look like:
```
enabled: true
wwns:
  - 350014ee20ce3848a
```


