### PR TITLE
incus-osd/providers: Use the Root CA to verifiy update metadata

### DIFF
--- a/incus-osd/internal/providers/structs.go
+++ b/incus-osd/internal/providers/structs.go
@@ -82,7 +82,7 @@ func GetUpdateCACert() (string, error) {
 
 	err = pem.Encode(&b, &pem.Block{
 		Type:  "CERTIFICATE",
-		Bytes: embeddedCerts.UpdateCACertificate.Raw,
+		Bytes: embeddedCerts.RootCACertificate.Raw,
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
At the moment we're signing the json files with the Root CA, not the Update CA.

This restores the expected certificate prior to the changes in #858 (https://github.com/lxc/incus-os/pull/858/changes#diff-ef78a2dbb87cdf1ede8cf32a54781e9b3540b32de439a29f600d6780c500ec4bL127-L138)