### PR TITLE
Ignore SHA256 hashes in EFI signature lists

### DIFF
--- a/incus-osd/internal/secureboot/certificates.go
+++ b/incus-osd/internal/secureboot/certificates.go
@@ -92,7 +92,7 @@ func parseEfiSignatureList(b []byte) ([]parsedSignatureList, error) {
 				sigOffset += signatures.Header.SignatureSize
 			}
 		default:
-			err = fmt.Errorf("unhandled signature type %s", signatureType)
+			err = fmt.Errorf("unhandled signature EFI_GUID type '%x-%x-%x-%x-%x'", signatureType[:4], signatureType[4:6], signatureType[6:8], signatureType[8:10], signatureType[10:])
 		}
 
 		if err != nil {


### PR DESCRIPTION
#839 copied and tweaked library code used to parse EFI signature lists. We've encountered existing systems that seem to have SHA256 hashes pre-enrolled in their `dbx` EFI variable, which is now raising an error. Add back the bit of logic that parses such hashes to restore the prior behavior. It probably isn't quite right to just ignore the hashes; see #870 to track correcting that before we really start rolling out annual certificate revocations.