### PR TITLE
incus-osd: Tweak GetPrimary logic

### DIFF
--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -719,7 +719,7 @@ func updateChecker(ctx context.Context, s *state.State, t *tui.TUI, p providers.
 
 	for {
 		// Determine if a primary application is installed or not.
-		primaryApplication, err := applications.GetPrimary(ctx, s)
+		primaryApplication, err := applications.GetPrimary(ctx, s, false)
 		if err != nil && !errors.Is(err, applications.ErrNoPrimary) {
 			s.System.Update.State.Status = "Failed to check if a primary application is installed"
 			slog.ErrorContext(ctx, s.System.Update.State.Status, "err", err.Error())

--- a/incus-osd/internal/applications/load.go
+++ b/incus-osd/internal/applications/load.go
@@ -36,11 +36,11 @@ func Load(_ context.Context, s *state.State, name string) (Application, error) {
 	return app, nil
 }
 
-// GetPrimary returns the current primary application once initialized.
-func GetPrimary(ctx context.Context, s *state.State) (Application, error) {
+// GetPrimary returns the current primary application (optionally checking if initialized).
+func GetPrimary(ctx context.Context, s *state.State, requireInitialized bool) (Application, error) {
 	for appName, v := range s.Applications {
 		// Skip uninitialized applications.
-		if !v.State.Initialized {
+		if requireInitialized && !v.State.Initialized {
 			continue
 		}
 

--- a/incus-osd/internal/providers/provider_operations_center.go
+++ b/incus-osd/internal/providers/provider_operations_center.go
@@ -159,14 +159,14 @@ func (p *operationsCenter) Register(ctx context.Context, _ bool) error {
 		return err
 	}
 
-	// Get the primary application.
-	app, err := applications.GetPrimary(ctx, p.state)
-	if err != nil {
-		return err
-	}
-
 	// Get the server certificate.
 	if registrationResp.Certificate != "" {
+		// Get the primary application.
+		app, err := applications.GetPrimary(ctx, p.state, true)
+		if err != nil {
+			return err
+		}
+
 		err = app.AddTrustedCertificate(ctx, p.serverURL, registrationResp.Certificate)
 		if err != nil {
 			return err
@@ -287,7 +287,7 @@ func (p *operationsCenter) load(ctx context.Context) error {
 	p.serverToken = p.state.System.Provider.Config.Config["server_token"]
 
 	// Check if we're running Operations Center locally.
-	app, err := applications.GetPrimary(ctx, p.state)
+	app, err := applications.GetPrimary(ctx, p.state, false)
 	if err != nil && !errors.Is(err, applications.ErrNoPrimary) {
 		return err
 	}
@@ -370,7 +370,7 @@ func (p *operationsCenter) loadTLS(ctx context.Context) error {
 
 func (p *operationsCenter) configureClientCertificate(ctx context.Context, tlsConfig *tls.Config) error {
 	// Get the primary application.
-	app, err := applications.GetPrimary(ctx, p.state)
+	app, err := applications.GetPrimary(ctx, p.state, true)
 	if err != nil {
 		if errors.Is(err, applications.ErrNoPrimary) {
 			// Don't try to setup the TLS client certificate if no primary application installed yet.


### PR DESCRIPTION
This allows selectively requiring an initialized primary application.