### PR TITLE
Enable Intel NPU Support as Part of the GPU Support Application

### DIFF
--- a/app-build/applications.json
+++ b/app-build/applications.json
@@ -83,6 +83,10 @@
                 "usr/lib/firmware/"
             ],
             [
+                "intel/vpu",
+                "usr/lib/firmware/intel/"
+            ],
+            [
                 "nvidia",
                 "usr/lib/firmware/"
             ],
@@ -94,6 +98,7 @@
         "clean_targets": [
             "usr/lib/firmware/amdgpu",
             "usr/lib/firmware/i915",
+            "usr/lib/firmware/intel/vpu",
             "usr/lib/firmware/nvidia",
             "usr/lib/firmware/xe"
         ]

--- a/incus-osd/internal/applications/app_gpu_support.go
+++ b/incus-osd/internal/applications/app_gpu_support.go
@@ -25,7 +25,7 @@ func (*gpuSupport) IsRunning(_ context.Context) bool {
 
 func (*gpuSupport) Start(ctx context.Context, _ string) error {
 	// Reload the modules if loaded.
-	for _, module := range []string{"amdgpu", "i915", "nouveau", "xe"} {
+	for _, module := range []string{"amdgpu", "i915", "intel_vpu", "nouveau", "xe"} {
 		// Check if loaded.
 		_, err := os.Stat("/sys/module/" + module)
 		if err != nil {


### PR DESCRIPTION
Include intel_vpu driver/firmware as part of the gpu-support application, which is neccessary for the Intel NPU to work.

This driver/firmware is technically not required for the iGPU to work, however this application provides all the required infrastructure and is related to hardware acceleration.