### PR TITLE
Fix applying multiple OS updates between reboots when Secure Boot is disabled

### DIFF
--- a/incus-osd/internal/systemd/sysupdate.go
+++ b/incus-osd/internal/systemd/sysupdate.go
@@ -172,7 +172,7 @@ func ApplySystemUpdate(ctx context.Context, luksPassword string, version string,
 		}
 	} else if !sbEnabled {
 		// If Secure Boot is disabled, we always must update the PCR4 bindings for the new UKI.
-		err := secureboot.UpdatePCR4Binding(ctx, newUKIFile)
+		err := secureboot.UpdatePCR4Binding(ctx, luksPassword, newUKIFile)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When Secure Boot is disabled, we bind LUKS encryption to PCR4+7, and had been depending on the TPM to automatically unlock the LUKS headers. This works fine, until a second OS update is applied on top of a pending one. At that point, the TPM state could no longer unlock the disks and we returned a TPM rebind error. But that resulted in a confusing state where doing so would reboot the system into the pending OS update, but the TPM bindings would have been reset to the prior version. It's possible to recover from this by either entering a recovery passphrase or rebooting into the older version of IncusOS, but neither is ideal.

Instead, rely on an existing encryption recovery passphrase when updating the PCR4+7 encryption bindings. Now we can apply multiple OS updates between reboots and the system will correctly unlock the LUKS volumes as expected.