### PR TITLE
Tweak reported device IDs for LVM members to return a nicer ID

### DIFF
--- a/incus-osd/internal/storage/storage.go
+++ b/incus-osd/internal/storage/storage.go
@@ -265,6 +265,11 @@ func DeviceToID(ctx context.Context, device string) (string, error) {
 	slices.Sort(candidates)
 
 	for _, dev := range candidates {
+		// For LVM devices, skip the uglier UUID symlink in favor of a human-readable one that should include drive's the serial number.
+		if strings.HasPrefix(dev, "disk/by-id/lvm-pv-uuid-") {
+			continue
+		}
+
 		if strings.HasPrefix(dev, "disk/by-id/") {
 			dev = strings.TrimSuffix(dev, "\n")
 


### PR DESCRIPTION
Devices in use by LVM have multiple symlinks that point to the underlying device. Rather than returning the UUID, which sorts first, skip over that option and return the nicer symlink in the storage API.

```
disk/by-id/lvm-pv-uuid-H5uYDc-3i1O-Fa7g-wckB-JQAl-8Z9E-VF8kHs
disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
```

Closes #902