### PR TITLE
github/workflows/daily: Pass DEBIAN_FRONTEND environment variable through sudo

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           sudo apt-get install --yes \
             linux-headers-$(uname -r)
-          sudo apt-get install --yes \
+          sudo --preserve-env=DEBIAN_FRONTEND apt-get install --yes \
             dosfstools \
             gdisk \
             genisoimage \


### PR DESCRIPTION
Maybe we don't actually need `sudo` in the CI test environment, but I like having it for commands that normally would require root privileges.