### PR TITLE
base: Tweak IOMMU kernel boot parameters

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -34,7 +34,7 @@ Bootable=true
 BaseTrees=%O/base
 UnifiedKernelImages=true
 UnifiedKernelImageFormat=%i_%v
-KernelCommandLine=rw vt.handoff=1 iommu=pt intel_iommu=on amd_iommu=on quiet loglevel=0 systemd.show_status=0 rootflags=noexec,nodev,nosuid rd.systemd.mount-extra=/dev/disk/by-partlabel/esp:/boot:vfat:rw modprobe.blacklist=nvidiafb
+KernelCommandLine=rw vt.handoff=1 intel_iommu=on quiet loglevel=0 systemd.show_status=0 rootflags=noexec,nodev,nosuid rd.systemd.mount-extra=/dev/disk/by-partlabel/esp:/boot:vfat:rw modprobe.blacklist=nvidiafb
 KernelModulesInitrd=true
 KernelModulesInitrdExclude=.*
 KernelModulesInitrdInclude=default


### PR DESCRIPTION
iommu=pt is meant as a workaround for buggy systems/devices. It has the annoying side-effect of breaking some features like AMD SNP.

amd_iommu=on is not required as AMD IOMMU is always automatically on when supported. This is however still needed on Intel platforms, so let's keep intel_iommu=on.