### PR TITLE
incus-osd/tests: Limit daily tests to two parallel tests

### DIFF
--- a/incus-osd/tests/api-tests.py
+++ b/incus-osd/tests/api-tests.py
@@ -70,7 +70,7 @@ num_pass = 0
 num_fail = 0
 
 # Run the tests
-with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
     tests = IncusOSTests(prior_image_img, current_image_img, current_image_iso)
     futures = {executor.submit(fn, image): name for name,fn,image in tests.GetTests()}
 


### PR DESCRIPTION
We're still pretty consistently failing in the daily the CI runner with errors of "timed out waiting for agent to start". Restrict the tests to only running two in parallel.