### PR TITLE
Fix SecureBoot tests

### DIFF
--- a/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
+++ b/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
@@ -86,7 +86,7 @@ class IncusTestVM:
         else:
             subprocess.run(["incus", "stop", self.vm_name], capture_output=True, check=True, timeout=timeout)
 
-    def WaitSystemReady(self, incusos_version, source="/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0", target="/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root", application="incus", remove_devices=[], agent_timeout=300):
+    def WaitSystemReady(self, incusos_version, source="/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0", target="/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root", application="incus", remove_devices=[], agent_timeout=300, secureboot_disabled=False):
         """Wait for the system install to complete, the given application to be configured and the system become ready for use."""
 
         # Perform IncusOS install.
@@ -106,7 +106,8 @@ class IncusTestVM:
         self.StartVM()
         self.WaitAgentRunning(agent_timeout)
         self.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
-        self.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
+        if not secureboot_disabled:
+            self.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
         self.WaitExpectedLog("incus-osd", "Downloading application update application="+application+" version="+incusos_version)
         self.WaitExpectedLog("incus-osd", "System is ready version="+incusos_version)
 

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_reset.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_reset.py
@@ -123,7 +123,7 @@ def TestIncusOSAPISystemResetSecureBootDisabled(install_image):
     util._remove_secureboot_keys(test_image)
 
     with IncusTestVM(test_name, test_image) as vm:
-        vm.WaitSystemReady(incusos_version)
+        vm.WaitSystemReady(incusos_version, secureboot_disabled=True)
 
         # Should see a log message about SecureBoot being disabled
         vm.WaitExpectedLog("incus-osd", "Degraded security state: Secure Boot is disabled")
@@ -138,7 +138,6 @@ def TestIncusOSAPISystemResetSecureBootDisabled(install_image):
         # Wait for the system to come back up.
         vm.WaitAgentRunning()
         vm.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
-        vm.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
         vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+incusos_version)
         vm.WaitExpectedLog("incus-osd", "System is ready version="+incusos_version)
 
@@ -158,7 +157,7 @@ def TestIncusOSAPISystemResetSecureBootDisabledToSB(install_image):
         util._remove_secureboot_keys(test_image)
 
         with IncusTestVM(test_name, test_image) as vm:
-            vm.WaitSystemReady(incusos_version)
+            vm.WaitSystemReady(incusos_version, secureboot_disabled=True)
 
             # Should see a log message about SecureBoot being disabled
             vm.WaitExpectedLog("incus-osd", "Degraded security state: Secure Boot is disabled")

--- a/incus-osd/tests/incusos_tests/tests_incusos_live.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_live.py
@@ -114,7 +114,6 @@ def TestIncusOSLiveNoSecureBoot(install_image):
         vm.StartVM()
         vm.WaitAgentRunning()
         vm.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
-        vm.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
         vm.WaitExpectedLog("incus-osd", "Degraded security state: Secure Boot is disabled")
         vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+incusos_version)
         vm.WaitExpectedLog("incus-osd", "System is ready version="+incusos_version)

--- a/incus-osd/tests/incusos_tests/tests_install_secureboot_disabled.py
+++ b/incus-osd/tests/incusos_tests/tests_install_secureboot_disabled.py
@@ -12,7 +12,7 @@ def TestInstallSecureBootDisabled(install_image):
     util._remove_secureboot_keys(test_image)
 
     with IncusTestVM(test_name, test_image) as vm:
-        vm.WaitSystemReady(incusos_version)
+        vm.WaitSystemReady(incusos_version, secureboot_disabled=True)
 
         # Should see a log message about SecureBoot being disabled
         vm.WaitExpectedLog("incus-osd", "Degraded security state: Secure Boot is disabled")


### PR DESCRIPTION
With SecureBoot disabled, we don't see the upgrading PCR message. This is because PCR15 is already bound when the PCR4+7 rebind happens immediately after generation of the recovery key.