### PR TITLE
Handle missing degraded storage devices

### DIFF
--- a/incus-osd/internal/zfs/zfs.go
+++ b/incus-osd/internal/zfs/zfs.go
@@ -496,7 +496,13 @@ func DestroyZpool(ctx context.Context, zpoolName string) error {
 // Helper method to zap any GPT table and opportunistically run blkdiscard
 // to fully wipe a device that's just been removed from a storage pool.
 func clearDevice(ctx context.Context, device string) error {
-	_, err := subprocess.RunCommandContext(ctx, "sgdisk", "-Z", device)
+	_, err := os.Stat(device)
+	if err != nil && os.IsNotExist(err) {
+		// Nothing to do if the device doesn't exist.
+		return nil
+	}
+
+	_, err = subprocess.RunCommandContext(ctx, "sgdisk", "-Z", device)
 	if err != nil {
 		return err
 	}

--- a/incus-osd/internal/zfs/zfs.go
+++ b/incus-osd/internal/zfs/zfs.go
@@ -595,7 +595,7 @@ func UpdateZpool(ctx context.Context, newConfig api.SystemStoragePool) error {
 		}
 	} else {
 		// Perform a normal update of the zpool's storage device(s).
-		err := updateZpoolHelper(ctx, newConfig.Name, newConfig.Type, currentConfig.Devices, newConfig.Devices)
+		err := updateZpoolHelper(ctx, newConfig.Name, newConfig.Type, currentConfig.Devices, currentConfig.DevicesDegraded, newConfig.Devices)
 		if err != nil {
 			return err
 		}
@@ -606,18 +606,18 @@ func UpdateZpool(ctx context.Context, newConfig api.SystemStoragePool) error {
 		logType = "zfs-raid1"
 	}
 
-	err = updateZpoolHelper(ctx, newConfig.Name, logType, currentConfig.Log, newConfig.Log)
+	err = updateZpoolHelper(ctx, newConfig.Name, logType, currentConfig.Log, currentConfig.LogDegraded, newConfig.Log)
 	if err != nil {
 		return err
 	}
 
-	err = updateZpoolHelper(ctx, newConfig.Name, "zfs-raid0", currentConfig.Cache, newConfig.Cache)
+	err = updateZpoolHelper(ctx, newConfig.Name, "zfs-raid0", currentConfig.Cache, currentConfig.CacheDegraded, newConfig.Cache)
 	if err != nil {
 		return err
 	}
 
 	if newConfig.Special != nil {
-		err := updateZpoolHelper(ctx, newConfig.Name, newConfig.Special.Type, currentConfig.Special.Devices, newConfig.Special.Devices)
+		err := updateZpoolHelper(ctx, newConfig.Name, newConfig.Special.Type, currentConfig.Special.Devices, currentConfig.SpecialDegraded, newConfig.Special.Devices)
 		if err != nil {
 			return err
 		}
@@ -687,8 +687,29 @@ func partitionLocalPoolDevice(ctx context.Context, device string) (string, error
 	return device + "-part11", nil
 }
 
-func updateZpoolHelper(ctx context.Context, zpoolName string, zpoolType string, currentDevices []string, newDevices []string) error {
-	// Compare the two lists of devices and apply updates as needed.
+func updateZpoolHelper(ctx context.Context, zpoolName string, zpoolType string, currentDevices []string, degradedDevices []string, newDevices []string) error {
+	// Iterate over each degraded device. If the device itself is missing, this likely means
+	// it was a failed drive that's already been physically removed. As such, it won't show up
+	// in the storage API, but will still be recorded as part of the zpool. An end user will
+	// intuitively attempt to replace the degraded device with a new one by adding another
+	// existing drive to the zpool's configuration, which will result in an extra new device
+	// here. Rather than using it to expand the zpool, which would still be degraded, instead
+	// attempt to automatically replace the existing degraded device with the new one.
+	for _, degradedDevice := range degradedDevices {
+		// If no more extra devices are available, break out of the loop.
+		if len(currentDevices) >= len(newDevices) {
+			break
+		}
+
+		_, err := os.Stat(degradedDevice)
+		if err != nil && os.IsNotExist(err) {
+			// Add the missing degraded device to the list of current devices.
+			// This will trigger a replace in the logic below.
+			currentDevices = append(currentDevices, degradedDevice)
+		}
+	}
+
+	// Compare the list of current devices to the list of new devices and apply updates as needed.
 	for idx := range currentDevices {
 		if newDevices[idx] == "" { //nolint:nestif
 			// The update contains an empty string for this device -> remove from the pool.
@@ -744,7 +765,7 @@ func updateZpoolHelper(ctx context.Context, zpoolName string, zpoolType string, 
 		}
 	}
 
-	// Add any additional new devices.
+	// Add any remaining new devices to the zpool.
 	devicesToAdd := newDevices[len(currentDevices):]
 
 	if len(devicesToAdd) == 0 {

--- a/incus-osd/internal/zfs/zfs.go
+++ b/incus-osd/internal/zfs/zfs.go
@@ -649,28 +649,36 @@ func convertPoolToMirror(ctx context.Context, currentConfig api.SystemStoragePoo
 		}
 	}
 
-	// The "local" zpool is special. It is automatically created on first boot, but
-	// can be extended into a RAID0 or RAID1 configuration by adding another drive.
-	// When converting to RAID1, we attempt to partition the second device in a similar
-	// fashion so the two underlying devices are the same size.
 	if newConfig.Name == "local" {
-		// Create the partition at the correct offset
-		_, err = subprocess.RunCommandContext(ctx, "sgdisk", "-n", "11:69826560:", newPoolDevice)
+		newPoolDevice, err = partitionLocalPoolDevice(ctx, newPoolDevice)
 		if err != nil {
 			return err
 		}
-
-		newPoolDevice += "-part11"
-
-		// Sleep for a bit, otherwise there's a race between udev updating symlinks and
-		// ZFS trying to add the device to the pool.
-		time.Sleep(500 * time.Millisecond)
 	}
 
 	// Convert the pool to a mirror.
 	_, err = subprocess.RunCommandContext(ctx, "zpool", "attach", newConfig.Name, existingPoolDevice, newPoolDevice)
 
 	return err
+}
+
+// The "local" zpool is special. It is automatically created on first boot, but
+// can be extended into a RAID0 or RAID1 configuration by adding another drive.
+// When adding or replacing a device in this pool after converting to RAID1, we
+// attempt to partition the second device in a similar fashion so the two underlying
+// devices are the same size.
+func partitionLocalPoolDevice(ctx context.Context, device string) (string, error) {
+	// Create the partition at the correct offset
+	_, err := subprocess.RunCommandContext(ctx, "sgdisk", "-n", "11:69826560:", device)
+	if err != nil {
+		return "", err
+	}
+
+	// Sleep for a bit, otherwise there's a race between udev updating symlinks and
+	// ZFS trying to add the device to the pool.
+	time.Sleep(500 * time.Millisecond)
+
+	return device + "-part11", nil
 }
 
 func updateZpoolHelper(ctx context.Context, zpoolName string, zpoolType string, currentDevices []string, newDevices []string) error {
@@ -711,23 +719,11 @@ func updateZpoolHelper(ctx context.Context, zpoolName string, zpoolType string, 
 				return err
 			}
 
-			// The "local" zpool is special. It is automatically created on first boot, but
-			// can be extended into a RAID0 or RAID1 configuration by adding another drive.
-			// When replacing a device after converting to RAID1, we attempt to partition
-			// the second device in a similar fashion so the two underlying devices are the
-			// same size.
 			if zpoolName == "local" && zpoolType == "zfs-raid1" {
-				// Create the partition at the correct offset
-				_, err = subprocess.RunCommandContext(ctx, "sgdisk", "-n", "11:69826560:", actualDevNew)
+				actualDevNew, err = partitionLocalPoolDevice(ctx, actualDevNew)
 				if err != nil {
 					return err
 				}
-
-				actualDevNew += "-part11"
-
-				// Sleep for a bit, otherwise there's a race between udev updating symlinks and
-				// ZFS trying to add the device to the pool.
-				time.Sleep(500 * time.Millisecond)
 			}
 
 			_, err = subprocess.RunCommandContext(ctx, "zpool", "replace", zpoolName, actualDevOld, actualDevNew)

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_storage_local_pool.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_storage_local_pool.py
@@ -482,3 +482,114 @@ def TestIncusOSAPISystemStorageLocalPoolScrubSchedule(install_image):
 
         if result["metadata"]["config"]["scrub_schedule"] != "0 0 * * 5":
             raise IncusOSException("expected scrub schedule to be updated")
+
+def TestIncusOSAPISystemStorageLocalPoolDegraded(install_image):
+    test_name = "incusos-api-system-storage-local-pool-degraded"
+    test_seed = {
+        "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}""",
+    }
+
+    test_image, incusos_version = util._prepare_test_image(install_image, test_seed)
+
+    with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk1_img:
+        with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk2_img:
+            disk1_img.truncate(50*1024*1024*1024)
+            disk2_img.truncate(50*1024*1024*1024)
+
+            with IncusTestVM(test_name, test_image) as vm:
+                vm.AddDevice("disk1", "disk", "source="+disk1_img.name)
+                vm.AddDevice("disk2", "disk", "source="+disk2_img.name)
+
+                vm.WaitSystemReady(incusos_version)
+
+                # Extend the "local" pool with the second drive and convert to RAID1.
+                result = vm.APIRequest("/1.0/system/storage", method="PUT", body="""{"config":{"scrub_schedule": "0 4 * * 0", "pools":[{"name":"local","type":"zfs-raid1","devices":["/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11","/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1"]}]}}""")
+                if result["status_code"] != 200:
+                    raise IncusOSException("unexpected status code %d: %s" % (result["status_code"], result["error"]))
+
+                # Get the storage state.
+                result = vm.APIRequest("/1.0/system/storage")
+                if result["status_code"] != 200:
+                    raise IncusOSException("unexpected status code %d: %s" % (result["status_code"], result["error"]))
+
+                if len(result["metadata"]["state"]["pools"][0]["devices"]) != 2:
+                    raise IncusOSException("expected two member devices for local pool")
+
+                if result["metadata"]["state"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1-part11":
+                    raise IncusOSException("pool doesn't have expected member device")
+
+                if result["metadata"]["state"]["pools"][0]["devices"][1] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
+                    raise IncusOSException("pool doesn't have expected member device")
+
+                if result["metadata"]["state"]["pools"][0]["type"] != "zfs-raid1":
+                    raise IncusOSException("pool has unexpected type: " + result["metadata"]["state"]["pools"][0]["type"])
+
+                if result["metadata"]["state"]["pools"][0]["name"] != "local":
+                    raise IncusOSException("pool has unexpected name: " + result["metadata"]["state"]["pools"][0]["name"])
+
+                # Physically yank the second drive and trigger a scrub to put the pool into a degraded state.
+                vm.RemoveDevice("disk1")
+                vm.RunCommand("zpool", "scrub", "local")
+
+                # Wait for scrub to complete.
+                time.sleep(5)
+
+                # Get the updated storage state.
+                result = vm.APIRequest("/1.0/system/storage")
+                if result["status_code"] != 200:
+                    raise IncusOSException("unexpected status code %d: %s" % (result["status_code"], result["error"]))
+
+                if len(result["metadata"]["state"]["pools"][0]["devices"]) != 1:
+                    raise IncusOSException("expected one member device for local pool")
+
+                if result["metadata"]["state"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
+                    raise IncusOSException("pool doesn't have expected member device")
+
+                if len(result["metadata"]["state"]["pools"][0]["devices_degraded"]) != 1:
+                    raise IncusOSException("expected one degraded device for local pool")
+
+                if result["metadata"]["state"]["pools"][0]["devices_degraded"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1-part11":
+                    raise IncusOSException("pool doesn't have expected degraded device")
+
+                if result["metadata"]["state"]["pools"][0]["type"] != "zfs-raid1":
+                    raise IncusOSException("pool has unexpected type: " + result["metadata"]["state"]["pools"][0]["type"])
+
+                if result["metadata"]["state"]["pools"][0]["name"] != "local":
+                    raise IncusOSException("pool has unexpected name: " + result["metadata"]["state"]["pools"][0]["name"])
+
+                if result["metadata"]["state"]["pools"][0]["state"] != "DEGRADED":
+                    raise IncusOSException("pool has unexpected state: " + result["metadata"]["state"]["pools"][0]["state"])
+
+                # Replace the missing drive with the third one.
+                result = vm.APIRequest("/1.0/system/storage", method="PUT", body="""{"config":{"scrub_schedule": "0 4 * * 0", "pools":[{"name":"local","type":"zfs-raid1","devices":["/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11","/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2"]}]}}""")
+                if result["status_code"] != 200:
+                    raise IncusOSException("unexpected status code %d: %s" % (result["status_code"], result["error"]))
+
+                # Wait for scrub to complete.
+                time.sleep(5)
+
+                # Get the updated storage state.
+                result = vm.APIRequest("/1.0/system/storage")
+                if result["status_code"] != 200:
+                    raise IncusOSException("unexpected status code %d: %s" % (result["status_code"], result["error"]))
+
+                if len(result["metadata"]["state"]["pools"][0]["devices"]) != 2:
+                    raise IncusOSException("expected two member devices for local pool")
+
+                if result["metadata"]["state"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2-part11":
+                    raise IncusOSException("pool doesn't have expected member device")
+
+                if result["metadata"]["state"]["pools"][0]["devices"][1] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
+                    raise IncusOSException("pool doesn't have expected member device")
+
+                if len(result["metadata"]["state"]["pools"][0].get("devices_degraded", [])) != 0:
+                    raise IncusOSException("expected no degraded devices for local pool")
+
+                if result["metadata"]["state"]["pools"][0]["type"] != "zfs-raid1":
+                    raise IncusOSException("pool has unexpected type: " + result["metadata"]["state"]["pools"][0]["type"])
+
+                if result["metadata"]["state"]["pools"][0]["name"] != "local":
+                    raise IncusOSException("pool has unexpected name: " + result["metadata"]["state"]["pools"][0]["name"])
+
+                if result["metadata"]["state"]["pools"][0]["state"] != "ONLINE":
+                    raise IncusOSException("pool has unexpected state: " + result["metadata"]["state"]["pools"][0]["state"])


### PR DESCRIPTION
Currently, if a storage device that's part of a pool is physically removed (failure, etc), it will be reported as a degraded pool device, but won't be reported as an available drive when querying the storage API. Attempting to replace the missing device with another will incorrectly attempt to _extend_ the existing pool, which will still be in a degraded state.

Fix this by adding logic to detect missing, degraded device(s) during pool updates, and if additional new device(s) are provided, first use those to replace the degraded devices before extending the existing pool. This handles the intuitive actions of a user who is trying to replace their failed device.