### PR TITLE
Add ability to manually flush DNS cache 

### DIFF
--- a/doc/reference/system/network.md
+++ b/doc/reference/system/network.md
@@ -220,6 +220,12 @@ config:
     timezone: "America/New_York"
 ```
 
+To manually flush the DNS cache at any time, run:
+
+```
+incus admin os system network flush-dns
+```
+
 #### Proxy
 
 Configure a simple anonymous HTTP(S) proxy for IncusOS:

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -4491,23 +4491,20 @@ definitions:
         type: object
         x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkPut:
-        description: NetworkPut represents the modifiable fields of a network
+        description: |-
+            NetworkPut represents the fields available for an update of the
+            system's network configuration.
         properties:
-            config:
-                description: Network configuration map (refer to doc/networks.md)
-                example:
-                    ipv4.address: 10.0.0.1/24
-                    ipv4.nat: "true"
-                    ipv6.address: none
-                type: object
-                x-go-name: Config
-            description:
-                description: Description of the profile
-                example: My new bridge
+            address:
+                description: Address of Operations Center which is used by managed servers to connect.
                 type: string
-                x-go-name: Description
+                x-go-name: OperationsCenterAddress
+            rest_server_address:
+                description: Address and port to bind the REST API to.
+                type: string
+                x-go-name: RestServerAddress
         type: object
-        x-go-package: github.com/lxc/incus/v6/shared/api
+        x-go-package: github.com/FuturFusion/operations-center/shared/api/system
     NetworkState:
         description: NetworkState represents the network state
         properties:
@@ -9788,6 +9785,20 @@ paths:
                 "400":
                     $ref: '#/responses/BadRequest'
             summary: Confirm a new network configuration
+            tags:
+                - system
+    /1.0/system/network/:flush-dns:
+        post:
+            description: Flush the system's DNS cache. This is needed after network changes to ensure that any cached DNS entries that may have become stale are cleared.
+            operationId: system_post_network_flush_dns
+            produces:
+                - application/json
+            responses:
+                "200":
+                    $ref: '#/responses/EmptySyncResponse'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Flush the DNS cache
             tags:
                 - system
     /1.0/system/provider:

--- a/incus-osd/cli/cli_system.go
+++ b/incus-osd/cli/cli_system.go
@@ -120,7 +120,15 @@ func (c *cmdAdminOSSystem) command() *cobra.Command {
 					endpoint:    "system/network",
 				}
 
-				return []*cobra.Command{networkConfirmCmd.command()}
+				// Flush DNS cache.
+				flushDNSCmd := cmdGenericRun{
+					os:          c.os,
+					action:      "flush-dns",
+					description: "Flush the DNS cache",
+					endpoint:    "system/network",
+				}
+
+				return []*cobra.Command{networkConfirmCmd.command(), flushDNSCmd.command()}
 			},
 		},
 		{

--- a/incus-osd/internal/rest/api_system_network.go
+++ b/incus-osd/internal/rest/api_system_network.go
@@ -281,3 +281,36 @@ func (s *Server) apiSystemNetworkConfirm(w http.ResponseWriter, r *http.Request)
 
 	_ = response.EmptySyncResponse.Render(w)
 }
+
+// swagger:operation POST /1.0/system/network/:flush-dns system system_post_network_flush_dns
+//
+//	Flush the DNS cache
+//
+//	Flush the system's DNS cache. This is needed after network changes to ensure that any cached DNS entries that may have become stale are cleared.
+//
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
+func (*Server) apiSystemNetworkFlushDNS(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method != http.MethodPost {
+		_ = response.NotImplemented(nil).Render(w)
+
+		return
+	}
+
+	err := systemd.FlushDNSCache(r.Context())
+	if err != nil {
+		_ = response.InternalError(err).Render(w)
+
+		return
+	}
+
+	_ = response.EmptySyncResponse.Render(w)
+}

--- a/incus-osd/internal/rest/server.go
+++ b/incus-osd/internal/rest/server.go
@@ -83,6 +83,7 @@ func (s *Server) Serve(ctx context.Context) error {
 	router.HandleFunc("/1.0/system/logging", s.apiSystemLogging)
 	router.HandleFunc("/1.0/system/network", s.apiSystemNetwork)
 	router.HandleFunc("/1.0/system/network/:confirm", s.apiSystemNetworkConfirm)
+	router.HandleFunc("/1.0/system/network/:flush-dns", s.apiSystemNetworkFlushDNS)
 	router.HandleFunc("/1.0/system/provider", s.apiSystemProvider)
 	router.HandleFunc("/1.0/system/resources", s.apiSystemResources)
 	router.HandleFunc("/1.0/system/security", s.apiSystemSecurity)

--- a/incus-osd/internal/systemd/resolvectl.go
+++ b/incus-osd/internal/systemd/resolvectl.go
@@ -1,0 +1,17 @@
+package systemd
+
+import (
+	"context"
+
+	"github.com/lxc/incus/v6/shared/subprocess"
+)
+
+// FlushDNSCache instructs the system to flush the DNS cache. This is needed after network changes to ensure that any cached DNS entries that may have become stale are cleared.
+func FlushDNSCache(ctx context.Context) error {
+	_, err := subprocess.RunCommandContext(ctx, "resolvectl", "flush-caches")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Resolves https://github.com/lxc/incus-os/issues/970

This PR allows users to manually flush DNS cache using cli : `incus admin os system network flush-dns`
Action plan followed from the description & comments in issue.