### PR TITLE
incus-osd/services/netbird: Always use netbird up instead of netbird login

### DIFF
--- a/incus-osd/internal/services/service_netbird.go
+++ b/incus-osd/internal/services/service_netbird.go
@@ -111,11 +111,8 @@ func (n *Netbird) configure(ctx context.Context) error {
 		return err
 	}
 
-	// Join with the provided key, management and admin server.
-	_, err = subprocess.RunCommandContext(
-		ctx,
-		"netbird",
-		"login",
+	args := []string{
+		"up",
 		"--no-browser",
 		"--setup-key",
 		n.state.Services.Netbird.Config.SetupKey,
@@ -123,15 +120,6 @@ func (n *Netbird) configure(ctx context.Context) error {
 		n.state.Services.Netbird.Config.ManagementURL,
 		"--admin-url",
 		n.state.Services.Netbird.Config.AdminURL,
-	)
-	if err != nil {
-		return err
-	}
-
-	// Connect to netbird with the supplied configuration.
-	args := []string{
-		"up",
-		"--no-browser",
 		"--dns-resolver-address",
 		n.state.Services.Netbird.Config.DNSResolverAddress,
 		"--external-ip-map",
@@ -168,6 +156,7 @@ func (n *Netbird) configure(ctx context.Context) error {
 		args = append(args, "--disable-firewall")
 	}
 
+	// Connect to netbird with the supplied configuration.
 	_, err = subprocess.RunCommandContext(ctx, "netbird", args...)
 	if err != nil {
 		return err


### PR DESCRIPTION
Closes #1016 

The netbird services now uses `netbird up` on every configuration change instead of `netbird login`.