### PR TITLE
Add netdev_max_backlog, tcp_mtu_probing, and ring buffer settings for high-speed NICs

### DIFF
--- a/incus-osd/api/system_kernel.go
+++ b/incus-osd/api/system_kernel.go
@@ -18,8 +18,8 @@ type SystemKernelConfigNetwork struct {
 	BufferSize             int    `json:"buffer_size,omitempty"              yaml:"buffer_size,omitempty"`
 	QueuingDiscipline      string `json:"queuing_discipline,omitempty"       yaml:"queuing_discipline,omitempty"`
 	TCPCongestionAlgorithm string `json:"tcp_congestion_algorithm,omitempty" yaml:"tcp_congestion_algorithm,omitempty"`
-	NetdevMaxBacklog       int    `json:"netdev_max_backlog,omitempty" yaml:"netdev_max_backlog,omitempty"`
-	TCPMTUProbing          bool   `json:"tcp_mtu_probing,omitempty" yaml:"tcp_mtu_probing,omitempty"`
+	NetdevMaxBacklog       int    `json:"netdev_max_backlog,omitempty"       yaml:"netdev_max_backlog,omitempty"`
+	TCPMTUProbing          bool   `json:"tcp_mtu_probing,omitempty"          yaml:"tcp_mtu_probing,omitempty"`
 }
 
 // SystemKernelConfigPCI holds PCI-specific kernel configuration.

--- a/incus-osd/api/system_kernel.go
+++ b/incus-osd/api/system_kernel.go
@@ -18,6 +18,7 @@ type SystemKernelConfigNetwork struct {
 	BufferSize             int    `json:"buffer_size,omitempty"              yaml:"buffer_size,omitempty"`
 	QueuingDiscipline      string `json:"queuing_discipline,omitempty"       yaml:"queuing_discipline,omitempty"`
 	TCPCongestionAlgorithm string `json:"tcp_congestion_algorithm,omitempty" yaml:"tcp_congestion_algorithm,omitempty"`
+	NetdevMaxBacklog       int    `json:"netdev_max_backlog,omitempty" yaml:"netdev_max_backlog,omitempty"`
 }
 
 // SystemKernelConfigPCI holds PCI-specific kernel configuration.

--- a/incus-osd/api/system_kernel.go
+++ b/incus-osd/api/system_kernel.go
@@ -19,6 +19,7 @@ type SystemKernelConfigNetwork struct {
 	QueuingDiscipline      string `json:"queuing_discipline,omitempty"       yaml:"queuing_discipline,omitempty"`
 	TCPCongestionAlgorithm string `json:"tcp_congestion_algorithm,omitempty" yaml:"tcp_congestion_algorithm,omitempty"`
 	NetdevMaxBacklog       int    `json:"netdev_max_backlog,omitempty" yaml:"netdev_max_backlog,omitempty"`
+	TCPMTUProbing          bool   `json:"tcp_mtu_probing,omitempty" yaml:"tcp_mtu_probing,omitempty"`
 }
 
 // SystemKernelConfigPCI holds PCI-specific kernel configuration.

--- a/incus-osd/api/system_network.go
+++ b/incus-osd/api/system_network.go
@@ -98,6 +98,10 @@ type SystemNetworkEthernet struct {
 	WakeOnLAN              bool     `json:"wakeonlan,omitempty"                yaml:"wakeonlan,omitempty"`
 	WakeOnLANModes         []string `json:"wakeonlan_modes,omitempty"          yaml:"wakeonlan_modes,omitempty"`
 	WakeOnLANPassword      string   `json:"wakeonlan_password,omitempty"       yaml:"wakeonlan_password,omitempty"`
+	RxBufferSize           *int     `json:"rx_buffer_size,omitempty"           yaml:"rx_buffer_size,omitempty"`
+	TxBufferSize           *int     `json:"tx_buffer_size,omitempty"           yaml:"tx_buffer_size,omitempty"`
+	RxJumboBufferSize      *int     `json:"rx_jumbo_buffer_size,omitempty"     yaml:"rx_jumbo_buffer_size,omitempty"`
+	RxMiniBufferSize       *int     `json:"rx_mini_buffer_size,omitempty"      yaml:"rx_mini_buffer_size,omitempty"`
 }
 
 // SystemNetworkFirewallRule defines a firewall rule.

--- a/incus-osd/internal/kernel/kernel.go
+++ b/incus-osd/internal/kernel/kernel.go
@@ -180,6 +180,13 @@ func updateSysctlConfig(ctx context.Context, netConfig *api.SystemKernelConfigNe
 		}
 	}
 
+	if netConfig.TCPMTUProbing {
+		_, err := fd.WriteString("net.ipv4.tcp_mtu_probing = 1\n")
+		if err != nil {
+			return err
+		}
+	}
+
 	// Restart the systemd-sysctl service to pickup changes.
 	return systemd.RestartUnit(ctx, "systemd-sysctl.service")
 }

--- a/incus-osd/internal/kernel/kernel.go
+++ b/incus-osd/internal/kernel/kernel.go
@@ -116,6 +116,10 @@ func updateSysctlConfig(ctx context.Context, netConfig *api.SystemKernelConfigNe
 		}
 	}
 
+	if netConfig.NetdevMaxBacklog < 0 {
+		return errors.New("maximum backlog cannot be negative")
+	}
+
 	// Remove the existing configuration files, if they exist.
 	err := os.Remove("/etc/sysctl.d/99-local-sysctl.conf")
 	if err != nil && !os.IsNotExist(err) {
@@ -164,6 +168,13 @@ func updateSysctlConfig(ctx context.Context, netConfig *api.SystemKernelConfigNe
 
 	if netConfig.TCPCongestionAlgorithm != "" {
 		_, err := fd.WriteString("net.ipv4.tcp_congestion_control = " + netConfig.TCPCongestionAlgorithm + "\n")
+		if err != nil {
+			return err
+		}
+	}
+
+	if netConfig.NetdevMaxBacklog != 0 {
+		_, err := fmt.Fprintf(fd, "net.core.netdev_max_backlog = %d\n", netConfig.NetdevMaxBacklog)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- support setting ring buffer sizes per interface
- introduce TCPMTUProbing in SystemKernelConfigNetwork
- NetdevMaxBacklog in SystemKernelConfigNetwork

Closes #1012 