### PR TITLE
Add application-specific datasets

### DIFF
--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -875,5 +875,66 @@ func setupLocalStorage(ctx context.Context, s *state.State) error {
 		return err
 	}
 
+	// Migrate application data for Migration Manager and Operations Center to
+	// dedicated zfs datasets. This code can be removed after June 2026.
+	_, err = os.Stat("/var/lib/migration-manager")
+	if err == nil {
+		err := migrateApplicationData(ctx, "migration-manager")
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err = os.Stat("/var/lib/operations-center")
+	if err == nil {
+		err := migrateApplicationData(ctx, "operations-center")
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+func migrateApplicationData(ctx context.Context, applicationName string) error {
+	// Check if the application-specific dataset already exists.
+	_, err := subprocess.RunCommandContext(ctx, "zfs", "get", "mountpoint", "local/"+applicationName)
+	if err == nil {
+		return nil
+	}
+
+	slog.InfoContext(ctx, "Moving /var/lib/"+applicationName+" to dedicated dataset")
+
+	// Rename the existing application data directory.
+	err = os.Rename(filepath.Join("/var/lib/", applicationName), filepath.Join("/var/lib/", applicationName+".bak"))
+	if err != nil {
+		return err
+	}
+
+	// Create a new zfs dataset for the application.
+	err = zfs.CreateApplicationDataset(ctx, applicationName)
+	if err != nil {
+		// Attempt to restore the application's data.
+		_ = os.Rename(filepath.Join("/var/lib/", applicationName+".bak"), filepath.Join("/var/lib/", applicationName))
+
+		return err
+	}
+
+	// Move any existing application data.
+	entries, err := os.ReadDir(filepath.Join("/var/lib/", applicationName+".bak"))
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		// os.Rename() doesn't work across file system boundaries, so just be lazy and
+		// rely on `mv`.
+		_, err := subprocess.RunCommandContext(ctx, "mv", filepath.Join("/var/lib/", applicationName+".bak", entry.Name()), filepath.Join("/var/lib/", applicationName, entry.Name()))
+		if err != nil {
+			return err
+		}
+	}
+
+	// Remove the old directory.
+	return os.RemoveAll(filepath.Join("/var/lib/", applicationName+".bak"))
 }

--- a/incus-osd/internal/applications/app_common.go
+++ b/incus-osd/internal/applications/app_common.go
@@ -118,7 +118,7 @@ func (*common) NeedsLateUpdateCheck() bool {
 }
 
 // WipeLocalData removes local data created by the application.
-func (*common) WipeLocalData() error {
+func (*common) WipeLocalData(_ context.Context) error {
 	return nil
 }
 
@@ -509,7 +509,7 @@ func UninstallApplication(ctx context.Context, s *state.State, name string) erro
 	}
 
 	// Wipe local data.
-	err = app.WipeLocalData()
+	err = app.WipeLocalData(ctx)
 	if err != nil {
 		return err
 	}

--- a/incus-osd/internal/applications/app_incus.go
+++ b/incus-osd/internal/applications/app_incus.go
@@ -274,7 +274,7 @@ func (a *incus) FactoryReset(ctx context.Context) error {
 	}
 
 	// Wipe local configuration.
-	err = a.WipeLocalData()
+	err = a.WipeLocalData(ctx)
 	if err != nil {
 		return err
 	}
@@ -290,7 +290,7 @@ func (a *incus) FactoryReset(ctx context.Context) error {
 }
 
 // WipeLocalData removes local data created by the application.
-func (*incus) WipeLocalData() error {
+func (*incus) WipeLocalData(_ context.Context) error {
 	// Attempt to unmount the logs directory if it exists and is mounted.
 	logsPath, err := filepath.EvalSymlinks("/var/lib/incus/logs/")
 	if err == nil && logsPath != "" {

--- a/incus-osd/internal/applications/app_migration_manager.go
+++ b/incus-osd/internal/applications/app_migration_manager.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	mmapi "github.com/FuturFusion/migration-manager/shared/api"
+	"golang.org/x/sys/unix"
 
 	"github.com/lxc/incus-os/incus-osd/api"
 	apiseed "github.com/lxc/incus-os/incus-osd/api/seed"
@@ -283,7 +284,7 @@ func (mm *migrationManager) FactoryReset(ctx context.Context) error {
 	}
 
 	// Wipe local configuration.
-	err = mm.WipeLocalData()
+	err = mm.WipeLocalData(ctx)
 	if err != nil {
 		return err
 	}
@@ -299,8 +300,27 @@ func (mm *migrationManager) FactoryReset(ctx context.Context) error {
 }
 
 // WipeLocalData removes local data created by the application.
-func (*migrationManager) WipeLocalData() error {
-	return os.RemoveAll("/var/lib/migration-manager/")
+func (*migrationManager) WipeLocalData(ctx context.Context) error {
+	// Unmount the dataset.
+	err := unix.Unmount("/var/lib/migration-manager/", 0)
+	if err != nil {
+		return err
+	}
+
+	// Destroy the dataset.
+	err = zfs.DestroyDataset(ctx, "local", "migration-manager", false)
+	if err != nil {
+		return err
+	}
+
+	// For good measure, remove the mount point.
+	err = os.RemoveAll("/var/lib/migration-manager/")
+	if err != nil {
+		return err
+	}
+
+	// Create a fresh dataset for the application.
+	return zfs.CreateApplicationDataset(ctx, "migration-manager")
 }
 
 // GetBackup returns a tar archive backup of the application's configuration and/or state.

--- a/incus-osd/internal/applications/app_migration_manager.go
+++ b/incus-osd/internal/applications/app_migration_manager.go
@@ -19,6 +19,7 @@ import (
 	apiseed "github.com/lxc/incus-os/incus-osd/api/seed"
 	"github.com/lxc/incus-os/incus-osd/internal/seed"
 	"github.com/lxc/incus-os/incus-osd/internal/systemd"
+	"github.com/lxc/incus-os/incus-osd/internal/zfs"
 )
 
 type migrationManager struct {
@@ -30,7 +31,21 @@ func (*migrationManager) Name() string {
 }
 
 // Start starts the systemd unit.
-func (*migrationManager) Start(ctx context.Context) error {
+func (mm *migrationManager) Start(ctx context.Context) error {
+	// If this is the first time starting the application, create a ZFS
+	// dataset for it to use.
+	if !mm.state.Applications["migration-manager"].State.Initialized {
+		err := zfs.CreateApplicationDataset(ctx, "migration-manager")
+		if err != nil {
+			return err
+		}
+	} else {
+		err := zfs.MountApplicationDataset(ctx, "migration-manager")
+		if err != nil {
+			return err
+		}
+	}
+
 	// Start the unit.
 	return systemd.StartUnit(ctx, "migration-manager.service")
 }

--- a/incus-osd/internal/applications/app_operations_center.go
+++ b/incus-osd/internal/applications/app_operations_center.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	ocapi "github.com/FuturFusion/operations-center/shared/api/system"
+	"golang.org/x/sys/unix"
 
 	"github.com/lxc/incus-os/incus-osd/api"
 	apiseed "github.com/lxc/incus-os/incus-osd/api/seed"
@@ -298,7 +299,7 @@ func (oc *operationsCenter) FactoryReset(ctx context.Context) error {
 	}
 
 	// Wipe local configuration.
-	err = oc.WipeLocalData()
+	err = oc.WipeLocalData(ctx)
 	if err != nil {
 		return err
 	}
@@ -320,8 +321,27 @@ func (oc *operationsCenter) FactoryReset(ctx context.Context) error {
 }
 
 // WipeLocalData removes local data created by the application.
-func (*operationsCenter) WipeLocalData() error {
-	return os.RemoveAll("/var/lib/operations-center/")
+func (*operationsCenter) WipeLocalData(ctx context.Context) error {
+	// Unmount the dataset.
+	err := unix.Unmount("/var/lib/operations-center/", 0)
+	if err != nil {
+		return err
+	}
+
+	// Destroy the dataset.
+	err = zfs.DestroyDataset(ctx, "local", "operations-center", false)
+	if err != nil {
+		return err
+	}
+
+	// For good measure, remove the mount point.
+	err = os.RemoveAll("/var/lib/operations-center/")
+	if err != nil {
+		return err
+	}
+
+	// Create a fresh dataset for the application.
+	return zfs.CreateApplicationDataset(ctx, "operations-center")
 }
 
 // GetBackup returns a tar archive backup of the application's configuration and/or state.

--- a/incus-osd/internal/applications/app_operations_center.go
+++ b/incus-osd/internal/applications/app_operations_center.go
@@ -19,6 +19,7 @@ import (
 	apiseed "github.com/lxc/incus-os/incus-osd/api/seed"
 	"github.com/lxc/incus-os/incus-osd/internal/seed"
 	"github.com/lxc/incus-os/incus-osd/internal/systemd"
+	"github.com/lxc/incus-os/incus-osd/internal/zfs"
 )
 
 type operationsCenter struct {
@@ -30,7 +31,21 @@ func (*operationsCenter) Name() string {
 }
 
 // Start starts the systemd unit.
-func (*operationsCenter) Start(ctx context.Context) error {
+func (oc *operationsCenter) Start(ctx context.Context) error {
+	// If this is the first time starting the application, create a ZFS
+	// dataset for it to use.
+	if !oc.state.Applications["operations-center"].State.Initialized {
+		err := zfs.CreateApplicationDataset(ctx, "operations-center")
+		if err != nil {
+			return err
+		}
+	} else {
+		err := zfs.MountApplicationDataset(ctx, "operations-center")
+		if err != nil {
+			return err
+		}
+	}
+
 	// Start the unit.
 	return systemd.StartUnit(ctx, "operations-center.service")
 }

--- a/incus-osd/internal/applications/struct.go
+++ b/incus-osd/internal/applications/struct.go
@@ -28,5 +28,5 @@ type Application interface { //nolint:interfacebloat
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
 	Update(ctx context.Context) error
-	WipeLocalData() error
+	WipeLocalData(_ context.Context) error
 }

--- a/incus-osd/internal/zfs/zfs.go
+++ b/incus-osd/internal/zfs/zfs.go
@@ -1058,3 +1058,21 @@ func ScrubAllPools(ctx context.Context) error {
 
 	return nil
 }
+
+// CreateApplicationDataset creates an application-specific dataset in the "local" pool. The dataset is will be
+// mounted under /var/lib/, and is tagged with an "incusos:use" property.
+func CreateApplicationDataset(ctx context.Context, applicationName string) error {
+	_, err := subprocess.RunCommandContext(ctx, "zfs", "create", "-o", "mountpoint=/var/lib/"+applicationName+"/", "-o", "incusos:use="+applicationName, "local/"+applicationName)
+
+	return err
+}
+
+// MountApplicationDataset ensures that an application's dataset is mounted.
+func MountApplicationDataset(ctx context.Context, applicationName string) error {
+	_, err := subprocess.RunCommandContext(ctx, "zfs", "mount", "local/"+applicationName)
+	if err != nil && !strings.Contains(err.Error(), "filesystem already mounted") {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add code to create application-specific ZFS datasets for Migration Manager and Operations Center, and add migration logic at system start for existing installs.

Each application gets its own ZFS dataset within the "local" pool and is tagged with an appropriate "incusos:use" property.

Closes #1031