### PR TITLE
Auto-expand "local" pool

### DIFF
--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -875,6 +875,17 @@ func setupLocalStorage(ctx context.Context, s *state.State) error {
 		return err
 	}
 
+	// Detect if the root drive has increased in size. If so, attempt to auto-expand
+	// the zfs "local" pool to use the additional space. systemd-repart uses zero-based
+	// indices when reporting partitions.
+	_, err = subprocess.RunCommandContext(ctx, "journalctl", "-b", "-u", "systemd-repart", "-g", "Growing existing partition 10")
+	if err == nil {
+		err := storage.ExpandLocalPool(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Migrate application data for Migration Manager and Operations Center to
 	// dedicated zfs datasets. This code can be removed after June 2026.
 	_, err = os.Stat("/var/lib/migration-manager")

--- a/incus-osd/internal/storage/storage.go
+++ b/incus-osd/internal/storage/storage.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1042,4 +1043,33 @@ func IsBMC(entry BlockDevices) bool {
 	}
 
 	return false
+}
+
+// ExpandLocalPool attempts to auto-expand the "local" pool when we detect the underlying storage
+// device has increased its capacity. This only really happens when IncusOS is running in a VM and
+// its root device is expanded. We only perform the pool expansion if it consists of a single
+// device and is configured as RAID0.
+func ExpandLocalPool(ctx context.Context) error {
+	p, err := GetZpoolMembers(ctx, "local")
+	if err != nil {
+		return err
+	}
+
+	// We only support automatically growing the local pool if it exists of a single vdev.
+	if p.Type != "zfs-raid0" || len(p.Devices) != 1 {
+		return nil
+	}
+
+	slog.InfoContext(ctx, "Expanding 'local' pool to utilize new disk capacity")
+
+	// Enable autoexpand.
+	_, err = subprocess.RunCommandContext(ctx, "zpool", "set", "autoexpand=on", "local")
+	if err != nil {
+		return err
+	}
+
+	// Trigger the local pool expansion.
+	_, err = subprocess.RunCommandContext(ctx, "zpool", "online", "-e", "local", p.Devices[0])
+
+	return err
 }

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_storage_local_pool.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_storage_local_pool.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import tempfile
 import time
 
@@ -593,3 +594,44 @@ def TestIncusOSAPISystemStorageLocalPoolDegraded(install_image):
 
                 if result["metadata"]["state"]["pools"][0]["state"] != "ONLINE":
                     raise IncusOSException("pool has unexpected state: " + result["metadata"]["state"]["pools"][0]["state"])
+
+def TestIncusOSAPISystemStorageLocalAutoexpand(install_image):
+    test_name = "incusos-api-system-storage-local-autoexpand"
+    test_seed = {
+        "install.json": "{}",
+    }
+
+    test_image, incusos_version = util._prepare_test_image(install_image, test_seed)
+
+    with IncusTestVM(test_name, test_image) as vm:
+        vm.WaitSystemReady(incusos_version)
+
+        # Get current storage state.
+        result = vm.APIRequest("/1.0/system/storage")
+        if result["status_code"] != 200:
+            raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+        if result["metadata"]["state"]["pools"][0]["raw_pool_size_in_bytes"] != 17716740096:
+            raise IncusOSException("local pool has incorrect initial size")
+
+        # Stop the VM and expand the root device
+        vm.StopVM()
+
+        subprocess.run(["incus", "config", "device", "set", vm.vm_name, "root", "size", "55GiB"], capture_output=True, check=True)
+
+        # Start the VM and expect to see a message about expanding the local pool
+        vm.StartVM()
+        vm.WaitAgentRunning()
+        vm.WaitExpectedLog("incus-osd", "Expanding 'local' pool to utilize new disk capacity")
+        vm.WaitExpectedLog("incus-osd", "System is ready version="+incusos_version)
+
+        # Sleep a few seconds to allow the zpool to settle
+        time.sleep(5)
+
+        # Get updated storage state.
+        result = vm.APIRequest("/1.0/system/storage")
+        if result["status_code"] != 200:
+            raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+        if result["metadata"]["state"]["pools"][0]["raw_pool_size_in_bytes"] != 23085449216:
+            raise IncusOSException("local pool has incorrect updated size")


### PR DESCRIPTION
`systemd-repart` automatically takes care of expanding the local pool's partition when the disk is enlarged, so we just need to trigger a ZFS autoexpand of the local pool.

Closes #1032