### PR TITLE
Fix Operations Center provider loading

### DIFF
--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -640,7 +640,40 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 		return err
 	}
 
-	// Get the provider.
+	// Ensure all systemd extensions are applied.
+	err = systemd.RefreshExtensions(ctx, s.Applications, &s.OS)
+	if err != nil {
+		return err
+	}
+
+	// Run services startup actions. This must be done before bringing up any storage pools.
+	for _, srvName := range services.Supported(s) {
+		srv, err := services.Load(ctx, s, srvName)
+		if err != nil {
+			return err
+		}
+
+		if !srv.ShouldStart() {
+			continue
+		}
+
+		slog.InfoContext(ctx, "Starting service", "name", srvName)
+
+		err = srv.Start(ctx)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed starting service", "name", srvName, "err", err)
+		}
+	}
+
+	// Ensure any locally-defined pools are available.
+	err = setupLocalStorage(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	// Get the provider. Must be done after storage pools are loaded, since the operations-center
+	// provider depends on fetching the primary application's client certificate which may be
+	// stored in a local zfs dataset.
 	var provider string
 
 	var providerConfig map[string]string
@@ -687,37 +720,6 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 	if !delayInitialUpdateCheck {
 		// Perform an initial blocking check for updates before proceeding.
 		update.Checker(ctx, s, p, true, false)
-	}
-
-	// Ensure all systemd extensions are applied.
-	err = systemd.RefreshExtensions(ctx, s.Applications, &s.OS)
-	if err != nil {
-		return err
-	}
-
-	// Run services startup actions. This must be done before bringing up any storage pools.
-	for _, srvName := range services.Supported(s) {
-		srv, err := services.Load(ctx, s, srvName)
-		if err != nil {
-			return err
-		}
-
-		if !srv.ShouldStart() {
-			continue
-		}
-
-		slog.InfoContext(ctx, "Starting service", "name", srvName)
-
-		err = srv.Start(ctx)
-		if err != nil {
-			slog.ErrorContext(ctx, "Failed starting service", "name", srvName, "err", err)
-		}
-	}
-
-	// Ensure any locally-defined pools are available.
-	err = setupLocalStorage(ctx, s)
-	if err != nil {
-		return err
 	}
 
 	// Run application startup actions. Must be done after storage pools are loaded.

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -886,6 +886,19 @@ func setupLocalStorage(ctx context.Context, s *state.State) error {
 		}
 	}
 
+	// Mount any application-specific datasets.
+	for appName := range s.Applications {
+		app, err := applications.Load(ctx, s, appName)
+		if err != nil {
+			return err
+		}
+
+		err = app.ConfigureLocalStorage(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Migrate application data for Migration Manager and Operations Center to
 	// dedicated zfs datasets. This code can be removed after June 2026.
 	_, err = os.Stat("/var/lib/migration-manager")

--- a/incus-osd/internal/applications/app_common.go
+++ b/incus-osd/internal/applications/app_common.go
@@ -137,6 +137,11 @@ func (*common) RestoreBackup(_ context.Context, _ io.Reader) error {
 	return errors.New("not supported")
 }
 
+// ConfigureLocalStorage configures local storage for the application.
+func (*common) ConfigureLocalStorage(_ context.Context) error {
+	return nil
+}
+
 // Common helper to construct an HTTP client using the provided local Unix socket.
 func unixHTTPClient(socketPath string) (*http.Client, error) {
 	// Setup a Unix socket dialer

--- a/incus-osd/internal/applications/app_migration_manager.go
+++ b/incus-osd/internal/applications/app_migration_manager.go
@@ -181,7 +181,8 @@ func (*migrationManager) IsRunning(ctx context.Context) bool {
 
 // NeedsLateUpdateCheck reports if the application depends on a delayed provider update check.
 func (*migrationManager) NeedsLateUpdateCheck() bool {
-	return false
+	// Depends on application client TLS certificate stored in ZFS dataset.
+	return true
 }
 
 // GetClientCertificate returns the keypair for the client certificate.

--- a/incus-osd/internal/applications/app_migration_manager.go
+++ b/incus-osd/internal/applications/app_migration_manager.go
@@ -33,18 +33,9 @@ func (*migrationManager) Name() string {
 
 // Start starts the systemd unit.
 func (mm *migrationManager) Start(ctx context.Context) error {
-	// If this is the first time starting the application, create a ZFS
-	// dataset for it to use.
-	if !mm.state.Applications["migration-manager"].State.Initialized {
-		err := zfs.CreateApplicationDataset(ctx, "migration-manager")
-		if err != nil {
-			return err
-		}
-	} else {
-		err := zfs.MountApplicationDataset(ctx, "migration-manager")
-		if err != nil {
-			return err
-		}
+	err := mm.ConfigureLocalStorage(ctx)
+	if err != nil {
+		return err
 	}
 
 	// Start the unit.
@@ -335,4 +326,22 @@ func (*migrationManager) GetBackup(archive io.Writer, complete bool) error {
 // RestoreBackup restores a tar archive backup of the application's configuration and/or state.
 func (*migrationManager) RestoreBackup(ctx context.Context, archive io.Reader) error {
 	return extractTarArchive(ctx, "/var/lib/migration-manager/", []string{"migration-manager.service"}, archive)
+}
+
+// ConfigureLocalStorage configures local storage for the application.
+func (mm *migrationManager) ConfigureLocalStorage(ctx context.Context) error {
+	// If the application isn't initialized, create a ZFS dataset for it to use.
+	if !mm.state.Applications["migration-manager"].State.Initialized {
+		err := zfs.CreateApplicationDataset(ctx, "migration-manager")
+		if err != nil {
+			return err
+		}
+	} else {
+		err := zfs.MountApplicationDataset(ctx, "migration-manager")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/incus-osd/internal/applications/app_operations_center.go
+++ b/incus-osd/internal/applications/app_operations_center.go
@@ -33,18 +33,9 @@ func (*operationsCenter) Name() string {
 
 // Start starts the systemd unit.
 func (oc *operationsCenter) Start(ctx context.Context) error {
-	// If this is the first time starting the application, create a ZFS
-	// dataset for it to use.
-	if !oc.state.Applications["operations-center"].State.Initialized {
-		err := zfs.CreateApplicationDataset(ctx, "operations-center")
-		if err != nil {
-			return err
-		}
-	} else {
-		err := zfs.MountApplicationDataset(ctx, "operations-center")
-		if err != nil {
-			return err
-		}
+	err := oc.ConfigureLocalStorage(ctx)
+	if err != nil {
+		return err
 	}
 
 	// Start the unit.
@@ -356,4 +347,22 @@ func (*operationsCenter) GetBackup(archive io.Writer, complete bool) error {
 // RestoreBackup restores a tar archive backup of the application's configuration and/or state.
 func (*operationsCenter) RestoreBackup(ctx context.Context, archive io.Reader) error {
 	return extractTarArchive(ctx, "/var/lib/operations-center/", []string{"operations-center.service"}, archive)
+}
+
+// ConfigureLocalStorage configures local storage for the application.
+func (oc *operationsCenter) ConfigureLocalStorage(ctx context.Context) error {
+	// If the application isn't initialized, create a ZFS dataset for it to use.
+	if !oc.state.Applications["operations-center"].State.Initialized {
+		err := zfs.CreateApplicationDataset(ctx, "operations-center")
+		if err != nil {
+			return err
+		}
+	} else {
+		err := zfs.MountApplicationDataset(ctx, "operations-center")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/incus-osd/internal/applications/app_operations_center.go
+++ b/incus-osd/internal/applications/app_operations_center.go
@@ -196,6 +196,9 @@ func (*operationsCenter) IsRunning(ctx context.Context) bool {
 
 // NeedsLateUpdateCheck reports if the application depends on a delayed provider update check.
 func (*operationsCenter) NeedsLateUpdateCheck() bool {
+	// Depends on application client TLS certificate stored in ZFS dataset.
+	// Operations Center can also be self-hosted, which also requires a delay
+	// before we can check for updates.
 	return true
 }
 

--- a/incus-osd/internal/applications/struct.go
+++ b/incus-osd/internal/applications/struct.go
@@ -11,6 +11,7 @@ import (
 // Application represents an installed application.
 type Application interface { //nolint:interfacebloat
 	AddTrustedCertificate(ctx context.Context, name string, cert string) error
+	ConfigureLocalStorage(ctx context.Context) error
 	Debug(ctx context.Context, data any) response.Response
 	DebugStruct() any
 	FactoryReset(ctx context.Context) error


### PR DESCRIPTION
Fix a regression caused by #1053 moving application data to ZFS datasets, which weren't yet available when attempting to setup the provider.