### PR TITLE
"exit-node" Support for Tailscale

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -122,6 +122,7 @@ syslog
 systemd
 systemd's
 Tailscale
+Tailnet
 TCP
 TDB
 TiB

--- a/doc/reference/services/tailscale.md
+++ b/doc/reference/services/tailscale.md
@@ -24,6 +24,12 @@ The following configuration options can be set:
 
 * `serve_service`: Tailscale [Service](https://tailscale.com/docs/features/tailscale-services) to expose the service as. Corresponds to the `--service=` flag in `tailscale serve`, not passed if empty. Note: At time of writing this feature is [not supported in Headscale](https://github.com/juanfont/headscale/issues/2845).
 
+* `advertise_exit_node`: If `true`, offer to be an [exit node](https://tailscale.com/docs/features/exit-nodes#advertise-a-device-as-an-exit-node) for internet traffic for the tailnet.
+
+* `exit_node`: Tailscale exit node (IP, base name, or auto:any) for internet traffic, or empty string to not use an exit node.
+
+* `exit_node_allow_lan_access`: If `true`, allow direct access to the local network when routing traffic via an exit node. 
+
 ```{note}
 Enabling Tailscale Serve requires provisioning HTTPS certificates on the dashboard beforehand ([documentation](https://tailscale.com/kb/1153/enabling-https#configure-https))
 ```

--- a/doc/reference/services/tailscale.md
+++ b/doc/reference/services/tailscale.md
@@ -24,6 +24,12 @@ The following configuration options can be set:
 
 * `serve_service`: Tailscale [Service](https://tailscale.com/docs/features/tailscale-services) to expose the service as. Corresponds to the `--service=` flag in `tailscale serve`, not passed if empty. Note: At time of writing this feature is [not supported in Headscale](https://github.com/juanfont/headscale/issues/2845).
 
+* `advertise_exit_node`: If `true`, offer to be an [exit node](https://tailscale.com/docs/features/exit-nodes#advertise-a-device-as-an-exit-node) for internet traffic for the Tailnet.
+
+* `exit_node`: Tailscale exit node (IP, base name, or auto:any) for internet traffic, or empty string to not use an exit node.
+
+* `exit_node_allow_lan_access`: If `true`, allow direct access to the local network when routing traffic via an exit node.
+
 ```{note}
 Enabling Tailscale Serve requires provisioning HTTPS certificates on the dashboard beforehand ([documentation](https://tailscale.com/kb/1153/enabling-https#configure-https))
 ```

--- a/incus-osd/api/service_tailscale.go
+++ b/incus-osd/api/service_tailscale.go
@@ -8,12 +8,15 @@ type ServiceTailscale struct {
 
 // ServiceTailscaleConfig represents additional configuration for the Tailscale service.
 type ServiceTailscaleConfig struct {
-	Enabled          bool     `json:"enabled"           yaml:"enabled"`
-	LoginServer      string   `json:"login_server"      yaml:"login_server"`
-	AuthKey          string   `json:"auth_key"          yaml:"auth_key"`
-	AcceptRoutes     bool     `json:"accept_routes"     yaml:"accept_routes"`
-	AdvertisedRoutes []string `json:"advertised_routes" yaml:"advertised_routes"`
-	ServeEnabled     bool     `json:"serve_enabled"     yaml:"serve_enabled"`
-	ServePort        int      `json:"serve_port"        yaml:"serve_port"`
-	ServeService     string   `json:"serve_service"     yaml:"serve_service"`
+	Enabled                bool     `json:"enabled"           yaml:"enabled"`
+	LoginServer            string   `json:"login_server"      yaml:"login_server"`
+	AuthKey                string   `json:"auth_key"          yaml:"auth_key"`
+	AcceptRoutes           bool     `json:"accept_routes"     yaml:"accept_routes"`
+	AdvertisedRoutes       []string `json:"advertised_routes" yaml:"advertised_routes"`
+	AdvertiseExitNode      bool     `json:"advertise_exit_node" yaml:"advertise_exit_node"`
+	ExitNode               string   `json:"exit_node" yaml:"exit_node"`
+	ExitNodeAllowLanAccess bool     `json:"exit_node_allow_lan_access" yaml:"exit_node_allow_lan_access"`
+	ServeEnabled           bool     `json:"serve_enabled"     yaml:"serve_enabled"`
+	ServePort              int      `json:"serve_port"        yaml:"serve_port"`
+	ServeService           string   `json:"serve_service"     yaml:"serve_service"`
 }

--- a/incus-osd/api/service_tailscale.go
+++ b/incus-osd/api/service_tailscale.go
@@ -12,15 +12,18 @@ type ServiceTailscale struct {
 
 // ServiceTailscaleConfig represents additional configuration for the Tailscale service.
 type ServiceTailscaleConfig struct {
-	Enabled          bool     `json:"enabled"           yaml:"enabled"`
-	LoginServer      string   `json:"login_server"      yaml:"login_server"`
-	AuthKey          string   `json:"auth_key"          yaml:"auth_key"`
-	AcceptRoutes     bool     `json:"accept_routes"     yaml:"accept_routes"`
-	AcceptDNS        bool     `json:"accept_dns"        yaml:"accept_dns"`
-	AdvertisedRoutes []string `json:"advertised_routes" yaml:"advertised_routes"`
-	ServeEnabled     bool     `json:"serve_enabled"     yaml:"serve_enabled"`
-	ServePort        int      `json:"serve_port"        yaml:"serve_port"`
-	ServeService     string   `json:"serve_service"     yaml:"serve_service"`
+	Enabled                bool     `json:"enabled"                    yaml:"enabled"`
+	LoginServer            string   `json:"login_server"               yaml:"login_server"`
+	AuthKey                string   `json:"auth_key"                   yaml:"auth_key"`
+	AcceptRoutes           bool     `json:"accept_routes"              yaml:"accept_routes"`
+	AcceptDNS              bool     `json:"accept_dns"                 yaml:"accept_dns"`
+	AdvertisedRoutes       []string `json:"advertised_routes"          yaml:"advertised_routes"`
+	AdvertiseExitNode      bool     `json:"advertise_exit_node"        yaml:"advertise_exit_node"`
+	ExitNode               string   `json:"exit_node"                  yaml:"exit_node"`
+	ExitNodeAllowLanAccess bool     `json:"exit_node_allow_lan_access" yaml:"exit_node_allow_lan_access"`
+	ServeEnabled           bool     `json:"serve_enabled"              yaml:"serve_enabled"`
+	ServePort              int      `json:"serve_port"                 yaml:"serve_port"`
+	ServeService           string   `json:"serve_service"              yaml:"serve_service"`
 }
 
 // ServiceTailscaleBackendStateEnum represents the possible states of the Tailscale backend.

--- a/incus-osd/internal/services/service_tailscale.go
+++ b/incus-osd/internal/services/service_tailscale.go
@@ -144,7 +144,16 @@ func (n *Tailscale) configure(ctx context.Context, needsRejoin bool) error {
 		}
 	}
 
-	_, err := subprocess.RunCommandContext(ctx, "tailscale", "set", "--advertise-routes", strings.Join(n.state.Services.Tailscale.Config.AdvertisedRoutes, ","), "--accept-routes="+strconv.FormatBool(n.state.Services.Tailscale.Config.AcceptRoutes))
+	args := []string{
+		"set",
+		"--advertise-routes=" + strings.Join(n.state.Services.Tailscale.Config.AdvertisedRoutes, ","),
+		"--accept-routes=" + strconv.FormatBool(n.state.Services.Tailscale.Config.AcceptRoutes),
+		"--advertise-exit-node=" + strconv.FormatBool(n.state.Services.Tailscale.Config.AdvertiseExitNode),
+		"--exit-node=" + n.state.Services.Tailscale.Config.ExitNode,
+		"--exit-node-allow-lan-access=" + strconv.FormatBool(n.state.Services.Tailscale.Config.ExitNodeAllowLanAccess),
+	}
+
+	_, err := subprocess.RunCommandContext(ctx, "tailscale", args...)
 	if err != nil {
 		return err
 	}

--- a/incus-osd/internal/services/service_tailscale.go
+++ b/incus-osd/internal/services/service_tailscale.go
@@ -176,7 +176,17 @@ func (n *Tailscale) configure(ctx context.Context, needsRejoin bool) error {
 		}
 	}
 
-	_, err := subprocess.RunCommandContext(ctx, "tailscale", "set", "--advertise-routes", strings.Join(n.state.Services.Tailscale.Config.AdvertisedRoutes, ","), "--accept-routes="+strconv.FormatBool(n.state.Services.Tailscale.Config.AcceptRoutes), "--accept-dns="+strconv.FormatBool(n.state.Services.Tailscale.Config.AcceptDNS))
+	args := []string{
+		"set",
+		"--advertise-routes=" + strings.Join(n.state.Services.Tailscale.Config.AdvertisedRoutes, ","),
+		"--accept-routes=" + strconv.FormatBool(n.state.Services.Tailscale.Config.AcceptRoutes),
+		"--accept-dns=" + strconv.FormatBool(n.state.Services.Tailscale.Config.AcceptDNS),
+		"--advertise-exit-node=" + strconv.FormatBool(n.state.Services.Tailscale.Config.AdvertiseExitNode),
+		"--exit-node=" + n.state.Services.Tailscale.Config.ExitNode,
+		"--exit-node-allow-lan-access=" + strconv.FormatBool(n.state.Services.Tailscale.Config.ExitNodeAllowLanAccess),
+	}
+
+	_, err := subprocess.RunCommandContext(ctx, "tailscale", args...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I've added support for advertising exit node and using exit node to the tailscale service.

However, when I tried testing on my machine, I was not able to see other machines that are advertising exit nodes from the Incus OS(shell access through `debug` application and run `tailscale exit-node list`). It might be a tailscale issue but I'm not sure. Please give it a try on your machine and see if using exit node works for you!