### PR TITLE
Reorganize some code

### DIFF
--- a/incus-osd/internal/applications/app_common.go
+++ b/incus-osd/internal/applications/app_common.go
@@ -1,49 +1,27 @@
 package applications
 
 import (
-	"archive/tar"
-	"bytes"
-	"compress/gzip"
 	"context"
-	"crypto/sha256"
 	"crypto/tls"
-	"crypto/x509"
-	"encoding/hex"
-	"encoding/json"
-	"encoding/pem"
 	"errors"
-	"fmt"
 	"io"
-	"io/fs"
-	"log/slog"
-	"net"
-	"net/http"
-	"os"
-	"path/filepath"
-	"slices"
-	"strings"
-	"syscall"
-	"time"
-
-	"github.com/lxc/incus/v6/shared/api"
-	"github.com/lxc/incus/v6/shared/revert"
 
 	"github.com/lxc/incus-os/incus-osd/internal/rest/response"
 	"github.com/lxc/incus-os/incus-osd/internal/state"
-	"github.com/lxc/incus-os/incus-osd/internal/systemd"
 )
 
 type common struct {
 	state *state.State
 }
 
-func (*common) Name() string {
-	return ""
-}
-
 // AddTrustedCertificate adds a new trusted certificate to the application.
 func (*common) AddTrustedCertificate(_ context.Context, _ string, _ string) error {
 	return errors.New("not supported")
+}
+
+// ConfigureLocalStorage configures local storage for the application.
+func (*common) ConfigureLocalStorage(_ context.Context) error {
+	return nil
 }
 
 // Debug runs a debug action.
@@ -58,11 +36,26 @@ func (*common) DebugStruct() any {
 	return &data
 }
 
+// FactoryReset performs a full factory reset of the application.
+func (*common) FactoryReset(_ context.Context) error {
+	return errors.New("not supported")
+}
+
+// GetBackup returns a tar archive backup of the application's configuration and/or state.
+func (*common) GetBackup(_ io.Writer, _ bool) error {
+	return errors.New("not supported")
+}
+
 // GetClientCertificate gets the client certificate for the application.
 // That is, the client certificate that the application would use when
 // it needs to authenticate itself with a 3rd party service (like a provider).
 func (*common) GetClientCertificate() (*tls.Certificate, error) {
 	return nil, errors.New("not supported")
+}
+
+// GetDependencies returns a list of other applications this application depends on.
+func (*common) GetDependencies() []string {
+	return nil
 }
 
 // GetServerCertificate gets the server certificate for the application.
@@ -72,19 +65,38 @@ func (*common) GetServerCertificate() (*tls.Certificate, error) {
 	return nil, errors.New("not supported")
 }
 
-// GetDependencies returns a list of other applications this application depends on.
-func (*common) GetDependencies() []string {
-	return nil
-}
-
 // Initialize runs first time initialization.
 func (*common) Initialize(_ context.Context) error {
 	return nil
 }
 
+// IsPrimary reports if the application is a primary application.
+func (*common) IsPrimary() bool {
+	return false
+}
+
+// IsRunning reports if the application is currently running.
+func (*common) IsRunning(_ context.Context) bool {
+	return false
+}
+
+func (*common) Name() string {
+	return ""
+}
+
+// NeedsLateUpdateCheck reports if the application depends on a delayed provider update check.
+func (*common) NeedsLateUpdateCheck() bool {
+	return false
+}
+
 // Restart restarts runs restart action.
 func (*common) Restart(_ context.Context) error {
 	return nil
+}
+
+// RestoreBackup restores a tar archive backup of the application's configuration and/or state.
+func (*common) RestoreBackup(_ context.Context, _ io.Reader) error {
+	return errors.New("not supported")
 }
 
 // Start runs startup action.
@@ -102,476 +114,7 @@ func (*common) Update(_ context.Context) error {
 	return nil
 }
 
-// IsPrimary reports if the application is a primary application.
-func (*common) IsPrimary() bool {
-	return false
-}
-
-// IsRunning reports if the application is currently running.
-func (*common) IsRunning(_ context.Context) bool {
-	return false
-}
-
-// NeedsLateUpdateCheck reports if the application depends on a delayed provider update check.
-func (*common) NeedsLateUpdateCheck() bool {
-	return false
-}
-
 // WipeLocalData removes local data created by the application.
 func (*common) WipeLocalData(_ context.Context) error {
 	return nil
-}
-
-// FactoryReset performs a full factory reset of the application.
-func (*common) FactoryReset(_ context.Context) error {
-	return errors.New("not supported")
-}
-
-// GetBackup returns a tar archive backup of the application's configuration and/or state.
-func (*common) GetBackup(_ io.Writer, _ bool) error {
-	return errors.New("not supported")
-}
-
-// RestoreBackup restores a tar archive backup of the application's configuration and/or state.
-func (*common) RestoreBackup(_ context.Context, _ io.Reader) error {
-	return errors.New("not supported")
-}
-
-// ConfigureLocalStorage configures local storage for the application.
-func (*common) ConfigureLocalStorage(_ context.Context) error {
-	return nil
-}
-
-// Common helper to construct an HTTP client using the provided local Unix socket.
-func unixHTTPClient(socketPath string) (*http.Client, error) {
-	// Setup a Unix socket dialer
-	unixDial := func(_ context.Context, _ string, _ string) (net.Conn, error) {
-		raddr, err := net.ResolveUnixAddr("unix", socketPath)
-		if err != nil {
-			return nil, err
-		}
-
-		return net.DialUnix("unix", nil, raddr)
-	}
-
-	// Define the http transport
-	transport := &http.Transport{
-		DialContext:           unixDial,
-		DisableKeepAlives:     true,
-		ExpectContinueTimeout: time.Second * 30,
-		ResponseHeaderTimeout: time.Second * 3600,
-		TLSHandshakeTimeout:   time.Second * 5,
-	}
-
-	// Define the http client
-	client := &http.Client{}
-
-	client.Transport = transport
-
-	// Setup redirect policy
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		// Replicate the headers
-		req.Header = via[len(via)-1].Header // #nosec G119
-
-		return nil
-	}
-
-	return client, nil
-}
-
-// Common helper for performing REST API calls.
-func doRequest(ctx context.Context, socket string, url string, method string, body []byte) ([]byte, error) {
-	client, err := unixHTTPClient(socket)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(body))
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	r := &api.ResponseRaw{}
-
-	err = json.NewDecoder(resp.Body).Decode(r)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK || r.StatusCode != http.StatusOK {
-		return nil, errors.New(r.Error)
-	}
-
-	ret, err := json.Marshal(r.Metadata)
-	if err != nil {
-		return nil, err
-	}
-
-	return ret, nil
-}
-
-// Comment helper to compute the SHA256 fingerprint of a PEM-encoded certificate.
-func getCertificateFingerprint(certificate string) (string, error) {
-	certBlock, _ := pem.Decode([]byte(certificate))
-	if certBlock == nil {
-		return "", errors.New("cannot parse certificate PEM")
-	}
-
-	cert, err := x509.ParseCertificate(certBlock.Bytes)
-	if err != nil {
-		return "", fmt.Errorf("invalid certificate: %w", err)
-	}
-
-	rawFp := sha256.Sum256(cert.Raw)
-
-	return hex.EncodeToString(rawFp[:]), nil
-}
-
-func createTarArchive(archiveRoot string, excludePaths []string, archive io.Writer) error {
-	zw := gzip.NewWriter(archive)
-	tw := tar.NewWriter(zw)
-
-	// Stat the archive root to get the device it's on, so we can limit our walk to just that file system.
-	s, err := os.Stat(archiveRoot)
-	if err != nil {
-		return err
-	}
-
-	rootStat, ok := s.Sys().(*syscall.Stat_t)
-	if !ok {
-		return errors.New("unable to stat file " + archiveRoot)
-	}
-
-	rootDev := rootStat.Dev
-
-	err = filepath.WalkDir(archiveRoot, func(path string, dirEntry fs.DirEntry, _ error) error {
-		archiveFilename := strings.TrimPrefix(path, archiveRoot)
-
-		// Skip the root directory and any relative path starting with a path to be excluded.
-		if archiveFilename == "" || slices.ContainsFunc(excludePaths, func(s string) bool {
-			return strings.HasPrefix(archiveFilename, s)
-		}) {
-			return nil
-		}
-
-		info, err := dirEntry.Info()
-		if err != nil {
-			return err
-		}
-
-		mode := int64(info.Mode().Perm())
-		modTime := info.ModTime()
-
-		stat, ok := info.Sys().(*syscall.Stat_t)
-		if !ok {
-			return errors.New("unable to stat file " + archiveFilename)
-		}
-
-		uid := int(stat.Uid)
-		gid := int(stat.Gid)
-
-		// Don't walk other file systems.
-		if info.Mode().IsDir() && stat.Dev != rootDev {
-			return fs.SkipDir
-		}
-
-		switch {
-		case info.Mode().IsDir():
-			// Create the header for the directory.
-			header := &tar.Header{
-				Name:     archiveFilename,
-				Typeflag: tar.TypeDir,
-				Mode:     mode,
-				ModTime:  modTime,
-				Uid:      uid,
-				Gid:      gid,
-			}
-
-			// Write the header.
-			err := tw.WriteHeader(header)
-			if err != nil {
-				return err
-			}
-		case info.Mode()&os.ModeSymlink == os.ModeSymlink:
-			// Get the symlink destination.
-			dest, err := os.Readlink(path)
-			if err != nil {
-				return err
-			}
-
-			// Create the header for the symlink.
-			header := &tar.Header{
-				Name:     archiveFilename,
-				Typeflag: tar.TypeSymlink,
-				Linkname: dest,
-				Mode:     mode,
-				ModTime:  modTime,
-				Uid:      uid,
-				Gid:      gid,
-			}
-
-			// Write the header.
-			err = tw.WriteHeader(header)
-			if err != nil {
-				return err
-			}
-		case info.Mode().IsRegular():
-			// Open the file.
-			// #nosec G304,G122
-			file, err := os.Open(path)
-			if err != nil {
-				return err
-			}
-			defer file.Close()
-
-			// Create the header for the file.
-			header := &tar.Header{
-				Name:     archiveFilename,
-				Typeflag: tar.TypeReg,
-				Mode:     mode,
-				ModTime:  modTime,
-				Uid:      uid,
-				Gid:      gid,
-				Size:     info.Size(),
-			}
-
-			// Write the header and file contents.
-			err = tw.WriteHeader(header)
-			if err != nil {
-				return err
-			}
-
-			_, err = io.Copy(tw, file)
-			if err != nil {
-				return err
-			}
-		default:
-			return errors.New("unsupported file: " + archiveFilename)
-		}
-
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	err = tw.Close()
-	if err != nil {
-		return err
-	}
-
-	return zw.Close()
-}
-
-func extractTarArchive(ctx context.Context, archiveRoot string, restartUnits []string, archive io.Reader) error {
-	reverter := revert.New()
-	defer reverter.Fail()
-
-	// Create the new root directory.
-	stat, err := os.Stat(archiveRoot)
-	if err != nil {
-		return err
-	}
-
-	newArchiveRoot := strings.TrimSuffix(archiveRoot, "/") + ".new"
-
-	err = os.Mkdir(newArchiveRoot, stat.Mode())
-	if err != nil {
-		return err
-	}
-
-	// If we encounter an error, clean up intermediate state.
-	reverter.Add(func() {
-		_ = os.RemoveAll(newArchiveRoot)
-	})
-
-	// Iterate through each file in the tar archive.
-	gz, err := gzip.NewReader(archive)
-	if err != nil {
-		return err
-	}
-	defer gz.Close()
-
-	tr := tar.NewReader(gz)
-	for {
-		header, err := tr.Next()
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-
-			return err
-		}
-
-		// Don't let someone feed us a path traversal escape attack.
-		// #nosec G305
-		filename := filepath.Join(newArchiveRoot, header.Name)
-		if !strings.HasPrefix(filename, newArchiveRoot) {
-			return fmt.Errorf("cannot restore file outside of application root '%s' (bad file '%s')", archiveRoot, filename)
-		}
-
-		mode := fs.FileMode(header.Mode) // #nosec G115
-
-		switch header.Typeflag {
-		case tar.TypeDir:
-			err := os.Mkdir(filename, mode)
-			if err != nil {
-				return err
-			}
-		case tar.TypeSymlink:
-			err := os.Symlink(header.Linkname, filename)
-			if err != nil {
-				return err
-			}
-		case tar.TypeReg:
-			// Write file to disk.
-			// #nosec G304
-			file, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, mode)
-			if err != nil {
-				return err
-			}
-			defer file.Close() //nolint:revive
-
-			// Read from the archive in chunks to avoid excessive memory consumption.
-			var size int64
-
-			for {
-				n, err := io.CopyN(file, tr, 4*1024*1024)
-				size += n
-
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-
-					return err
-				}
-			}
-		default:
-			return errors.New("unsupported file: " + header.Name)
-		}
-
-		// Set proper ownership.
-		err = os.Lchown(filename, header.Uid, header.Gid)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Stop unit(s).
-	err = systemd.StopUnit(ctx, restartUnits...)
-	if err != nil {
-		return err
-	}
-
-	// Remove the existing directory.
-	err = os.RemoveAll(archiveRoot)
-	if err != nil {
-		return err
-	}
-
-	// Rename the new directory.
-	err = os.Rename(newArchiveRoot, archiveRoot)
-	if err != nil {
-		return err
-	}
-
-	// Start unit(s).
-	err = systemd.StartUnit(ctx, restartUnits...)
-	if err != nil {
-		return err
-	}
-
-	reverter.Success()
-
-	return nil
-}
-
-// UninstallApplication removes the given application from the state, wipes any local
-// data, and removes the sysext image for the application.
-func UninstallApplication(ctx context.Context, s *state.State, name string) error {
-	// Load the application.
-	app, err := Load(ctx, s, name)
-	if err != nil {
-		return err
-	}
-
-	// Can't remove a primary application.
-	if app.IsPrimary() {
-		return errors.New("cannot remove a primary application")
-	}
-
-	// Stop the application.
-	err = app.Stop(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Wipe local data.
-	err = app.WipeLocalData(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Remove application from the state.
-	delete(s.Applications, app.Name())
-
-	// Remove the sysext image.
-	err = systemd.RemoveExtension(ctx, app.Name())
-	if err != nil {
-		return err
-	}
-
-	// Save the state to disk.
-	return s.Save()
-}
-
-// StartInitialize starts the specified application, and if needed performs initialization actions.
-func StartInitialize(ctx context.Context, s *state.State, appName string) error {
-	// Get the application.
-	app, err := Load(ctx, s, appName)
-	if err != nil {
-		return err
-	}
-
-	// At this point, we know the application will exist in the map.
-	appInfo := s.Applications[appName]
-
-	// Start the application.
-	slog.InfoContext(ctx, "Starting application", "name", appName, "version", appInfo.State.Version)
-
-	err = app.Start(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Run initialization if needed.
-	if !appInfo.State.Initialized {
-		slog.InfoContext(ctx, "Initializing application", "name", appName, "version", appInfo.State.Version)
-
-		err = app.Initialize(ctx)
-		if err != nil {
-			return err
-		}
-
-		appInfo.State.Initialized = true
-		s.Applications[appName] = appInfo
-	}
-
-	// If the application has a TLS certificate, print its fingerprint so the user can verify it when initially connecting.
-	cert, err := app.GetServerCertificate()
-	if err == nil {
-		rawFp := sha256.Sum256(cert.Certificate[0])
-
-		slog.InfoContext(ctx, "Application TLS certificate fingerprint", "name", appName, "fingerprint", hex.EncodeToString(rawFp[:]))
-	}
-
-	// Save the state to disk.
-	return s.Save()
 }

--- a/incus-osd/internal/applications/app_gpu_support.go
+++ b/incus-osd/internal/applications/app_gpu_support.go
@@ -15,12 +15,12 @@ type gpuSupport struct {
 	common
 }
 
-func (*gpuSupport) Name() string {
-	return "gpu-support"
-}
-
 func (*gpuSupport) IsRunning(_ context.Context) bool {
 	return true
+}
+
+func (*gpuSupport) Name() string {
+	return "gpu-support"
 }
 
 func (*gpuSupport) Start(ctx context.Context) error {

--- a/incus-osd/internal/applications/app_incus.go
+++ b/incus-osd/internal/applications/app_incus.go
@@ -30,34 +30,26 @@ type incus struct {
 	common
 }
 
-func (*incus) Name() string {
-	return "incus"
-}
+// AddTrustedCertificate adds a new trusted certificate to the application.
+func (*incus) AddTrustedCertificate(_ context.Context, name string, cert string) error {
+	// Connect to Incus.
+	c, err := incusclient.ConnectIncusUnix("", nil)
+	if err != nil {
+		return err
+	}
 
-type incusCeph struct {
-	common
-}
+	// Add the certificate.
+	req := incusapi.CertificatesPost{}
+	req.Name = name
+	req.Type = "client"
+	req.Certificate = cert
 
-func (*incusCeph) Name() string {
-	return "incus-ceph"
-}
+	err = c.CreateCertificate(req)
+	if err != nil {
+		return err
+	}
 
-// GetDependencies returns a list of other applications this application depends on.
-func (*incusCeph) GetDependencies() []string {
-	return []string{"incus"}
-}
-
-type incusLinstor struct {
-	common
-}
-
-func (*incusLinstor) Name() string {
-	return "incus-linstor"
-}
-
-// GetDependencies returns a list of other applications this application depends on.
-func (*incusLinstor) GetDependencies() []string {
-	return []string{"incus"}
+	return nil
 }
 
 // Debug runs a debug action.
@@ -90,62 +82,57 @@ func (*incus) DebugStruct() any {
 	return data
 }
 
-// Start starts all the systemd units.
-func (*incus) Start(ctx context.Context) error {
-	// Refresh the system users.
-	err := systemd.RefreshUsers(ctx)
+// FactoryReset performs a full factory reset of the application.
+func (a *incus) FactoryReset(ctx context.Context) error {
+	// Stop the application.
+	err := a.Stop(ctx)
 	if err != nil {
 		return err
 	}
 
-	// Refresh the sysctls.
-	err = systemd.RestartUnit(ctx, "systemd-sysctl.service")
+	// Wipe local configuration.
+	err = a.WipeLocalData(ctx)
 	if err != nil {
 		return err
 	}
 
-	// Start the units.
-	return systemd.StartUnit(ctx, "incus.socket", "incus-lxcfs.service", "incus-startup.service", "incus.service")
+	// Start the application.
+	err = a.Start(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Perform first start initialization.
+	return a.Initialize(ctx)
 }
 
-// Stop stops all the systemd units.
-func (*incus) Stop(ctx context.Context) error {
-	// Trigger a clean shutdown.
-	err := systemd.StopUnit(ctx, "incus-startup.service")
-	if err != nil {
-		return err
-	}
+// GetBackup returns a tar archive backup of the application's configuration and/or state.
+func (*incus) GetBackup(archive io.Writer, _ bool) error {
+	return createTarArchive("/var/lib/incus/", []string{"guestapi", "shmounts", "unix.socket"}, archive)
+}
 
-	// Stop the remaining units.
-	err = systemd.StopUnit(ctx, "incus.service", "incus.socket", "incus-lxcfs.service")
-	if err != nil {
-		return err
-	}
+// GetClientCertificate returns the keypair for the client certificate.
+func (a *incus) GetClientCertificate() (*tls.Certificate, error) {
+	return a.getCertificate("server")
+}
 
+// GetDependencies returns a list of other applications this application depends on.
+func (*incus) GetDependencies() []string {
 	return nil
 }
 
-// Restart restarts the main systemd unit.
-func (*incus) Restart(ctx context.Context) error {
-	return systemd.RestartUnit(ctx, "incus.service")
-}
-
-// Update triggers a partial restart after an application update.
-func (*incus) Update(ctx context.Context) error {
-	// Refresh the system users.
-	err := systemd.RefreshUsers(ctx)
+// GetServerCertificate returns the keypair for the server certificate.
+func (a *incus) GetServerCertificate() (*tls.Certificate, error) {
+	cert, err := a.getCertificate("cluster")
 	if err != nil {
-		return err
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+
+		return a.getCertificate("server")
 	}
 
-	// Reload the systemd daemon to pickup any service definition changes.
-	err = systemd.ReloadDaemon(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Restart the main unit.
-	return systemd.RestartUnit(ctx, "incus.service")
+	return cert, nil
 }
 
 // Initialize runs first time initialization.
@@ -204,9 +191,18 @@ func (a *incus) Initialize(ctx context.Context) error {
 	return nil
 }
 
+// IsPrimary reports if the application is a primary application.
+func (*incus) IsPrimary() bool {
+	return true
+}
+
 // IsRunning reports if the application is currently running.
 func (*incus) IsRunning(ctx context.Context) bool {
 	return systemd.IsActive(ctx, "incus.service")
+}
+
+func (*incus) Name() string {
+	return "incus"
 }
 
 // NeedsLateUpdateCheck reports if the application depends on a delayed provider update check.
@@ -214,50 +210,44 @@ func (*incus) NeedsLateUpdateCheck() bool {
 	return false
 }
 
-// IsPrimary reports if the application is a primary application.
-func (*incus) IsPrimary() bool {
-	return true
+// Restart restarts the main systemd unit.
+func (*incus) Restart(ctx context.Context) error {
+	return systemd.RestartUnit(ctx, "incus.service")
 }
 
-// GetClientCertificate returns the keypair for the client certificate.
-func (a *incus) GetClientCertificate() (*tls.Certificate, error) {
-	return a.getCertificate("server")
+// RestoreBackup restores a tar archive backup of the application's configuration and/or state.
+func (*incus) RestoreBackup(ctx context.Context, archive io.Reader) error {
+	return extractTarArchive(ctx, "/var/lib/incus/", []string{"incus-startup.service", "incus.socket", "incus.service", "incus-lxcfs.service"}, archive)
 }
 
-// GetServerCertificate returns the keypair for the server certificate.
-func (a *incus) GetServerCertificate() (*tls.Certificate, error) {
-	cert, err := a.getCertificate("cluster")
-	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			return nil, err
-		}
-
-		return a.getCertificate("server")
-	}
-
-	return cert, nil
-}
-
-// GetDependencies returns a list of other applications this application depends on.
-func (*incus) GetDependencies() []string {
-	return nil
-}
-
-// AddTrustedCertificate adds a new trusted certificate to the application.
-func (*incus) AddTrustedCertificate(_ context.Context, name string, cert string) error {
-	// Connect to Incus.
-	c, err := incusclient.ConnectIncusUnix("", nil)
+// Start starts all the systemd units.
+func (*incus) Start(ctx context.Context) error {
+	// Refresh the system users.
+	err := systemd.RefreshUsers(ctx)
 	if err != nil {
 		return err
 	}
 
-	// Add the certificate.
-	req := incusapi.CertificatesPost{}
-	req.Name = name
-	req.Type = "client"
-	req.Certificate = cert
+	// Refresh the sysctls.
+	err = systemd.RestartUnit(ctx, "systemd-sysctl.service")
+	if err != nil {
+		return err
+	}
 
-	err = c.CreateCertificate(req)
+	// Start the units.
+	return systemd.StartUnit(ctx, "incus.socket", "incus-lxcfs.service", "incus-startup.service", "incus.service")
+}
+
+// Stop stops all the systemd units.
+func (*incus) Stop(ctx context.Context) error {
+	// Trigger a clean shutdown.
+	err := systemd.StopUnit(ctx, "incus-startup.service")
+	if err != nil {
+		return err
+	}
+
+	// Stop the remaining units.
+	err = systemd.StopUnit(ctx, "incus.service", "incus.socket", "incus-lxcfs.service")
 	if err != nil {
 		return err
 	}
@@ -265,28 +255,22 @@ func (*incus) AddTrustedCertificate(_ context.Context, name string, cert string)
 	return nil
 }
 
-// FactoryReset performs a full factory reset of the application.
-func (a *incus) FactoryReset(ctx context.Context) error {
-	// Stop the application.
-	err := a.Stop(ctx)
+// Update triggers a partial restart after an application update.
+func (*incus) Update(ctx context.Context) error {
+	// Refresh the system users.
+	err := systemd.RefreshUsers(ctx)
 	if err != nil {
 		return err
 	}
 
-	// Wipe local configuration.
-	err = a.WipeLocalData(ctx)
+	// Reload the systemd daemon to pickup any service definition changes.
+	err = systemd.ReloadDaemon(ctx)
 	if err != nil {
 		return err
 	}
 
-	// Start the application.
-	err = a.Start(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Perform first start initialization.
-	return a.Initialize(ctx)
+	// Restart the main unit.
+	return systemd.RestartUnit(ctx, "incus.service")
 }
 
 // WipeLocalData removes local data created by the application.
@@ -308,16 +292,6 @@ func (*incus) WipeLocalData(_ context.Context) error {
 	}
 
 	return os.RemoveAll("/var/log/incus/")
-}
-
-// GetBackup returns a tar archive backup of the application's configuration and/or state.
-func (*incus) GetBackup(archive io.Writer, _ bool) error {
-	return createTarArchive("/var/lib/incus/", []string{"guestapi", "shmounts", "unix.socket"}, archive)
-}
-
-// RestoreBackup restores a tar archive backup of the application's configuration and/or state.
-func (*incus) RestoreBackup(ctx context.Context, archive io.Reader) error {
-	return extractTarArchive(ctx, "/var/lib/incus/", []string{"incus-startup.service", "incus.socket", "incus.service", "incus-lxcfs.service"}, archive)
 }
 
 func (a *incus) applyDefaults(ctx context.Context, c incusclient.InstanceServer) error {

--- a/incus-osd/internal/applications/app_incus_services.go
+++ b/incus-osd/internal/applications/app_incus_services.go
@@ -1,0 +1,27 @@
+package applications
+
+type incusCeph struct {
+	common
+}
+
+// GetDependencies returns a list of other applications this application depends on.
+func (*incusCeph) GetDependencies() []string {
+	return []string{"incus"}
+}
+
+func (*incusCeph) Name() string {
+	return "incus-ceph"
+}
+
+type incusLinstor struct {
+	common
+}
+
+// GetDependencies returns a list of other applications this application depends on.
+func (*incusLinstor) GetDependencies() []string {
+	return []string{"incus"}
+}
+
+func (*incusLinstor) Name() string {
+	return "incus-linstor"
+}

--- a/incus-osd/internal/applications/app_migration_manager.go
+++ b/incus-osd/internal/applications/app_migration_manager.go
@@ -27,42 +27,127 @@ type migrationManager struct {
 	common
 }
 
-func (*migrationManager) Name() string {
-	return "migration-manager"
-}
-
-// Start starts the systemd unit.
-func (mm *migrationManager) Start(ctx context.Context) error {
-	err := mm.ConfigureLocalStorage(ctx)
+// AddTrustedCertificate adds a new trusted certificate to the application.
+func (*migrationManager) AddTrustedCertificate(ctx context.Context, _ string, cert string) error {
+	// Compute the certificate's fingerprint.
+	fp, err := getCertificateFingerprint(cert)
 	if err != nil {
 		return err
 	}
 
-	// Start the unit.
-	return systemd.StartUnit(ctx, "migration-manager.service")
-}
-
-// Stop stops the systemd unit.
-func (*migrationManager) Stop(ctx context.Context) error {
-	// Stop the unit.
-	return systemd.StopUnit(ctx, "migration-manager.service")
-}
-
-// Restart restarts the main systemd unit.
-func (*migrationManager) Restart(ctx context.Context) error {
-	return systemd.RestartUnit(ctx, "migration-manager.service")
-}
-
-// Update triggers restart after an application update.
-func (*migrationManager) Update(ctx context.Context) error {
-	// Reload the systemd daemon to pickup any service definition changes.
-	err := systemd.ReloadDaemon(ctx)
+	// Get the current security configuration.
+	body, err := doMMRequest(ctx, "http://localhost/1.0/system/security", http.MethodGet, nil)
 	if err != nil {
 		return err
 	}
 
-	// Restart the unit.
-	return systemd.RestartUnit(ctx, "migration-manager.service")
+	sec := &mmapi.SystemSecurity{}
+
+	err = json.Unmarshal(body, sec)
+	if err != nil {
+		return err
+	}
+
+	// Check if the certificate is already trusted.
+	if slices.Contains(sec.TrustedTLSClientCertFingerprints, fp) {
+		return errors.New("client certificate is already trusted")
+	}
+
+	// Add the certificate's fingerprint to list of trusted clients.
+	sec.TrustedTLSClientCertFingerprints = append(sec.TrustedTLSClientCertFingerprints, fp)
+
+	contentJSON, err := json.Marshal(sec)
+	if err != nil {
+		return err
+	}
+
+	_, err = doMMRequest(ctx, "http://localhost/1.0/system/security", http.MethodPut, contentJSON)
+
+	return err
+}
+
+// ConfigureLocalStorage configures local storage for the application.
+func (mm *migrationManager) ConfigureLocalStorage(ctx context.Context) error {
+	// If the application isn't initialized, create a ZFS dataset for it to use.
+	if !mm.state.Applications["migration-manager"].State.Initialized {
+		err := zfs.CreateApplicationDataset(ctx, "migration-manager")
+		if err != nil {
+			return err
+		}
+	} else {
+		err := zfs.MountApplicationDataset(ctx, "migration-manager")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// FactoryReset performs a full factory reset of the application.
+func (mm *migrationManager) FactoryReset(ctx context.Context) error {
+	// Stop the application.
+	err := mm.Stop(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Wipe local configuration.
+	err = mm.WipeLocalData(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Start the application.
+	err = mm.Start(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Perform first start initialization.
+	return mm.Initialize(ctx)
+}
+
+// GetBackup returns a tar archive backup of the application's configuration and/or state.
+func (*migrationManager) GetBackup(archive io.Writer, complete bool) error {
+	if complete {
+		return createTarArchive("/var/lib/migration-manager/", nil, archive)
+	}
+
+	return createTarArchive("/var/lib/migration-manager/", []string{"artifacts"}, archive)
+}
+
+// GetClientCertificate returns the keypair for the client certificate.
+func (mm *migrationManager) GetClientCertificate() (*tls.Certificate, error) {
+	// Migration Manager doesn't have a separate certificate it uses when contacting other servers.
+	return mm.GetServerCertificate()
+}
+
+// GetDependencies returns a list of other applications this application depends on.
+func (*migrationManager) GetDependencies() []string {
+	return nil
+}
+
+// GetServerCertificate returns the keypair for the server certificate.
+func (*migrationManager) GetServerCertificate() (*tls.Certificate, error) {
+	// Load the certificate.
+	tlsCert, err := os.ReadFile("/var/lib/migration-manager/server.crt")
+	if err != nil {
+		return nil, err
+	}
+
+	tlsKey, err := os.ReadFile("/var/lib/migration-manager/server.key")
+	if err != nil {
+		return nil, err
+	}
+
+	// Put together a keypair.
+	cert, err := tls.X509KeyPair(tlsCert, tlsKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cert, nil
 }
 
 // Initialize runs first time initialization.
@@ -174,9 +259,18 @@ func (mm *migrationManager) Initialize(ctx context.Context) error {
 	return nil
 }
 
+// IsPrimary reports if the application is a primary application.
+func (*migrationManager) IsPrimary() bool {
+	return true
+}
+
 // IsRunning reports if the application is currently running.
 func (*migrationManager) IsRunning(ctx context.Context) bool {
 	return systemd.IsActive(ctx, "migration-manager.service")
+}
+
+func (*migrationManager) Name() string {
+	return "migration-manager"
 }
 
 // NeedsLateUpdateCheck reports if the application depends on a delayed provider update check.
@@ -185,110 +279,43 @@ func (*migrationManager) NeedsLateUpdateCheck() bool {
 	return true
 }
 
-// GetClientCertificate returns the keypair for the client certificate.
-func (mm *migrationManager) GetClientCertificate() (*tls.Certificate, error) {
-	// Migration Manager doesn't have a separate certificate it uses when contacting other servers.
-	return mm.GetServerCertificate()
+// Restart restarts the main systemd unit.
+func (*migrationManager) Restart(ctx context.Context) error {
+	return systemd.RestartUnit(ctx, "migration-manager.service")
 }
 
-// GetServerCertificate returns the keypair for the server certificate.
-func (*migrationManager) GetServerCertificate() (*tls.Certificate, error) {
-	// Load the certificate.
-	tlsCert, err := os.ReadFile("/var/lib/migration-manager/server.crt")
-	if err != nil {
-		return nil, err
-	}
-
-	tlsKey, err := os.ReadFile("/var/lib/migration-manager/server.key")
-	if err != nil {
-		return nil, err
-	}
-
-	// Put together a keypair.
-	cert, err := tls.X509KeyPair(tlsCert, tlsKey)
-	if err != nil {
-		return nil, err
-	}
-
-	return &cert, nil
+// RestoreBackup restores a tar archive backup of the application's configuration and/or state.
+func (*migrationManager) RestoreBackup(ctx context.Context, archive io.Reader) error {
+	return extractTarArchive(ctx, "/var/lib/migration-manager/", []string{"migration-manager.service"}, archive)
 }
 
-// GetDependencies returns a list of other applications this application depends on.
-func (*migrationManager) GetDependencies() []string {
-	return nil
+// Start starts the systemd unit.
+func (mm *migrationManager) Start(ctx context.Context) error {
+	err := mm.ConfigureLocalStorage(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Start the unit.
+	return systemd.StartUnit(ctx, "migration-manager.service")
 }
 
-// AddTrustedCertificate adds a new trusted certificate to the application.
-func (*migrationManager) AddTrustedCertificate(ctx context.Context, _ string, cert string) error {
-	// Compute the certificate's fingerprint.
-	fp, err := getCertificateFingerprint(cert)
-	if err != nil {
-		return err
-	}
-
-	// Get the current security configuration.
-	body, err := doMMRequest(ctx, "http://localhost/1.0/system/security", http.MethodGet, nil)
-	if err != nil {
-		return err
-	}
-
-	sec := &mmapi.SystemSecurity{}
-
-	err = json.Unmarshal(body, sec)
-	if err != nil {
-		return err
-	}
-
-	// Check if the certificate is already trusted.
-	if slices.Contains(sec.TrustedTLSClientCertFingerprints, fp) {
-		return errors.New("client certificate is already trusted")
-	}
-
-	// Add the certificate's fingerprint to list of trusted clients.
-	sec.TrustedTLSClientCertFingerprints = append(sec.TrustedTLSClientCertFingerprints, fp)
-
-	contentJSON, err := json.Marshal(sec)
-	if err != nil {
-		return err
-	}
-
-	_, err = doMMRequest(ctx, "http://localhost/1.0/system/security", http.MethodPut, contentJSON)
-
-	return err
+// Stop stops the systemd unit.
+func (*migrationManager) Stop(ctx context.Context) error {
+	// Stop the unit.
+	return systemd.StopUnit(ctx, "migration-manager.service")
 }
 
-// Migration Manager specific helper to interact with the REST API.
-func doMMRequest(ctx context.Context, url string, method string, body []byte) ([]byte, error) {
-	return doRequest(ctx, "/run/migration-manager/unix.socket", url, method, body)
-}
-
-// IsPrimary reports if the application is a primary application.
-func (*migrationManager) IsPrimary() bool {
-	return true
-}
-
-// FactoryReset performs a full factory reset of the application.
-func (mm *migrationManager) FactoryReset(ctx context.Context) error {
-	// Stop the application.
-	err := mm.Stop(ctx)
+// Update triggers restart after an application update.
+func (*migrationManager) Update(ctx context.Context) error {
+	// Reload the systemd daemon to pickup any service definition changes.
+	err := systemd.ReloadDaemon(ctx)
 	if err != nil {
 		return err
 	}
 
-	// Wipe local configuration.
-	err = mm.WipeLocalData(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Start the application.
-	err = mm.Start(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Perform first start initialization.
-	return mm.Initialize(ctx)
+	// Restart the unit.
+	return systemd.RestartUnit(ctx, "migration-manager.service")
 }
 
 // WipeLocalData removes local data created by the application.
@@ -315,34 +342,7 @@ func (*migrationManager) WipeLocalData(ctx context.Context) error {
 	return zfs.CreateApplicationDataset(ctx, "migration-manager")
 }
 
-// GetBackup returns a tar archive backup of the application's configuration and/or state.
-func (*migrationManager) GetBackup(archive io.Writer, complete bool) error {
-	if complete {
-		return createTarArchive("/var/lib/migration-manager/", nil, archive)
-	}
-
-	return createTarArchive("/var/lib/migration-manager/", []string{"artifacts"}, archive)
-}
-
-// RestoreBackup restores a tar archive backup of the application's configuration and/or state.
-func (*migrationManager) RestoreBackup(ctx context.Context, archive io.Reader) error {
-	return extractTarArchive(ctx, "/var/lib/migration-manager/", []string{"migration-manager.service"}, archive)
-}
-
-// ConfigureLocalStorage configures local storage for the application.
-func (mm *migrationManager) ConfigureLocalStorage(ctx context.Context) error {
-	// If the application isn't initialized, create a ZFS dataset for it to use.
-	if !mm.state.Applications["migration-manager"].State.Initialized {
-		err := zfs.CreateApplicationDataset(ctx, "migration-manager")
-		if err != nil {
-			return err
-		}
-	} else {
-		err := zfs.MountApplicationDataset(ctx, "migration-manager")
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+// Migration Manager specific helper to interact with the REST API.
+func doMMRequest(ctx context.Context, url string, method string, body []byte) ([]byte, error) {
+	return doRequest(ctx, "/run/migration-manager/unix.socket", url, method, body)
 }

--- a/incus-osd/internal/applications/app_operations_center.go
+++ b/incus-osd/internal/applications/app_operations_center.go
@@ -27,42 +27,133 @@ type operationsCenter struct {
 	common
 }
 
-func (*operationsCenter) Name() string {
-	return "operations-center"
-}
-
-// Start starts the systemd unit.
-func (oc *operationsCenter) Start(ctx context.Context) error {
-	err := oc.ConfigureLocalStorage(ctx)
+// AddTrustedCertificate adds a new trusted certificate to the application.
+func (*operationsCenter) AddTrustedCertificate(ctx context.Context, _ string, cert string) error {
+	// Compute the certificate's fingerprint.
+	fp, err := getCertificateFingerprint(cert)
 	if err != nil {
 		return err
 	}
 
-	// Start the unit.
-	return systemd.StartUnit(ctx, "operations-center.service")
-}
-
-// Stop stops the systemd unit.
-func (*operationsCenter) Stop(ctx context.Context) error {
-	// Stop the unit.
-	return systemd.StopUnit(ctx, "operations-center.service")
-}
-
-// Restart restarts the main systemd unit.
-func (*operationsCenter) Restart(ctx context.Context) error {
-	return systemd.RestartUnit(ctx, "operations-center.service")
-}
-
-// Update triggers restart after an application update.
-func (*operationsCenter) Update(ctx context.Context) error {
-	// Reload the systemd daemon to pickup any service definition changes.
-	err := systemd.ReloadDaemon(ctx)
+	// Get the current security configuration.
+	body, err := doOCRequest(ctx, "http://localhost/1.0/system/security", http.MethodGet, nil)
 	if err != nil {
 		return err
 	}
 
-	// Restart the unit.
-	return systemd.RestartUnit(ctx, "operations-center.service")
+	sec := &ocapi.Security{}
+
+	err = json.Unmarshal(body, sec)
+	if err != nil {
+		return err
+	}
+
+	// Check if the certificate is already trusted.
+	if slices.Contains(sec.TrustedTLSClientCertFingerprints, fp) {
+		return errors.New("client certificate is already trusted")
+	}
+
+	// Add the certificate's fingerprint to list of trusted clients.
+	sec.TrustedTLSClientCertFingerprints = append(sec.TrustedTLSClientCertFingerprints, fp)
+
+	contentJSON, err := json.Marshal(sec)
+	if err != nil {
+		return err
+	}
+
+	_, err = doOCRequest(ctx, "http://localhost/1.0/system/security", http.MethodPut, contentJSON)
+
+	return err
+}
+
+// ConfigureLocalStorage configures local storage for the application.
+func (oc *operationsCenter) ConfigureLocalStorage(ctx context.Context) error {
+	// If the application isn't initialized, create a ZFS dataset for it to use.
+	if !oc.state.Applications["operations-center"].State.Initialized {
+		err := zfs.CreateApplicationDataset(ctx, "operations-center")
+		if err != nil {
+			return err
+		}
+	} else {
+		err := zfs.MountApplicationDataset(ctx, "operations-center")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// FactoryReset performs a full factory reset of the application.
+func (oc *operationsCenter) FactoryReset(ctx context.Context) error {
+	// Stop the application.
+	err := oc.Stop(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Wipe local configuration.
+	err = oc.WipeLocalData(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Check if we're locally registered with it.
+	if oc.state.System.Provider.State.Registered && (oc.state.System.Provider.Config.Config == nil || oc.state.System.Provider.Config.Config["server_url"] == "") {
+		oc.state.System.Provider.State.Registered = false
+		oc.state.System.Provider.Config.Config = map[string]string{}
+	}
+
+	// Start the application.
+	err = oc.Start(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Perform first start initialization.
+	return oc.Initialize(ctx)
+}
+
+// GetBackup returns a tar archive backup of the application's configuration and/or state.
+func (*operationsCenter) GetBackup(archive io.Writer, complete bool) error {
+	if complete {
+		return createTarArchive("/var/lib/operations-center/", nil, archive)
+	}
+
+	return createTarArchive("/var/lib/operations-center/", []string{"updates"}, archive)
+}
+
+// GetClientCertificate returns the keypair for the client certificate.
+func (oc *operationsCenter) GetClientCertificate() (*tls.Certificate, error) {
+	// Operations Center doesn't have a separate certificate it uses when contacting other servers.
+	return oc.GetServerCertificate()
+}
+
+// GetDependencies returns a list of other applications this application depends on.
+func (*operationsCenter) GetDependencies() []string {
+	return nil
+}
+
+// GetServerCertificate returns the keypair for the server certificate.
+func (*operationsCenter) GetServerCertificate() (*tls.Certificate, error) {
+	// Load the certificate.
+	tlsCert, err := os.ReadFile("/var/lib/operations-center/server.crt")
+	if err != nil {
+		return nil, err
+	}
+
+	tlsKey, err := os.ReadFile("/var/lib/operations-center/server.key")
+	if err != nil {
+		return nil, err
+	}
+
+	// Put together a keypair.
+	cert, err := tls.X509KeyPair(tlsCert, tlsKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cert, nil
 }
 
 // Initialize runs first time initialization.
@@ -189,9 +280,18 @@ func (oc *operationsCenter) Initialize(ctx context.Context) error {
 	return nil
 }
 
+// IsPrimary reports if the application is a primary application.
+func (*operationsCenter) IsPrimary() bool {
+	return true
+}
+
 // IsRunning reports if the application is currently running.
 func (*operationsCenter) IsRunning(ctx context.Context) bool {
 	return systemd.IsActive(ctx, "operations-center.service")
+}
+
+func (*operationsCenter) Name() string {
+	return "operations-center"
 }
 
 // NeedsLateUpdateCheck reports if the application depends on a delayed provider update check.
@@ -202,116 +302,43 @@ func (*operationsCenter) NeedsLateUpdateCheck() bool {
 	return true
 }
 
-// GetClientCertificate returns the keypair for the client certificate.
-func (oc *operationsCenter) GetClientCertificate() (*tls.Certificate, error) {
-	// Operations Center doesn't have a separate certificate it uses when contacting other servers.
-	return oc.GetServerCertificate()
+// Restart restarts the main systemd unit.
+func (*operationsCenter) Restart(ctx context.Context) error {
+	return systemd.RestartUnit(ctx, "operations-center.service")
 }
 
-// GetServerCertificate returns the keypair for the server certificate.
-func (*operationsCenter) GetServerCertificate() (*tls.Certificate, error) {
-	// Load the certificate.
-	tlsCert, err := os.ReadFile("/var/lib/operations-center/server.crt")
-	if err != nil {
-		return nil, err
-	}
-
-	tlsKey, err := os.ReadFile("/var/lib/operations-center/server.key")
-	if err != nil {
-		return nil, err
-	}
-
-	// Put together a keypair.
-	cert, err := tls.X509KeyPair(tlsCert, tlsKey)
-	if err != nil {
-		return nil, err
-	}
-
-	return &cert, nil
+// RestoreBackup restores a tar archive backup of the application's configuration and/or state.
+func (*operationsCenter) RestoreBackup(ctx context.Context, archive io.Reader) error {
+	return extractTarArchive(ctx, "/var/lib/operations-center/", []string{"operations-center.service"}, archive)
 }
 
-// GetDependencies returns a list of other applications this application depends on.
-func (*operationsCenter) GetDependencies() []string {
-	return nil
+// Start starts the systemd unit.
+func (oc *operationsCenter) Start(ctx context.Context) error {
+	err := oc.ConfigureLocalStorage(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Start the unit.
+	return systemd.StartUnit(ctx, "operations-center.service")
 }
 
-// AddTrustedCertificate adds a new trusted certificate to the application.
-func (*operationsCenter) AddTrustedCertificate(ctx context.Context, _ string, cert string) error {
-	// Compute the certificate's fingerprint.
-	fp, err := getCertificateFingerprint(cert)
-	if err != nil {
-		return err
-	}
-
-	// Get the current security configuration.
-	body, err := doOCRequest(ctx, "http://localhost/1.0/system/security", http.MethodGet, nil)
-	if err != nil {
-		return err
-	}
-
-	sec := &ocapi.Security{}
-
-	err = json.Unmarshal(body, sec)
-	if err != nil {
-		return err
-	}
-
-	// Check if the certificate is already trusted.
-	if slices.Contains(sec.TrustedTLSClientCertFingerprints, fp) {
-		return errors.New("client certificate is already trusted")
-	}
-
-	// Add the certificate's fingerprint to list of trusted clients.
-	sec.TrustedTLSClientCertFingerprints = append(sec.TrustedTLSClientCertFingerprints, fp)
-
-	contentJSON, err := json.Marshal(sec)
-	if err != nil {
-		return err
-	}
-
-	_, err = doOCRequest(ctx, "http://localhost/1.0/system/security", http.MethodPut, contentJSON)
-
-	return err
+// Stop stops the systemd unit.
+func (*operationsCenter) Stop(ctx context.Context) error {
+	// Stop the unit.
+	return systemd.StopUnit(ctx, "operations-center.service")
 }
 
-// Operations Center specific helper to interact with the REST API.
-func doOCRequest(ctx context.Context, url string, method string, body []byte) ([]byte, error) {
-	return doRequest(ctx, "/run/operations-center/unix.socket", url, method, body)
-}
-
-// IsPrimary reports if the application is a primary application.
-func (*operationsCenter) IsPrimary() bool {
-	return true
-}
-
-// FactoryReset performs a full factory reset of the application.
-func (oc *operationsCenter) FactoryReset(ctx context.Context) error {
-	// Stop the application.
-	err := oc.Stop(ctx)
+// Update triggers restart after an application update.
+func (*operationsCenter) Update(ctx context.Context) error {
+	// Reload the systemd daemon to pickup any service definition changes.
+	err := systemd.ReloadDaemon(ctx)
 	if err != nil {
 		return err
 	}
 
-	// Wipe local configuration.
-	err = oc.WipeLocalData(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Check if we're locally registered with it.
-	if oc.state.System.Provider.State.Registered && (oc.state.System.Provider.Config.Config == nil || oc.state.System.Provider.Config.Config["server_url"] == "") {
-		oc.state.System.Provider.State.Registered = false
-		oc.state.System.Provider.Config.Config = map[string]string{}
-	}
-
-	// Start the application.
-	err = oc.Start(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Perform first start initialization.
-	return oc.Initialize(ctx)
+	// Restart the unit.
+	return systemd.RestartUnit(ctx, "operations-center.service")
 }
 
 // WipeLocalData removes local data created by the application.
@@ -338,34 +365,7 @@ func (*operationsCenter) WipeLocalData(ctx context.Context) error {
 	return zfs.CreateApplicationDataset(ctx, "operations-center")
 }
 
-// GetBackup returns a tar archive backup of the application's configuration and/or state.
-func (*operationsCenter) GetBackup(archive io.Writer, complete bool) error {
-	if complete {
-		return createTarArchive("/var/lib/operations-center/", nil, archive)
-	}
-
-	return createTarArchive("/var/lib/operations-center/", []string{"updates"}, archive)
-}
-
-// RestoreBackup restores a tar archive backup of the application's configuration and/or state.
-func (*operationsCenter) RestoreBackup(ctx context.Context, archive io.Reader) error {
-	return extractTarArchive(ctx, "/var/lib/operations-center/", []string{"operations-center.service"}, archive)
-}
-
-// ConfigureLocalStorage configures local storage for the application.
-func (oc *operationsCenter) ConfigureLocalStorage(ctx context.Context) error {
-	// If the application isn't initialized, create a ZFS dataset for it to use.
-	if !oc.state.Applications["operations-center"].State.Initialized {
-		err := zfs.CreateApplicationDataset(ctx, "operations-center")
-		if err != nil {
-			return err
-		}
-	} else {
-		err := zfs.MountApplicationDataset(ctx, "operations-center")
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+// Operations Center specific helper to interact with the REST API.
+func doOCRequest(ctx context.Context, url string, method string, body []byte) ([]byte, error) {
+	return doRequest(ctx, "/run/operations-center/unix.socket", url, method, body)
 }

--- a/incus-osd/internal/applications/helpers.go
+++ b/incus-osd/internal/applications/helpers.go
@@ -1,0 +1,466 @@
+package applications
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/lxc/incus/v6/shared/api"
+	"github.com/lxc/incus/v6/shared/revert"
+
+	"github.com/lxc/incus-os/incus-osd/internal/state"
+	"github.com/lxc/incus-os/incus-osd/internal/systemd"
+)
+
+// UninstallApplication removes the given application from the state, wipes any local
+// data, and removes the sysext image for the application.
+func UninstallApplication(ctx context.Context, s *state.State, name string) error {
+	// Load the application.
+	app, err := Load(ctx, s, name)
+	if err != nil {
+		return err
+	}
+
+	// Can't remove a primary application.
+	if app.IsPrimary() {
+		return errors.New("cannot remove a primary application")
+	}
+
+	// Stop the application.
+	err = app.Stop(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Wipe local data.
+	err = app.WipeLocalData(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Remove application from the state.
+	delete(s.Applications, app.Name())
+
+	// Remove the sysext image.
+	err = systemd.RemoveExtension(ctx, app.Name())
+	if err != nil {
+		return err
+	}
+
+	// Save the state to disk.
+	return s.Save()
+}
+
+// StartInitialize starts the specified application, and if needed performs initialization actions.
+func StartInitialize(ctx context.Context, s *state.State, appName string) error {
+	// Get the application.
+	app, err := Load(ctx, s, appName)
+	if err != nil {
+		return err
+	}
+
+	// At this point, we know the application will exist in the map.
+	appInfo := s.Applications[appName]
+
+	// Start the application.
+	slog.InfoContext(ctx, "Starting application", "name", appName, "version", appInfo.State.Version)
+
+	err = app.Start(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Run initialization if needed.
+	if !appInfo.State.Initialized {
+		slog.InfoContext(ctx, "Initializing application", "name", appName, "version", appInfo.State.Version)
+
+		err = app.Initialize(ctx)
+		if err != nil {
+			return err
+		}
+
+		appInfo.State.Initialized = true
+		s.Applications[appName] = appInfo
+	}
+
+	// If the application has a TLS certificate, print its fingerprint so the user can verify it when initially connecting.
+	cert, err := app.GetServerCertificate()
+	if err == nil {
+		rawFp := sha256.Sum256(cert.Certificate[0])
+
+		slog.InfoContext(ctx, "Application TLS certificate fingerprint", "name", appName, "fingerprint", hex.EncodeToString(rawFp[:]))
+	}
+
+	// Save the state to disk.
+	return s.Save()
+}
+
+// Common helper to construct an HTTP client using the provided local Unix socket.
+func unixHTTPClient(socketPath string) (*http.Client, error) {
+	// Setup a Unix socket dialer
+	unixDial := func(_ context.Context, _ string, _ string) (net.Conn, error) {
+		raddr, err := net.ResolveUnixAddr("unix", socketPath)
+		if err != nil {
+			return nil, err
+		}
+
+		return net.DialUnix("unix", nil, raddr)
+	}
+
+	// Define the http transport
+	transport := &http.Transport{
+		DialContext:           unixDial,
+		DisableKeepAlives:     true,
+		ExpectContinueTimeout: time.Second * 30,
+		ResponseHeaderTimeout: time.Second * 3600,
+		TLSHandshakeTimeout:   time.Second * 5,
+	}
+
+	// Define the http client
+	client := &http.Client{}
+
+	client.Transport = transport
+
+	// Setup redirect policy
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		// Replicate the headers
+		req.Header = via[len(via)-1].Header // #nosec G119
+
+		return nil
+	}
+
+	return client, nil
+}
+
+// Common helper for performing REST API calls.
+func doRequest(ctx context.Context, socket string, url string, method string, body []byte) ([]byte, error) {
+	client, err := unixHTTPClient(socket)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	r := &api.ResponseRaw{}
+
+	err = json.NewDecoder(resp.Body).Decode(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK || r.StatusCode != http.StatusOK {
+		return nil, errors.New(r.Error)
+	}
+
+	ret, err := json.Marshal(r.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// Comment helper to compute the SHA256 fingerprint of a PEM-encoded certificate.
+func getCertificateFingerprint(certificate string) (string, error) {
+	certBlock, _ := pem.Decode([]byte(certificate))
+	if certBlock == nil {
+		return "", errors.New("cannot parse certificate PEM")
+	}
+
+	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("invalid certificate: %w", err)
+	}
+
+	rawFp := sha256.Sum256(cert.Raw)
+
+	return hex.EncodeToString(rawFp[:]), nil
+}
+
+func createTarArchive(archiveRoot string, excludePaths []string, archive io.Writer) error {
+	zw := gzip.NewWriter(archive)
+	tw := tar.NewWriter(zw)
+
+	// Stat the archive root to get the device it's on, so we can limit our walk to just that file system.
+	s, err := os.Stat(archiveRoot)
+	if err != nil {
+		return err
+	}
+
+	rootStat, ok := s.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("unable to stat file " + archiveRoot)
+	}
+
+	rootDev := rootStat.Dev
+
+	err = filepath.WalkDir(archiveRoot, func(path string, dirEntry fs.DirEntry, _ error) error {
+		archiveFilename := strings.TrimPrefix(path, archiveRoot)
+
+		// Skip the root directory and any relative path starting with a path to be excluded.
+		if archiveFilename == "" || slices.ContainsFunc(excludePaths, func(s string) bool {
+			return strings.HasPrefix(archiveFilename, s)
+		}) {
+			return nil
+		}
+
+		info, err := dirEntry.Info()
+		if err != nil {
+			return err
+		}
+
+		mode := int64(info.Mode().Perm())
+		modTime := info.ModTime()
+
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return errors.New("unable to stat file " + archiveFilename)
+		}
+
+		uid := int(stat.Uid)
+		gid := int(stat.Gid)
+
+		// Don't walk other file systems.
+		if info.Mode().IsDir() && stat.Dev != rootDev {
+			return fs.SkipDir
+		}
+
+		switch {
+		case info.Mode().IsDir():
+			// Create the header for the directory.
+			header := &tar.Header{
+				Name:     archiveFilename,
+				Typeflag: tar.TypeDir,
+				Mode:     mode,
+				ModTime:  modTime,
+				Uid:      uid,
+				Gid:      gid,
+			}
+
+			// Write the header.
+			err := tw.WriteHeader(header)
+			if err != nil {
+				return err
+			}
+		case info.Mode()&os.ModeSymlink == os.ModeSymlink:
+			// Get the symlink destination.
+			dest, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+
+			// Create the header for the symlink.
+			header := &tar.Header{
+				Name:     archiveFilename,
+				Typeflag: tar.TypeSymlink,
+				Linkname: dest,
+				Mode:     mode,
+				ModTime:  modTime,
+				Uid:      uid,
+				Gid:      gid,
+			}
+
+			// Write the header.
+			err = tw.WriteHeader(header)
+			if err != nil {
+				return err
+			}
+		case info.Mode().IsRegular():
+			// Open the file.
+			// #nosec G304,G122
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+
+			// Create the header for the file.
+			header := &tar.Header{
+				Name:     archiveFilename,
+				Typeflag: tar.TypeReg,
+				Mode:     mode,
+				ModTime:  modTime,
+				Uid:      uid,
+				Gid:      gid,
+				Size:     info.Size(),
+			}
+
+			// Write the header and file contents.
+			err = tw.WriteHeader(header)
+			if err != nil {
+				return err
+			}
+
+			_, err = io.Copy(tw, file)
+			if err != nil {
+				return err
+			}
+		default:
+			return errors.New("unsupported file: " + archiveFilename)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	err = tw.Close()
+	if err != nil {
+		return err
+	}
+
+	return zw.Close()
+}
+
+func extractTarArchive(ctx context.Context, archiveRoot string, restartUnits []string, archive io.Reader) error {
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	// Create the new root directory.
+	stat, err := os.Stat(archiveRoot)
+	if err != nil {
+		return err
+	}
+
+	newArchiveRoot := strings.TrimSuffix(archiveRoot, "/") + ".new"
+
+	err = os.Mkdir(newArchiveRoot, stat.Mode())
+	if err != nil {
+		return err
+	}
+
+	// If we encounter an error, clean up intermediate state.
+	reverter.Add(func() {
+		_ = os.RemoveAll(newArchiveRoot)
+	})
+
+	// Iterate through each file in the tar archive.
+	gz, err := gzip.NewReader(archive)
+	if err != nil {
+		return err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		header, err := tr.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return err
+		}
+
+		// Don't let someone feed us a path traversal escape attack.
+		// #nosec G305
+		filename := filepath.Join(newArchiveRoot, header.Name)
+		if !strings.HasPrefix(filename, newArchiveRoot) {
+			return fmt.Errorf("cannot restore file outside of application root '%s' (bad file '%s')", archiveRoot, filename)
+		}
+
+		mode := fs.FileMode(header.Mode) // #nosec G115
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			err := os.Mkdir(filename, mode)
+			if err != nil {
+				return err
+			}
+		case tar.TypeSymlink:
+			err := os.Symlink(header.Linkname, filename)
+			if err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			// Write file to disk.
+			// #nosec G304
+			file, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, mode)
+			if err != nil {
+				return err
+			}
+			defer file.Close() //nolint:revive
+
+			// Read from the archive in chunks to avoid excessive memory consumption.
+			var size int64
+
+			for {
+				n, err := io.CopyN(file, tr, 4*1024*1024)
+				size += n
+
+				if err != nil {
+					if errors.Is(err, io.EOF) {
+						break
+					}
+
+					return err
+				}
+			}
+		default:
+			return errors.New("unsupported file: " + header.Name)
+		}
+
+		// Set proper ownership.
+		err = os.Lchown(filename, header.Uid, header.Gid)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Stop unit(s).
+	err = systemd.StopUnit(ctx, restartUnits...)
+	if err != nil {
+		return err
+	}
+
+	// Remove the existing directory.
+	err = os.RemoveAll(archiveRoot)
+	if err != nil {
+		return err
+	}
+
+	// Rename the new directory.
+	err = os.Rename(newArchiveRoot, archiveRoot)
+	if err != nil {
+		return err
+	}
+
+	// Start unit(s).
+	err = systemd.StartUnit(ctx, restartUnits...)
+	if err != nil {
+		return err
+	}
+
+	reverter.Success()
+
+	return nil
+}

--- a/incus-osd/internal/applications/struct.go
+++ b/incus-osd/internal/applications/struct.go
@@ -29,5 +29,5 @@ type Application interface { //nolint:interfacebloat
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
 	Update(ctx context.Context) error
-	WipeLocalData(_ context.Context) error
+	WipeLocalData(ctx context.Context) error
 }

--- a/incus-osd/internal/services/struct.go
+++ b/incus-osd/internal/services/struct.go
@@ -8,8 +8,8 @@ import (
 // Service represents a system service.
 type Service interface {
 	Get(ctx context.Context) (any, error)
-	ShouldStart() bool
 	Reset(ctx context.Context) error
+	ShouldStart() bool
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
 	Struct() any
@@ -19,8 +19,8 @@ type Service interface {
 
 type common struct{}
 
-func (*common) Get(_ context.Context) (any, error) {
-	return nil, nil //nolint:nilnil
+func (*common) Reset(_ context.Context) error {
+	return errors.New("reset isn't supported by this service")
 }
 
 func (*common) ShouldStart() bool {
@@ -35,18 +35,6 @@ func (*common) Stop(_ context.Context) error {
 	return nil
 }
 
-func (*common) Reset(_ context.Context) error {
-	return errors.New("Reset isn't supported by this service")
-}
-
-func (*common) Struct() any {
-	return nil
-}
-
 func (*common) Supported() bool {
 	return true
-}
-
-func (*common) Update(_ context.Context, _ any) error {
-	return nil
 }


### PR DESCRIPTION
* Purely reorganizing of application code:
  - Move generic helper methods to their own file
  - Sort application methods by alphabetical order
  - Move incus-ceph and incus-linstor applications to their own file
* Remove common methods that must be implemented by each service