### PR TITLE
Disable incus-agent exec and file transfers by default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,6 +132,7 @@ jobs:
             -c limits.memory=2GiB \
             -d root,size=50GiB
           incus config device add test-incus-os vtpm tpm
+          incus config set test-incus-os systemd.credential.fully-enable-incus-agent true
           incus start test-incus-os
 
           incus wait test-incus-os agent --timeout 300

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,9 @@ test:
 	incus config device add test-incus-os vtpm tpm
 	incus config device add test-incus-os boot-media disk source=$$(pwd)/mkosi.output/${OSNAME}_boot_media.img io.bus=usb boot.priority=10 readonly=false
 
+	# Enable full incus-agent capability
+	incus config set test-incus-os systemd.credential.fully-enable-incus-agent true
+
 	# Wait for installation to complete
 	incus start test-incus-os --console
 	@sleep 5 # Wait for VM self-reboot
@@ -162,6 +165,9 @@ test-iso:
 		-d root,size=50GiB
 	incus config device add test-incus-os vtpm tpm
 	incus config device add test-incus-os boot-media disk pool=default source=${OSNAME}_boot_media.iso boot.priority=10
+
+	# Enable full incus-agent capability
+	incus config set test-incus-os systemd.credential.fully-enable-incus-agent true
 
 	# Wait for installation to complete
 	incus start test-incus-os --console

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -56,6 +56,16 @@ You can now test your new command or other changes: `./incus admin os ...`
 
 ## Debugging
 
+```{note}
+Running commands or opening a shell on an IncusOS server is only possible when run as an Incus virtual machine and requires fully enabling `incus-agent`
+support. Be aware that this will cause the system to report a degraded security state via the API and an on-screen message. This is because running
+arbitrary commands within the virtual machine can make changes outside of the control of IncusOS.
+
+To fully enable `incus-agent` support in the virtual machine, run the following command and then restart the virtual machine.
+
+    incus config set <vm> systemd.credential.fully-enable-incus-agent true
+```
+
 When IncusOS is run in an Incus virtual machine, it is possible to `exec` into the running
 system to facilitate debugging of the system:
 

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/lxc/incus/v7/shared/subprocess"
+	"go.yaml.in/yaml/v4"
 	"golang.org/x/sys/unix"
 
 	"github.com/lxc/incus-os/incus-osd/certs"
@@ -93,6 +94,13 @@ func main() {
 	// Record the OS name and version in the state.
 	s.OS.Name = osName
 	s.OS.RunningRelease = osRelease
+
+	// Configure incus-agent.
+	err = configureIncusAgent(ctx, s)
+	if err != nil {
+		tui.EarlyError("unable to configure incus-agent: "+err.Error(), s.OS.Name)
+		os.Exit(1)
+	}
 
 	// Record if the system is relying on a swtpm-backed TPM.
 	s.UsingSWTPM = secureboot.GetSWTPMInUse()
@@ -974,4 +982,97 @@ func migrateApplicationData(ctx context.Context, applicationName string) error {
 
 	// Remove the old directory.
 	return os.RemoveAll(filepath.Join("/var/lib/", applicationName+".bak"))
+}
+
+func configureIncusAgent(ctx context.Context, s *state.State) error {
+	// Only attempt to configure incus-agent if we're running within an Incus VM.
+	_, err := os.Stat("/dev/virtio-ports/org.linuxcontainers.incus")
+	if err != nil {
+		return nil //nolint:nilerr
+	}
+
+	type agentConfig struct {
+		Features map[string]bool `yaml:"features"`
+	}
+
+	// Check if the systemd credential "fully-enable-incus-agent" is defined.
+	_, err = os.Stat("/run/credentials/@system/fully-enable-incus-agent")
+	enableAgent := err == nil
+
+	// Check if we will need to restart the incus-agent to pickup a configuration change.
+	restartAgent := false
+
+	data, err := os.ReadFile("/etc/incus-agent.yml")
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+
+		restartAgent = true
+	}
+
+	cfg := agentConfig{}
+
+	if len(data) > 0 {
+		err := yaml.Load(data, &cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Set basic incus-agent capabilities.
+	if cfg.Features == nil {
+		cfg.Features = make(map[string]bool)
+	}
+
+	cfg.Features["guestapi"] = true
+	cfg.Features["mounts"] = true
+	cfg.Features["metrics"] = true
+	cfg.Features["state"] = true
+
+	// Update incus-agent configuration if needed.
+	if enableAgent {
+		if !cfg.Features["exec"] || !cfg.Features["files"] {
+			restartAgent = true
+			cfg.Features["exec"] = true
+			cfg.Features["files"] = true
+
+			// This flag will always remain true once set to indicate
+			// that incus-agent was fully enabled at some point.
+			s.FullAgentEnabled = true
+
+			err := secureboot.BlowTrustedFuse()
+			if err != nil {
+				return errors.New("unable to blow security fuse: " + err.Error())
+			}
+		}
+	} else {
+		if cfg.Features["exec"] || cfg.Features["files"] {
+			restartAgent = true
+			cfg.Features["exec"] = false
+			cfg.Features["files"] = false
+		}
+	}
+
+	// Restart incus-agent if necessary.
+	if restartAgent {
+		// Write the configuration file.
+		data, err := yaml.Dump(&cfg, yaml.V2)
+		if err != nil {
+			return err
+		}
+
+		err = os.WriteFile("/etc/incus-agent.yml", data, 0o600)
+		if err != nil {
+			return err
+		}
+
+		// Restart incus-agent.
+		err = systemd.RestartUnit(ctx, "incus-agent.service")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -598,6 +598,11 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 		slog.WarnContext(ctx, "Degraded security state: Secure Boot is disabled")
 	}
 
+	// Display a warning if incus-agent has ever been fully enabled.
+	if s.FullAgentEnabled {
+		slog.WarnContext(ctx, "Degraded security state: incus-agent has been fully enabled")
+	}
+
 	// Display a warning if we're running from the backup image.
 	if s.OS.RunningFromBackup() {
 		slog.WarnContext(ctx, "Booted from backup "+s.OS.Name+" image version "+s.OS.RunningRelease)

--- a/incus-osd/internal/state/struct.go
+++ b/incus-osd/internal/state/struct.go
@@ -50,6 +50,7 @@ type State struct {
 	SecureBoot         SecureBoot `json:"secure_boot"`
 	UsingSWTPM         bool       `json:"using_swtpm"`
 	SecureBootDisabled bool       `json:"secure_boot_disabled"`
+	FullAgentEnabled   bool       `json:"full_agent_enabled"`
 
 	Applications struct {
 		Debug            api.Application      `json:"debug"`

--- a/incus-osd/internal/tui/tui.go
+++ b/incus-osd/internal/tui/tui.go
@@ -310,6 +310,10 @@ func (t *TUI) redrawScreen() {
 			t.frame.AddText("WARNING: Degraded security state: Secure Boot is disabled", true, tview.AlignCenter, tcell.ColorRed)
 		}
 
+		if t.state.FullAgentEnabled {
+			t.frame.AddText("WARNING: Degraded security state: incus-agent has been fully enabled", true, tview.AlignCenter, tcell.ColorRed)
+		}
+
 		// Get list of applications from state.
 		apps, err := applications.GetInstalled(context.Background(), t.state)
 		if err != nil {

--- a/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
+++ b/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
@@ -34,6 +34,8 @@ class IncusTestVM:
         else:
             self.AddDevice("boot-media", "disk", "pool=default", "source="+self.vm_name+".iso", "boot.priority=10")
 
+        subprocess.run(["incus", "config", "set", self.vm_name, "systemd.credential.fully-enable-incus-agent", "true"], capture_output=True, check=True)
+
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_reset.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_reset.py
@@ -30,8 +30,9 @@ def TestIncusOSAPISystemReset(install_image):
         vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+incusos_version)
         vm.WaitExpectedLog("incus-osd", "System is ready version="+incusos_version)
 
-        # Shouldn't see any mention of a degraded security state
-        vm.LogDoesntContain("incus-osd", "Degraded security state:")
+        # Shouldn't see any mention of a TPM or SecureBoot degraded security state
+        vm.LogDoesntContain("incus-osd", "Degraded security state: no physical TPM found, using swtpm")
+        vm.LogDoesntContain("incus-osd", "Degraded security state: Secure Boot is disabled")
 
 def TestIncusOSAPISystemResetSWTPM(install_image):
     test_name = "incusos-api-system-reset-swtpm"
@@ -110,8 +111,9 @@ def TestIncusOSAPISystemResetSWTPMToTPM(install_image):
         vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+incusos_version)
         vm.WaitExpectedLog("incus-osd", "System is ready version="+incusos_version)
 
-        # Shouldn't see any mention of a degraded security state
-        vm.LogDoesntContain("incus-osd", "Degraded security state:")
+        # Shouldn't see any mention of a TPM or SecureBoot degraded security state
+        vm.LogDoesntContain("incus-osd", "Degraded security state: no physical TPM found, using swtpm")
+        vm.LogDoesntContain("incus-osd", "Degraded security state: Secure Boot is disabled")
 
 def TestIncusOSAPISystemResetSecureBootDisabled(install_image):
     test_name = "incusos-api-system-reset-secureboot-disabled"
@@ -184,5 +186,6 @@ def TestIncusOSAPISystemResetSecureBootDisabledToSB(install_image):
             vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+incusos_version)
             vm.WaitExpectedLog("incus-osd", "System is ready version="+incusos_version)
 
-            # Shouldn't see any mention of a degraded security state
-            vm.LogDoesntContain("incus-osd", "Degraded security state:")
+            # Shouldn't see any mention of a TPM or SecureBoot degraded security state
+            vm.LogDoesntContain("incus-osd", "Degraded security state: no physical TPM found, using swtpm")
+            vm.LogDoesntContain("incus-osd", "Degraded security state: Secure Boot is disabled")

--- a/incus-osd/tests/incusos_tests/tests_incusos_live.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_live.py
@@ -25,8 +25,9 @@ def TestIncusOSLive(install_image):
         vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+incusos_version)
         vm.WaitExpectedLog("incus-osd", "System is ready version="+incusos_version)
 
-        # Shouldn't see any mention of a degraded security state
-        vm.LogDoesntContain("incus-osd", "Degraded security state:")
+        # Shouldn't see any mention of a TPM or SecureBoot degraded security state
+        vm.LogDoesntContain("incus-osd", "Degraded security state: no physical TPM found, using swtpm")
+        vm.LogDoesntContain("incus-osd", "Degraded security state: Secure Boot is disabled")
 
         # Verify that LUKS encryption is bound to PCRs 7+11+15
         result = vm.RunCommand("cryptsetup", "luksDump", "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_live--image-part9")

--- a/incus-osd/tests/incusos_tests/tests_install_multipath.py
+++ b/incus-osd/tests/incusos_tests/tests_install_multipath.py
@@ -19,8 +19,9 @@ def TestInstallMultipath(install_image):
         with IncusTestVM(test_name, test_image) as vm:
             _commonMultipathChecks(vm, incusos_version, disk_img.name)
 
-            # Shouldn't see any mention of a degraded security state
-            vm.LogDoesntContain("incus-osd", "Degraded security state:")
+            # Shouldn't see any mention of a TPM or SecureBoot degraded security state
+            vm.LogDoesntContain("incus-osd", "Degraded security state: no physical TPM found, using swtpm")
+            vm.LogDoesntContain("incus-osd", "Degraded security state: Secure Boot is disabled")
 
 def TestInstallMultipathUseSWTPM(install_image):
     test_name = "multipath-use-swtpm"

--- a/incus-osd/tests/incusos_tests/tests_install_smoke.py
+++ b/incus-osd/tests/incusos_tests/tests_install_smoke.py
@@ -34,8 +34,9 @@ def TestBaselineInstall(install_image):
     with IncusTestVM(test_name, test_image) as vm:
         vm.WaitSystemReady(incusos_version, source="/dev/disk/by-id/(usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0|scsi-0QEMU_QEMU_CD-ROM_incus_boot--media)")
 
-        # Shouldn't see any mention of a degraded security state
-        vm.LogDoesntContain("incus-osd", "Degraded security state:")
+        # Shouldn't see any mention of a TPM or SecureBoot degraded security state
+        vm.LogDoesntContain("incus-osd", "Degraded security state: no physical TPM found, using swtpm")
+        vm.LogDoesntContain("incus-osd", "Degraded security state: Secure Boot is disabled")
 
         # Verify that LUKS encryption is bound to PCRs 7+11+15
         result = vm.RunCommand("cryptsetup", "luksDump", "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part9")
@@ -57,8 +58,9 @@ def TestBaselineInstallReadonlyImage(install_image):
     with IncusTestVM(test_name, test_image, readonly_install_image="true") as vm:
         vm.WaitSystemReady(incusos_version)
 
-        # Shouldn't see any mention of a degraded security state
-        vm.LogDoesntContain("incus-osd", "Degraded security state:")
+        # Shouldn't see any mention of a TPM or SecureBoot degraded security state
+        vm.LogDoesntContain("incus-osd", "Degraded security state: no physical TPM found, using swtpm")
+        vm.LogDoesntContain("incus-osd", "Degraded security state: Secure Boot is disabled")
 
         # Verify that LUKS encryption is bound to PCRs 7+11+15
         result = vm.RunCommand("cryptsetup", "luksDump", "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part9")
@@ -82,8 +84,9 @@ def TestBaselineInstallNVME(install_image):
 
         vm.WaitSystemReady(incusos_version, source="/dev/disk/by-id/(usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0|scsi-0QEMU_QEMU_CD-ROM_incus_boot--media)", target="/dev/disk/by-id/nvme-QEMU_NVMe_Ctrl_incus_root")
 
-        # Shouldn't see any mention of a degraded security state
-        vm.LogDoesntContain("incus-osd", "Degraded security state:")
+        # Shouldn't see any mention of a TPM or SecureBoot degraded security state
+        vm.LogDoesntContain("incus-osd", "Degraded security state: no physical TPM found, using swtpm")
+        vm.LogDoesntContain("incus-osd", "Degraded security state: Secure Boot is disabled")
 
         # Verify that LUKS encryption is bound to PCRs 7+11+15
         result = vm.RunCommand("cryptsetup", "luksDump", "/dev/disk/by-id/nvme-QEMU_NVMe_Ctrl_incus_root-part9")
@@ -107,8 +110,9 @@ def TestBaselineInstallNVMEReadonlyImage(install_image):
 
         vm.WaitSystemReady(incusos_version, source="/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0", target="/dev/disk/by-id/nvme-QEMU_NVMe_Ctrl_incus_root")
 
-        # Shouldn't see any mention of a degraded security state
-        vm.LogDoesntContain("incus-osd", "Degraded security state:")
+        # Shouldn't see any mention of a TPM or SecureBoot degraded security state
+        vm.LogDoesntContain("incus-osd", "Degraded security state: no physical TPM found, using swtpm")
+        vm.LogDoesntContain("incus-osd", "Degraded security state: Secure Boot is disabled")
 
         # Verify that LUKS encryption is bound to PCRs 7+11+15
         result = vm.RunCommand("cryptsetup", "luksDump", "/dev/disk/by-id/nvme-QEMU_NVMe_Ctrl_incus_root-part9")

--- a/mkosi.images/base/mkosi.extra/usr/lib/incus-agent/incus-agent.yml
+++ b/mkosi.images/base/mkosi.extra/usr/lib/incus-agent/incus-agent.yml
@@ -1,0 +1,7 @@
+features:
+  exec: false
+  files: false
+  guestapi: true
+  metrics: true
+  mounts: true
+  state: true

--- a/mkosi.images/base/mkosi.extra/usr/lib/tmpfiles.d/80-incus-agent.conf
+++ b/mkosi.images/base/mkosi.extra/usr/lib/tmpfiles.d/80-incus-agent.conf
@@ -1,0 +1,1 @@
+C /etc/incus-agent.yml - - - - /usr/lib/incus-agent/incus-agent.yml


### PR DESCRIPTION
By default, configure incus-agent to disable exec and file transfers, but retain other capabilities. All features can be enabled by setting the `fully-enable-incus-agent=true` systemd-credential in the VM's configuration, but that will trigger IncusOS to report a degraded security state.

Closes #990