### PR TITLE
Activate a fallback HTTPS listener if the primary application fails to start

### DIFF
--- a/doc/reference/recovery.md
+++ b/doc/reference/recovery.md
@@ -4,6 +4,26 @@ IncusOS is designed to be fairly resilient to failures, but there may be times w
 your system misbehaves. Here are some suggestions that might be useful if you ever
 need to recover an IncusOS system.
 
+## Fallback API endpoint
+
+When IncusOS boots from the prior installed version, or if the primary application fails
+to start, the system will automatically attempt to activate a fallback API endpoint.
+This fallback endpoint allows trusted clients to maintain access to IncusOS via the
+network even if the primary application is unavailable for some reason.
+
+By default, IncusOS will pick a random port and attempt to listen on all available
+network interfaces. The chosen port number will be displayed on the system's terminal.
+A specific IP address and/or port can be set to limit where the fallback API endpoint
+is configured to listen.
+
+On first boot, IncusOS will attempt to extract any trusted client certificates present
+in seed data and set them as trusted client certificates for the fallback API endpoint.
+However, no further automatic synchronization of trusted client certificates is performed.
+The list of trusted client certificates for the fallback API endpoint can be updated at
+any time via
+
+    incus admin os system fallback-listener edit
+
 ## Try booting into the previous image
 
 IncusOS uses an A/B update mechanism to reboot onto the newer version while keeping

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -3539,44 +3539,17 @@ definitions:
         x-go-package: github.com/FuturFusion/migration-manager/shared/api
     Network:
         properties:
-            location:
-                description: Full inventory location path of the network
-                example: /vcenter01/network/net0
+            address:
+                description: Address of Operations Center which is used by managed servers to connect.
                 type: string
-                x-go-name: Location
-            overrides:
-                $ref: '#/definitions/NetworkPlacement'
-            placement:
-                $ref: '#/definitions/NetworkPlacement'
-            properties:
-                description: Additional properties of the network.
-                type: object
-                x-go-name: Properties
-            source:
-                description: vCenter source for the network
-                example: vcenter01
+                x-go-name: OperationsCenterAddress
+            rest_server_address:
+                description: Address and port to bind the REST API to.
                 type: string
-                x-go-name: Source
-            source_specific_id:
-                description: The source-specific identifier of the network
-                example: network-23
-                type: string
-                x-go-name: SourceSpecificID
-            type:
-                $ref: '#/definitions/NetworkType'
-                description: The network type
-                example: bridge
-                readOnly: true
-                type: string
-                x-go-name: Type
-            uuid:
-                description: UUID of the network.
-                format: uuid
-                type: string
-                x-go-name: UUID
-        title: Network defines the network config for use by the migration manager.
+                x-go-name: RestServerAddress
+        title: Network represents the system's network configuration.
         type: object
-        x-go-package: github.com/FuturFusion/migration-manager/shared/api
+        x-go-package: github.com/FuturFusion/operations-center/shared/api/system
     NetworkACL:
         properties:
             config:
@@ -7019,11 +6992,11 @@ definitions:
                     type: string
                 description: Server configuration map (refer to doc/server.md)
                 example:
-                    core.https_address: :8443
+                    core.https_address: :6443
                 type: object
                 x-go-name: Config
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/FuturFusion/migration-manager/shared/api
     ServerStorageDriverInfo:
         description: ServerStorageDriverInfo represents the read-only info about a storage driver
         properties:
@@ -7093,6 +7066,10 @@ definitions:
                 description: Daemon log level.
                 type: string
                 x-go-name: LogLevel
+            server_registration_scriptlet:
+                description: ServerRegistrationScriptlet hold the server registration scriptlet.
+                type: string
+                x-go-name: ServerRegistrationScriptlet
         title: Settings represents global system settings.
         type: object
         x-go-package: github.com/FuturFusion/operations-center/shared/api/system
@@ -7105,6 +7082,10 @@ definitions:
                 description: Daemon log level.
                 type: string
                 x-go-name: LogLevel
+            server_registration_scriptlet:
+                description: ServerRegistrationScriptlet hold the server registration scriptlet.
+                type: string
+                x-go-name: ServerRegistrationScriptlet
         type: object
         x-go-package: github.com/FuturFusion/operations-center/shared/api/system
     Source:
@@ -9583,6 +9564,89 @@ paths:
                 "200":
                     $ref: '#/responses/EmptySyncResponse'
             summary: Suspend the system
+            tags:
+                - system
+    /1.0/system/fallback-listener:
+        get:
+            description: |-
+                Returns information about the system's fallback HTTPS listener, which is activated if
+                the primary application fails to start.
+            operationId: system_get_fallback_listener
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: State and configuration for the fallback listener
+                    schema:
+                        description: Sync response
+                        properties:
+                            metadata:
+                                description: State and configuration for the fallback listener
+                                example:
+                                    config:
+                                        listen_address: 192.168.100.100:8443
+                                        trusted_client_certificates:
+                                            - |-
+                                              -----BEGIN CERTIFICATE-----
+                                              [cert]
+                                              -----END CERTIFICATE-----
+                                    state:
+                                        active: false
+                                type: json
+                            status:
+                                description: Status description
+                                example: Success
+                                type: string
+                            status_code:
+                                description: Status code
+                                example: 200
+                                type: integer
+                            type:
+                                description: Response type
+                                example: sync
+                                type: string
+                        type: object
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Get information about the fallback HTTPS listener
+            tags:
+                - system
+        put:
+            consumes:
+                - application/json
+            description: |-
+                Updates the configuration for the fallback HTTPS listener. Supported options include
+                listening on a specific IP:port and setting the list of trusted client TLS certificates,
+                which should be provided as PEM-encoded certificates.
+            operationId: system_put_fallback_listener
+            parameters:
+                - description: Fallback listener configuration
+                  in: body
+                  name: configuration
+                  required: true
+                  schema:
+                    properties:
+                        config:
+                            description: The fallback listener configuration
+                            example:
+                                listen_address: 192.168.100.100:8443
+                                trusted_client_certificates:
+                                    - |-
+                                      -----BEGIN CERTIFICATE-----
+                                      [cert]
+                                      -----END CERTIFICATE-----
+                            type: object
+                    type: object
+            produces:
+                - application/json
+            responses:
+                "200":
+                    $ref: '#/responses/EmptySyncResponse'
+                "400":
+                    $ref: '#/responses/BadRequest'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Update the fallback HTTPS listener configuration
             tags:
                 - system
     /1.0/system/kernel:

--- a/incus-osd/api/system_fallback_listener.go
+++ b/incus-osd/api/system_fallback_listener.go
@@ -1,0 +1,21 @@
+package api
+
+// SystemFallbackListenerState holds information about the current fallback listener state.
+type SystemFallbackListenerState struct {
+	Active bool `incusos:"-" json:"active" yaml:"active"`
+}
+
+// SystemFallbackListenerConfig holds fallback listener configuration settings.
+type SystemFallbackListenerConfig struct {
+	ListenAddress             string   `json:"listen_address,omitempty"              yaml:"listen_address,omitempty"`              // If defined, listen on the specified IP:port address, otherwise attempt to listen on all interfaces on a random port.
+	TrustedClientCertificates []string `json:"trusted_client_certificates,omitempty" yaml:"trusted_client_certificates,omitempty"` // A list of PEM-encoded trusted client certificates.
+}
+
+// SystemFallbackListener defines a struct to configure the fallback HTTPS listener that will
+// activate if the primary application fails to start, ensuring that basic API connectivity
+// to the system isn't lost.
+type SystemFallbackListener struct {
+	Config SystemFallbackListenerConfig `json:"config" yaml:"config"`
+
+	State SystemFallbackListenerState `json:"state" yaml:"state"`
+}

--- a/incus-osd/cli/cli_system.go
+++ b/incus-osd/cli/cli_system.go
@@ -98,6 +98,11 @@ func (c *cmdAdminOSSystem) command() *cobra.Command {
 
 	subCommands := []subCommand{
 		{
+			name:        "fallback-listener",
+			description: "System fallback HTTPS listener configuration",
+			isWritable:  true,
+		},
+		{
 			name:        "kernel",
 			description: "System kernel configuration",
 			isWritable:  true,

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -604,6 +604,11 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 
 	slog.InfoContext(ctx, "System is starting up", "mode", mode, "version", s.OS.RunningRelease, "machine-id", strings.TrimSuffix(machineID, "\n"))
 
+	// Create this channel early, so we don't block trying to trigger the fallback HTTPS listener.
+	// We can't move the channel processing loop here, because it depends on having a provider (and
+	// therefore potentially a network) properly configured.
+	s.TriggerFallbackListener = make(chan bool, 1)
+
 	// Display a warning if we're running with a swtpm-backed TPM.
 	if s.UsingSWTPM {
 		slog.WarnContext(ctx, "Degraded security state: no physical TPM found, using swtpm")
@@ -834,6 +839,13 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 			goto waitSignal
 		case <-s.TriggerUpdate:
 			update.Checker(ctx, s, p, false, true)
+
+			goto waitSignal
+		case <-s.TriggerFallbackListener:
+			err := startFallbackListener(ctx, s)
+			if err != nil {
+				slog.ErrorContext(ctx, "Failed to start fallback HTTPS listener", "err", err)
+			}
 
 			goto waitSignal
 		}
@@ -1094,6 +1106,51 @@ func configureIncusAgent(ctx context.Context, s *state.State) error {
 			return err
 		}
 	}
+
+	return nil
+}
+
+func startFallbackListener(ctx context.Context, s *state.State) error {
+	// Get the primary application, requiring that it be initialized.
+	app, err := applications.GetPrimary(ctx, s, true)
+	if err != nil {
+		return err
+	}
+
+	// Get server TLS certificates from the primary application so we don't trigger potential connection security warnings.
+	serverCert, err := app.GetServerCertificate()
+	if err != nil {
+		return err
+	}
+
+	listenAddress := s.System.FallbackListener.Config.ListenAddress
+	if listenAddress == "" {
+		// If no address is configured, attempt to listen on all interfaces.
+		listenAddress = ":0"
+	}
+
+	// Setup a TCP listener on the interface(s).
+	listenConfig := net.ListenConfig{}
+
+	tcpListener, err := listenConfig.Listen(ctx, "tcp", listenAddress)
+	if err != nil {
+		return err
+	}
+
+	// Start the fallback HTTPS server.
+	server, err := rest.NewServer(ctx, s, util.NewFancyTLSListener(tcpListener, *serverCert))
+	if err != nil {
+		return err
+	}
+
+	s.System.FallbackListener.State.Active = true
+
+	slog.InfoContext(ctx, "Fallback HTTPS listener started on "+tcpListener.Addr().String())
+
+	// Listen until reboot.
+	go func() {
+		_ = server.Serve()
+	}()
 
 	return nil
 }

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -627,6 +627,10 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 	// Display a warning if we're running from the backup image.
 	if s.OS.RunningFromBackup() {
 		slog.WarnContext(ctx, "Booted from backup "+s.OS.Name+" image version "+s.OS.RunningRelease)
+
+		slog.WarnContext(ctx, "Will attempt to enable fallback HTTPS server for additional connectivity after completing startup tasks")
+
+		s.TriggerFallbackListener <- true
 	}
 
 	// Check for and run recovery logic if present.

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -775,7 +775,19 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 	for _, app := range apps {
 		err := applications.StartInitialize(ctx, s, app.Name())
 		if err != nil {
-			return err
+			if !app.IsPrimary() {
+				return err
+			}
+
+			slog.ErrorContext(ctx, err.Error())
+
+			// If not running from the backup image, which automatically starts the fallback HTTPS listener,
+			// attempt to start it when the primary application has failed to start.
+			if !s.OS.RunningFromBackup() {
+				slog.WarnContext(ctx, "Primary application "+app.Name()+" failed to start; attempting to enable fallback HTTPS server for basic connectivity")
+
+				s.TriggerFallbackListener <- true
+			}
 		}
 	}
 

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -276,8 +277,23 @@ func run(ctx context.Context, s *state.State) error {
 		slog.WarnContext(ctx, fmt.Sprintf("Only %.02fGiB free space available in /", freeSpace))
 	}
 
+	// Create runtime path if missing.
+	err = os.Mkdir(runPath, 0o700)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	// Setup Unix socket listener.
+	_ = os.Remove(filepath.Join(runPath, "unix.socket"))
+	lc := &net.ListenConfig{}
+
+	unixListener, err := lc.Listen(ctx, "unix", filepath.Join(runPath, "unix.socket"))
+	if err != nil {
+		return err
+	}
+
 	// Start the API.
-	server, err := rest.NewServer(ctx, s, filepath.Join(runPath, "unix.socket"))
+	server, err := rest.NewServer(ctx, s, unixListener)
 	if err != nil {
 		return err
 	}
@@ -285,7 +301,7 @@ func run(ctx context.Context, s *state.State) error {
 	chErr := make(chan error, 1)
 
 	go func() {
-		err := server.Serve(ctx)
+		err := server.Serve()
 		chErr <- err
 	}()
 

--- a/incus-osd/internal/applications/helpers.go
+++ b/incus-osd/internal/applications/helpers.go
@@ -29,6 +29,7 @@ import (
 	"github.com/lxc/incus/v7/shared/subprocess"
 
 	"github.com/lxc/incus-os/incus-osd/api"
+	"github.com/lxc/incus-os/incus-osd/internal/seed"
 	"github.com/lxc/incus-os/incus-osd/internal/state"
 	"github.com/lxc/incus-os/incus-osd/internal/systemd"
 )
@@ -106,12 +107,52 @@ func StartInitialize(ctx context.Context, s *state.State, appName string) error 
 	}
 
 	// Run initialization if needed.
-	if !app.IsInitialized() {
+	if !app.IsInitialized() { //nolint:nestif
 		slog.InfoContext(ctx, "Initializing application", "name", appName, "version", app.Version())
 
 		err = app.Initialize(ctx)
 		if err != nil {
 			return err
+		}
+
+		// After initializing a primary application, fetch any provided trusted client certificates from
+		// seed data for use by the fallback HTTPS server authentication.
+		switch appName {
+		case "incus":
+			incusSeed, err := seed.GetIncus(ctx)
+			if err != nil && !seed.IsMissing(err) {
+				return err
+			}
+
+			if incusSeed != nil && incusSeed.Preseed != nil {
+				for _, cert := range incusSeed.Preseed.Certificates {
+					if cert.Type != "client" {
+						continue
+					}
+
+					s.System.FallbackListener.Config.TrustedClientCertificates = append(s.System.FallbackListener.Config.TrustedClientCertificates, cert.Certificate)
+				}
+			}
+		case "migration-manager":
+			mmSeed, err := seed.GetMigrationManager(ctx)
+			if err != nil && !seed.IsMissing(err) {
+				return err
+			}
+
+			if mmSeed != nil {
+				s.System.FallbackListener.Config.TrustedClientCertificates = mmSeed.TrustedClientCertificates
+			}
+		case "operations-center":
+			ocSeed, err := seed.GetOperationsCenter(ctx)
+			if err != nil && !seed.IsMissing(err) {
+				return err
+			}
+
+			if ocSeed != nil {
+				s.System.FallbackListener.Config.TrustedClientCertificates = ocSeed.TrustedClientCertificates
+			}
+		default:
+			// Nothing to do
 		}
 	}
 

--- a/incus-osd/internal/rest/api_system_fallback_listener.go
+++ b/incus-osd/internal/rest/api_system_fallback_listener.go
@@ -1,0 +1,146 @@
+package rest
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/netip"
+
+	"github.com/lxc/incus-os/incus-osd/api"
+	"github.com/lxc/incus-os/incus-osd/internal/rest/response"
+)
+
+// swagger:operation GET /1.0/system/fallback-listener system system_get_fallback_listener
+//
+//	Get information about the fallback HTTPS listener
+//
+//	Returns information about the system's fallback HTTPS listener, which is activated if
+//	the primary application fails to start.
+//
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    description: State and configuration for the fallback listener
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          description: Response type
+//	          example: sync
+//	          type: string
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: json
+//	          description: State and configuration for the fallback listener
+//	          example: {"config":{"listen_address":"192.168.100.100:8443","trusted_client_certificates":["-----BEGIN CERTIFICATE-----\n[cert]\n-----END CERTIFICATE-----"]},"state":{"active":false}}
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
+
+// swagger:operation PUT /1.0/system/fallback-listener system system_put_fallback_listener
+//
+//	Update the fallback HTTPS listener configuration
+//
+//	Updates the configuration for the fallback HTTPS listener. Supported options include
+//	listening on a specific IP:port and setting the list of trusted client TLS certificates,
+//	which should be provided as PEM-encoded certificates.
+//
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: configuration
+//	    description: Fallback listener configuration
+//	    required: true
+//	    schema:
+//	      type: object
+//	      properties:
+//	        config:
+//	          type: object
+//	          description: The fallback listener configuration
+//	          example: {"listen_address":"192.168.100.100:8443","trusted_client_certificates":["-----BEGIN CERTIFICATE-----\n[cert]\n-----END CERTIFICATE-----"]}
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
+func (s *Server) apiSystemFallbackListener(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	switch r.Method {
+	case http.MethodGet:
+		// Return the current system fallback listener state.
+		_ = response.SyncResponse(true, s.state.System.FallbackListener).Render(w)
+	case http.MethodPut:
+		// Update the fallback listener configuration.
+		fallbackListenerStruct := &api.SystemFallbackListener{}
+
+		counter := &countWrapper{ReadCloser: r.Body}
+
+		err := json.NewDecoder(counter).Decode(fallbackListenerStruct)
+		if err != nil && counter.n > 0 {
+			_ = response.BadRequest(err).Render(w)
+
+			return
+		}
+
+		// Validate the listen address, if specified.
+		if fallbackListenerStruct.Config.ListenAddress != "" {
+			_, err := netip.ParseAddrPort(fallbackListenerStruct.Config.ListenAddress)
+			if err != nil {
+				_ = response.BadRequest(errors.New("invalid listen address: " + err.Error())).Render(w)
+
+				return
+			}
+		}
+
+		if len(fallbackListenerStruct.Config.TrustedClientCertificates) == 0 {
+			_ = response.BadRequest(errors.New("at least one trusted client TLS certificate must be defined")).Render(w)
+
+			return
+		}
+
+		// Verify that we can parse each trusted certificate.
+		for i, pemCert := range fallbackListenerStruct.Config.TrustedClientCertificates {
+			block, _ := pem.Decode([]byte(pemCert))
+			if block == nil || block.Type != "CERTIFICATE" {
+				_ = response.BadRequest(fmt.Errorf("certificate at index %d is not PEM-encoded", i)).Render(w)
+
+				return
+			}
+
+			_, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				_ = response.BadRequest(fmt.Errorf("certificate at index %d is not valid: %s", i, err.Error())).Render(w)
+
+				return
+			}
+		}
+
+		s.state.System.FallbackListener = *fallbackListenerStruct
+
+		_ = response.EmptySyncResponse.Render(w)
+	default:
+		// If none of the supported methods, return NotImplemented.
+		_ = response.NotImplemented(nil).Render(w)
+	}
+
+	_ = s.state.Save()
+}

--- a/incus-osd/internal/rest/server.go
+++ b/incus-osd/internal/rest/server.go
@@ -1,9 +1,14 @@
 package rest
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/lxc/incus-os/incus-osd/internal/state"
@@ -85,7 +90,66 @@ func (s *Server) Serve() error {
 
 	// Setup server.
 	server := &http.Server{
-		Handler: router,
+		// If not listening on the local Unix socket, define a custom handler that first checks for
+		// a trusted client TLS certificate and then ensures a proper proxy header is present and
+		// trims the "/os" prefix if present before passing the request to the standard handler.
+		Handler: func(h http.Handler) http.Handler {
+			if s.listener.Addr().Network() != "unix" {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.TLS == nil {
+						http.Error(w, "Upgrade Required", http.StatusUpgradeRequired)
+
+						return
+					}
+
+					if len(r.TLS.PeerCertificates) == 0 {
+						http.Error(w, "Forbidden", http.StatusForbidden)
+
+						return
+					}
+
+					// Verify the client provided a TLS certificate that matches a trusted fingerprint.
+					foundTrustedClient := false
+
+					clientFp := sha256.Sum256(r.TLS.PeerCertificates[0].Raw)
+
+					for _, trustedCert := range s.state.System.FallbackListener.Config.TrustedClientCertificates {
+						block, _ := pem.Decode([]byte(trustedCert))
+						if block == nil || block.Type != "CERTIFICATE" {
+							continue
+						}
+
+						cert, err := x509.ParseCertificate(block.Bytes)
+						if err != nil {
+							continue
+						}
+
+						certFp := sha256.Sum256(cert.Raw)
+
+						if bytes.Equal(clientFp[:], certFp[:]) {
+							foundTrustedClient = true
+
+							break
+						}
+					}
+
+					if !foundTrustedClient {
+						http.Error(w, "Forbidden", http.StatusForbidden)
+
+						return
+					}
+
+					// Ensure a proper proxy header is set and trim the "/os" prefix if present.
+					r.Header.Set("X-IncusOS-Proxy", "/os")
+					r.URL.Path = strings.TrimPrefix(r.URL.Path, "/os")
+
+					// Serve the request.
+					h.ServeHTTP(w, r)
+				})
+			}
+
+			return h
+		}(router),
 
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 0,

--- a/incus-osd/internal/rest/server.go
+++ b/incus-osd/internal/rest/server.go
@@ -67,6 +67,7 @@ func (s *Server) Serve() error {
 	router.HandleFunc("/1.0/system/:reboot", s.apiSystemReboot)
 	router.HandleFunc("/1.0/system/:restore", s.apiSystemRestore)
 	router.HandleFunc("/1.0/system/:suspend", s.apiSystemSuspend)
+	router.HandleFunc("/1.0/system/fallback-listener", s.apiSystemFallbackListener)
 	router.HandleFunc("/1.0/system/kernel", s.apiSystemKernel)
 	router.HandleFunc("/1.0/system/logging", s.apiSystemLogging)
 	router.HandleFunc("/1.0/system/network", s.apiSystemNetwork)

--- a/incus-osd/internal/rest/server.go
+++ b/incus-osd/internal/rest/server.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/lxc/incus-os/incus-osd/internal/state"
@@ -13,38 +11,23 @@ import (
 
 // Server holds the internal state of the REST API server.
 type Server struct {
-	socketPath string
-	state      *state.State
+	listener net.Listener
+	state    *state.State
 }
 
 // NewServer returns a REST API server object.
-func NewServer(_ context.Context, s *state.State, socketPath string) (*Server, error) {
+func NewServer(_ context.Context, s *state.State, l net.Listener) (*Server, error) {
 	// Define the struct.
 	server := Server{
-		socketPath: socketPath,
-		state:      s,
-	}
-
-	// Create runtime path if missing.
-	err := os.Mkdir(filepath.Dir(socketPath), 0o700)
-	if err != nil && !os.IsExist(err) {
-		return nil, err
+		listener: l,
+		state:    s,
 	}
 
 	return &server, nil
 }
 
 // Serve starts the REST API server.
-func (s *Server) Serve(ctx context.Context) error {
-	// Setup listener.
-	_ = os.Remove(s.socketPath)
-	lc := &net.ListenConfig{}
-
-	listener, err := lc.Listen(ctx, "unix", s.socketPath)
-	if err != nil {
-		return err
-	}
-
+func (s *Server) Serve() error {
 	// Setup routing.
 	router := http.NewServeMux()
 
@@ -108,5 +91,5 @@ func (s *Server) Serve(ctx context.Context) error {
 		WriteTimeout: 0,
 	}
 
-	return server.Serve(listener)
+	return server.Serve(s.listener)
 }

--- a/incus-osd/internal/state/struct.go
+++ b/incus-osd/internal/state/struct.go
@@ -42,10 +42,11 @@ type State struct {
 	NetworkConfigurationChannel chan error `json:"-"`
 
 	// Triggers for daemon actions.
-	TriggerReboot   chan bool `json:"-"`
-	TriggerShutdown chan bool `json:"-"`
-	TriggerSuspend  chan bool `json:"-"`
-	TriggerUpdate   chan bool `json:"-"`
+	TriggerReboot           chan bool `json:"-"`
+	TriggerShutdown         chan bool `json:"-"`
+	TriggerSuspend          chan bool `json:"-"`
+	TriggerUpdate           chan bool `json:"-"`
+	TriggerFallbackListener chan bool `json:"-"`
 
 	SecureBoot         SecureBoot `json:"secure_boot"`
 	UsingSWTPM         bool       `json:"using_swtpm"`

--- a/incus-osd/internal/state/struct.go
+++ b/incus-osd/internal/state/struct.go
@@ -78,13 +78,14 @@ type State struct {
 	} `json:"services"`
 
 	System struct {
-		Kernel   api.SystemKernel   `json:"kernel"`
-		Logging  api.SystemLogging  `json:"logging"`
-		Network  api.SystemNetwork  `json:"network"`
-		Provider api.SystemProvider `json:"provider"`
-		Security api.SystemSecurity `json:"security"`
-		Update   api.SystemUpdate   `json:"update"`
-		Storage  api.SystemStorage  `json:"storage"`
+		FallbackListener api.SystemFallbackListener `json:"fallback_listener"`
+		Kernel           api.SystemKernel           `json:"kernel"`
+		Logging          api.SystemLogging          `json:"logging"`
+		Network          api.SystemNetwork          `json:"network"`
+		Provider         api.SystemProvider         `json:"provider"`
+		Security         api.SystemSecurity         `json:"security"`
+		Update           api.SystemUpdate           `json:"update"`
+		Storage          api.SystemStorage          `json:"storage"`
 	} `json:"system"`
 
 	// Used to handle an edge case of a new network configuration being applied, but

--- a/incus-osd/internal/update/update.go
+++ b/incus-osd/internal/update/update.go
@@ -295,6 +295,12 @@ func reloadApplication(ctx context.Context, s *state.State, appName string, appV
 			s.System.Update.State.Status = "Failed to reload application"
 			showModalError(ctx, s.OS.Name, s.System.Update.State.Status, err, p)
 
+			if app.IsPrimary() {
+				slog.WarnContext(ctx, "Primary application "+app.Name()+" failed to reload; attempting to enable fallback HTTPS server for basic connectivity")
+
+				s.TriggerFallbackListener <- true
+			}
+
 			return err
 		}
 	} else {
@@ -302,6 +308,12 @@ func reloadApplication(ctx context.Context, s *state.State, appName string, appV
 		if err != nil {
 			s.System.Update.State.Status = "Failed to start application"
 			showModalError(ctx, s.OS.Name, s.System.Update.State.Status, err, p)
+
+			if app.IsPrimary() {
+				slog.WarnContext(ctx, "Primary application "+app.Name()+" failed to start; attempting to enable fallback HTTPS server for basic connectivity")
+
+				s.TriggerFallbackListener <- true
+			}
 
 			return err
 		}

--- a/incus-osd/internal/util/fancytls.go
+++ b/incus-osd/internal/util/fancytls.go
@@ -1,0 +1,111 @@
+package util
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"slices"
+	"sync"
+
+	"github.com/pires/go-proxyproto"
+)
+
+// FancyTLSListener is a variation of the standard tls.Listener that supports
+// atomically swapping the underlying TLS configuration.
+// Requests served before the swap will continue using the old configuration.
+type FancyTLSListener struct {
+	net.Listener
+
+	mu           sync.RWMutex
+	config       *tls.Config
+	trustedProxy []net.IP
+}
+
+// NewFancyTLSListener creates a new FancyTLSListener.
+func NewFancyTLSListener(inner net.Listener, cert tls.Certificate) *FancyTLSListener {
+	listener := &FancyTLSListener{
+		Listener: inner,
+	}
+
+	listener.Config(cert)
+
+	return listener
+}
+
+// Accept waits for and returns the next incoming TLS connection then use the
+// current TLS configuration to handle it.
+func (l *FancyTLSListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	config := l.config
+
+	if isProxy(c.RemoteAddr().String(), l.trustedProxy) {
+		c = proxyproto.NewConn(c)
+	}
+
+	return tls.Server(c, config), nil
+}
+
+// Config safely swaps the underlying TLS configuration.
+func (l *FancyTLSListener) Config(cert tls.Certificate) {
+	config := &tls.Config{
+		MinVersion:   tls.VersionTLS13,
+		ClientAuth:   tls.RequestClientCert,
+		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{"h2", "http/1.1"},
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.config = config
+}
+
+// Close closes the listener.
+func (l *FancyTLSListener) Close() error {
+	err := l.Listener.Close()
+	if err != nil {
+		opErr, ok := err.(*net.OpError) //nolint:errorlint
+		if !ok || !errors.Is(opErr.Err, net.ErrClosed) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// TrustedProxy sets new the https trusted proxy configuration.
+func (l *FancyTLSListener) TrustedProxy(proxies []string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.trustedProxy = make([]net.IP, 0, len(proxies))
+	for _, p := range proxies {
+		ip := net.ParseIP(p)
+		if ip == nil {
+			return fmt.Errorf("HTTPS proxy %q is not a valid IP", p)
+		}
+
+		l.trustedProxy = append(l.trustedProxy, ip)
+	}
+
+	return nil
+}
+
+func isProxy(addr string, proxies []net.IP) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+
+	hostIP := net.ParseIP(host)
+
+	return slices.ContainsFunc(proxies, hostIP.Equal)
+}


### PR DESCRIPTION
This adds an automatic fallback HTTPS listener that is activated if a primary application fails to start, or when booting from the backup image.

Detection of a failed application depends on the service itself failing; we could further refine things by adding some sort of "application health" event loop that could perform application-specific checks to determine if the fallback listener should be started even if the service is still running.

Closes #920