### PR TITLE
Provide incus client versions in requirements.md

### DIFF
--- a/doc/getting-started/requirements.md
+++ b/doc/getting-started/requirements.md
@@ -35,3 +35,13 @@ Certain physical servers and Microsoft Hyper-V have known incomplete and/or brok
 ### Using a software-backed TPM
 
 Most consumer-grade ARM systems lack physical TPM chips, and it can be cost prohibitive to purchase one, such as when using a RaspberryPi. To support these systems, IncusOS can utilize `swtpm` for its TPM. For further details, see [Installing without a TPM](../reference/installing-without-tpm.md).
+
+## Compatible clients
+
+Some incus-os administrative functions can be accessed via `incus admin os ...`. `incus admin os` was added to Incus in the following client versions:
+
+ - 6.0.6 LTS
+ - 6.19
+ - 7.0 LTS
+
+Other client functions (eg launching instances) work with all versions of the `incus` client.


### PR DESCRIPTION
`incus admin os` is not available in all versions of the incus client but is needed for some management tasks, such as retrieving volume encryption keys. This change adds a note to the requirements page so administrators know to upgrade their clients.

I'm not sure if githubs signed-off-by in the commit is hiding my email or didn't include it at all; i'm happy to pull the repo and re sign off if its a problem.