### PR TITLE
Fix deprecated syntax error for setting "systemd.credential.fully-enable-incus-agent" config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ test:
 	incus config device add test-incus-os boot-media disk source=$$(pwd)/mkosi.output/${OSNAME}_boot_media.img io.bus=usb boot.priority=10 readonly=false
 
 	# Enable full incus-agent capability
-	incus config set test-incus-os systemd.credential.fully-enable-incus-agent true
+	incus config set test-incus-os systemd.credential.fully-enable-incus-agent=true
 
 	# Wait for installation to complete
 	incus start test-incus-os --console
@@ -165,7 +165,7 @@ test-iso:
 	incus config device add test-incus-os boot-media disk pool=default source=${OSNAME}_boot_media.iso boot.priority=10
 
 	# Enable full incus-agent capability
-	incus config set test-incus-os systemd.credential.fully-enable-incus-agent true
+	incus config set test-incus-os systemd.credential.fully-enable-incus-agent=true
 
 	# Wait for installation to complete
 	incus start test-incus-os --console

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -63,7 +63,7 @@ arbitrary commands within the virtual machine can make changes outside of the co
 
 To fully enable `incus-agent` support in the virtual machine, run the following command and then restart the virtual machine.
 
-    incus config set <vm> systemd.credential.fully-enable-incus-agent true
+    incus config set <vm> systemd.credential.fully-enable-incus-agent=true
 ```
 
 When IncusOS is run in an Incus virtual machine, it is possible to `exec` into the running

--- a/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
+++ b/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
@@ -35,7 +35,7 @@ class IncusTestVM:
         else:
             self.AddDevice("boot-media", "disk", "pool=default", "source="+self.vm_name+".iso", "boot.priority=10")
 
-        subprocess.run(["incus", "config", "set", self.vm_name, "systemd.credential.fully-enable-incus-agent", "true"], capture_output=True, check=True)
+        subprocess.run(["incus", "config", "set", self.vm_name, "systemd.credential.fully-enable-incus-agent=true"], capture_output=True, check=True)
 
         return self
 


### PR DESCRIPTION
Fix deprecated syntax error for setting "systemd.credential.fully-enable-incus-agent" config.