### PR TITLE
app-build: Fix lego 5.0 build

### DIFF
--- a/app-build/applications.json
+++ b/app-build/applications.json
@@ -48,7 +48,7 @@
         ]
     },
     "lego": {
-        "version": "v5.0.0",
+        "version": "v5.0.1",
         "repo": "https://github.com/go-acme/lego.git",
         "build_targets": [
             [
@@ -56,7 +56,7 @@
                 "dist/lego",
                 "-ldflags",
                 "-X main.version=@VERSION@",
-                "./cmd/lego"
+                "."
             ]
         ],
         "install_targets": [


### PR DESCRIPTION
This fixes the build of lego 5.0. I took a quick look at their blog (https://ldez.github.io/blog/2026/05/11/lego-v5/), and additional changes might be needed by code actually calling the resulting binary.