### PR TITLE
Fix flasher default build

### DIFF
--- a/incus-osd/internal/providers/provider_images.go
+++ b/incus-osd/internal/providers/provider_images.go
@@ -233,9 +233,11 @@ func (p *images) load(_ context.Context) error {
 
 		p.serverURL = "https://images.linuxcontainers.org/os"
 
-		p.updateCA, err = GetUpdateCACert()
-		if err != nil {
-			return err
+		if !p.ignoreSignedJSON {
+			p.updateCA, err = GetUpdateCACert()
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Trying to install the flahser-tool as documented (`go install github.com/lxc/incus-os/incus-osd/cmd/flasher-tool@latest`) currently fails because it expects to be able to embed files located in `incus-osd/certs/files/`. Work around this by providing an empty production-cert-subject-key-ids.txt so the embed directive is happy. Also adjust the images provider to not attempt to load the update CA if it's ignoring JSON metadata verification.