### PR TITLE
Report a friendly version of each application

### DIFF
--- a/app-build/applications.json
+++ b/app-build/applications.json
@@ -121,7 +121,8 @@
             "usr/lib/firmware/i915",
             "usr/lib/firmware/intel/vpu",
             "usr/lib/firmware/nvidia",
-            "usr/lib/firmware/xe"
+            "usr/lib/firmware/xe",
+            "usr/lib/firmware/linux-firmware-gpu-version"
         ]
     },
     "migration-manager": {

--- a/app-build/build-applications.py
+++ b/app-build/build-applications.py
@@ -188,6 +188,11 @@ def install(image, artifact):
         subprocess.run(["mkdir", "-p", os.path.join(base_path, "usr/share/migration-manager/images/")], check=True)
         subprocess.run(["cp", "migration-manager/worker-x86_64.img", os.path.join(base_path, "usr/share/migration-manager/images/")], check=True)
 
+    # Embed the linux-firmware-gpu version so it can be reported when the application is installed
+    if artifact == "linux-firmware-gpu":
+        with open(os.path.join(base_path, "usr/lib/firmware/linux-firmware-gpu-version"), "w") as f:
+            f.write(applications[artifact]["version"])
+
 def create_image_manifest(image, applications):
     manifest = []
 

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -29,6 +29,35 @@ definitions:
         title: AccessEntry represents an entity having access to the resource.
         type: object
         x-go-package: github.com/lxc/incus/v7/shared/api
+    ApplicationVersionData:
+        properties:
+            available_version:
+                description: |-
+                    AvailableVersion is the most recent version available for this application
+                    in the update channel assigned to the respective system.
+                type: string
+                x-go-name: AvailableVersion
+            in_maintenance:
+                $ref: '#/definitions/InMaintenanceState'
+            name:
+                description: Name of the software component.
+                example: IncusOS
+                type: string
+                x-go-name: Name
+            needs_update:
+                description: |-
+                    NeedsUpdate is true, if this application needs to be updated
+                    (available_version > version).
+                type: boolean
+                x-go-name: NeedsUpdate
+            version:
+                description: Version string.
+                example: "202512250102"
+                type: string
+                x-go-name: Version
+        title: ApplicationVersionData defines a single version information for an application.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
     Artifact:
         properties:
             architectures:
@@ -419,7 +448,7 @@ definitions:
                 x-go-name: Secret
         title: CertificateAddToken represents the fields contained within an encoded certificate add token.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     CertificatePost:
         description: |-
             CertificatePost represents the fields available for an update of the
@@ -527,6 +556,52 @@ definitions:
                 x-go-name: Type
         type: object
         x-go-package: github.com/lxc/incus/v7/shared/api
+    Channel:
+        properties:
+            description:
+                description: Description of the channel.
+                example: stable channel, used for production.
+                type: string
+                x-go-name: Description
+            last_updated:
+                description: LastUpdated is the time, when this information has been updated for the last time in RFC3339 format.
+                example: "2024-11-12T16:15:00Z"
+                format: date-time
+                type: string
+                x-go-name: LastUpdated
+            name:
+                description: Name of the channel.
+                example: stable
+                type: string
+                x-go-name: Name
+        title: Channel defines a channel.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ChannelPost:
+        properties:
+            description:
+                description: Description of the channel.
+                example: stable channel, used for production.
+                type: string
+                x-go-name: Description
+            name:
+                description: Name of the channel.
+                example: stable
+                type: string
+                x-go-name: Name
+        title: ChannelPost represents the fields available when creating a channel.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ChannelPut:
+        properties:
+            description:
+                description: Description of the channel.
+                example: stable channel, used for production.
+                type: string
+                x-go-name: Description
+        title: ChannelPut represents the fields available for update for a channel.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
     Cluster:
         properties:
             enabled:
@@ -548,22 +623,158 @@ definitions:
                 x-go-name: ServerName
         title: Cluster represents high-level information about a cluster.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
+    ClusterAddServersPost:
+        description: |-
+            ClusterAddServersPost represents a cluster add servers request containing
+            the names of the servers to be added to the cluster.
+        properties:
+            server_names:
+                description: Names of the servers to be added to the cluster.
+                example:
+                    - server1
+                    - server2
+                items:
+                    type: string
+                type: array
+                x-go-name: ServerNames
+            skip_post_join_operations:
+                description: |-
+                    If set to true, the post join operations (namely the creation of the local storage volumes for backups,
+                    images and logs) are skipped.
+                type: boolean
+                x-go-name: SkipPostJoinOperations
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ClusterArtifact:
+        properties:
+            cluster:
+                description: Cluster the artifact belongs to.
+                example: cluster01
+                type: string
+                x-go-name: Cluster
+            description:
+                description: Description of the cluster artifact.
+                example: Terraform configuration.
+                type: string
+                x-go-name: Description
+            files:
+                description: Files contains the list of files, that form the given artifact.
+                items:
+                    $ref: '#/definitions/ClusterArtifactFile'
+                type: array
+                x-go-name: Files
+            last_updated:
+                description: |-
+                    LastUpdated is the time, when this information has been updated for the
+                    last time in RFC3339 format.
+                example: "2024-11-12T16:15:00Z"
+                format: date-time
+                type: string
+                x-go-name: LastUpdated
+            name:
+                description: Name of the artifact
+                example: terraform-configuration
+                type: string
+                x-go-name: Name
+            properties:
+                description: |-
+                    Properties contains properties of the artifact as key/value pairs.
+                    Example (in YAML notation for readability):
+                    properties:
+                    arch: x86_64
+                    os: linux
+                type: object
+                x-go-name: Properties
+        title: ClusterArtifact defines an artifact, which belongs to a given cluster.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ClusterArtifactFile:
+        properties:
+            mime_type:
+                description: |-
+                    MimeType of the artifact file, used when the file content is returned
+                    to set the correct Content-Type header.
+                example: text/plain
+                type: string
+                x-go-name: MimeType
+            name:
+                description: Name of the artifact file.
+                example: somefile.txt
+                type: string
+                x-go-name: Name
+            size:
+                description: Size of the File in bytes.
+                example: 54300000
+                format: int64
+                type: integer
+                x-go-name: Size
+        title: ClusterArtifactFile defines a single file of a cluster artifact.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ClusterBulkUpdateAction:
+        type: string
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ClusterBulkUpdatePost:
+        description: |-
+            ClusterBulkUpdatePost represents a cluster bulk update request containing
+            action and optional arguments.
+        properties:
+            action:
+                $ref: '#/definitions/ClusterBulkUpdateAction'
+            arguments:
+                description: |-
+                    Arguments for the action, the exact structure depends on the
+                    defined action.
+                type: object
+                x-go-name: Arguments
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
     ClusterCertificatePut:
-        description: ClusterCertificatePut represents the certificate and key pair for all cluster members
         properties:
             cluster_certificate:
-                description: The new certificate (X509 PEM encoded) for the cluster
+                description: The new certificate (X509 PEM encoded) for the cluster.
                 example: X509 PEM certificate
                 type: string
                 x-go-name: ClusterCertificate
             cluster_certificate_key:
-                description: The new certificate key (X509 PEM encoded) for the cluster
+                description: The new certificate key (X509 PEM encoded) for the cluster.
                 example: X509 PEM certificate key
                 type: string
                 x-go-name: ClusterCertificateKey
+        title: ClusterCertificatePut represents the certificate and key pair for all cluster members.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ClusterConfig:
+        description: |-
+            ClusterConfig contains cluster wide configuration used by Operations Center
+            when interacting with the cluster.
+        properties:
+            rolling_restart:
+                $ref: '#/definitions/ClusterConfigRollingRestart'
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ClusterConfigRollingRestart:
+        properties:
+            post_restore_delay:
+                description: |-
+                    PostRestoreDelay holds the time.Duration (as string, e.g. "15m"), that is
+                    waited between the resore of a server and the evacuation of the next
+                    server. This should be set if RestoreMode is kept at the default value in
+                    order to grant a cluster enough time to move previously evacuated instances
+                    back to their originating server.
+                type: string
+                x-go-name: PostRestoreDelay
+            restore_mode:
+                description: |-
+                    RestoreMode is the mode applied dring Incus restore operation. Valid
+                    values are "" (default, move instances back, that have been evacuated
+                    previously) and "skip" (skip moving evacuated instances back).
+                example: skip
+                type: string
+                x-go-name: RestoreMode
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
     ClusterGroup:
         properties:
             config:
@@ -603,7 +814,7 @@ definitions:
                 x-go-name: UsedBy
         title: ClusterGroup represents a cluster group.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ClusterGroupPost:
         properties:
             name:
@@ -613,7 +824,7 @@ definitions:
                 x-go-name: Name
         title: ClusterGroupPost represents the fields required to rename a cluster group.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ClusterGroupPut:
         properties:
             config:
@@ -668,7 +879,7 @@ definitions:
                 x-go-name: Name
         title: ClusterGroupsPost represents the fields available for a new cluster group.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ClusterMember:
         properties:
             architecture:
@@ -736,7 +947,7 @@ definitions:
                 x-go-name: URL
         title: ClusterMember represents a member of a cluster.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ClusterMemberConfigKey:
         description: |-
             The Value field is empty when getting clustering information with GET
@@ -854,7 +1065,7 @@ definitions:
                 type: array
                 x-go-name: Roles
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ClusterMemberState:
         properties:
             storage_pools:
@@ -934,49 +1145,395 @@ definitions:
                 x-go-name: ServerName
         title: ClusterMembersPost represents the fields required to request a join token to add a member to the cluster.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
-    ClusterPut:
+        x-go-package: github.com/lxc/incus/v6/shared/api
+    ClusterPost:
         properties:
-            cluster_address:
-                description: The address of the cluster you wish to join
-                example: 10.0.0.1:8443
+            application_seed_config:
+                additionalProperties: {}
+                description: |-
+                    ApplicationSeedConfig contains the seed configuration for the application, which is
+                    applied during post clustering. This configuration is application specific.
+                type: object
+                x-go-name: ApplicationSeedConfig
+            certificate:
+                description: Certificate of the cluster endpoint in PEM encoded format.
                 type: string
-                x-go-name: ClusterAddress
-            cluster_certificate:
-                description: The expected certificate (X509 PEM encoded) for the cluster
-                example: X509 PEM certificate
+                x-go-name: Certificate
+            channel:
+                description: Channel the cluster is following for updates.
+                example: stable
                 type: string
-                x-go-name: ClusterCertificate
-            cluster_token:
-                description: The cluster join token for the cluster you're trying to join
-                example: blah
+                x-go-name: Channel
+            cluster_template:
+                description: |-
+                    ClusterTemplate contains the name of a cluster template, which should be
+                    used for the cluster creation.
+                    If ClusterTemplate is a none empty string, the respective cluster template
+                    is used and the values in ServiceConfig and ApplicationConfig are
+                    disregarded. If the cluster template is not found, an error is returned.
                 type: string
-                x-go-name: ClusterToken
-            enabled:
-                description: Whether clustering is enabled
-                example: true
-                type: boolean
-                x-go-name: Enabled
-            member_config:
-                description: List of member configuration keys (used during join)
-                example: []
+                x-go-name: ClusterTemplate
+            cluster_template_variable_values:
+                description: |-
+                    ClusterTemplateVariableValues contains the variable values, which should
+                    be applied to the respective placeholders in the cluster template.
+                type: object
+                x-go-name: ClusterTemplateVariableValues
+            config:
+                $ref: '#/definitions/ClusterConfig'
+            connection_url:
+                description: |-
+                    URL, hostname or IP address of the cluster endpoint.
+                    This is only user facing, e.g. the address of a load balancer infront of
+                    the cluster and not used by Operations Center for direct communication
+                    Operations Center relies on the connection URL of the cluster members.
+                example: https://incus.local:6443
+                type: string
+                x-go-name: ConnectionURL
+            description:
+                description: Description of the cluster.
+                example: Lab cluster with limited resources.
+                type: string
+                x-go-name: Description
+            fingerprint:
+                description: Fingerprint in SHA256 format of the certificate.
+                example: fd200419b271f1dc2a5591b693cc5774b7f234e1ff8c6b78ad703b6888fe2b69
+                type: string
+                x-go-name: Fingerprint
+            last_updated:
+                description: LastUpdated is the time, when this information has been updated for the last time in RFC3339 format.
+                example: "2024-11-12T16:15:00Z"
+                format: date-time
+                type: string
+                x-go-name: LastUpdated
+            name:
+                description: A human-friendly name for this cluster.
+                example: MyCluster
+                type: string
+                x-go-name: Name
+            properties:
+                description: |-
+                    Properties contains properties of the cluster as key/value pairs.
+                    Example (in YAML notation for readability):
+                    properties:
+                    env: lab
+                type: object
+                x-go-name: Properties
+            server_names:
+                description: Names of the servers beloning to the cluster.
+                example:
+                    - server1
+                    - server2
                 items:
-                    $ref: '#/definitions/ClusterMemberConfigKey'
+                    type: string
                 type: array
-                x-go-name: MemberConfig
-            server_address:
-                description: The local address to use for cluster communication
-                example: 10.0.0.2:8443
+                x-go-name: ServerNames
+            server_type:
+                description: |-
+                    ServerType is the expected type of servers to be clustered.
+                    Clustering will fail, if not all the servers are of the same type.
                 type: string
-                x-go-name: ServerAddress
-            server_name:
-                description: Name of the cluster member answering the request
-                example: server01
+                x-go-name: ServerType
+                x-go-type: github.com/FuturFusion/operations-center/shared/api.ServerType
+            services_config:
+                additionalProperties: {}
+                description: |-
+                    ServicesConfig contains the configuration for each service, which should be configured on Hypervisor OS.
+                    Operations Center is simply passing forward the settings to Hypervisor OS.
+                    For details about the configuration settings available refer to the service
+                    API definitions in https://github.com/lxc/incus-os/tree/main/incus-osd/api.
+                type: object
+                x-go-name: ServicesConfig
+            status:
+                description: |-
+                    Status contains the status the cluster is currently in from the point of view of Operations Center.
+                    Possible values for status are: pending, ready
+                example: pending
                 type: string
-                x-go-name: ServerName
-        title: ClusterPut represents the fields required to bootstrap or join a cluster.
+                x-go-name: Status
+                x-go-type: github.com/FuturFusion/operations-center/shared/api.ClusterStatus
+            update_status:
+                $ref: '#/definitions/ClusterUpdateStatus'
+        title: ClusterPost represents the fields available for a new cluster of servers running Hypervisor OS.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ClusterPut:
+        description: |-
+            ClusterPut defines the updateable part of a cluster of servers running
+            Hypervisor OS.
+        properties:
+            channel:
+                description: Channel the cluster is following for updates.
+                example: stable
+                type: string
+                x-go-name: Channel
+            config:
+                $ref: '#/definitions/ClusterConfig'
+            connection_url:
+                description: |-
+                    URL, hostname or IP address of the cluster endpoint.
+                    This is only user facing, e.g. the address of a load balancer infront of
+                    the cluster and not used by Operations Center for direct communication
+                    Operations Center relies on the connection URL of the cluster members.
+                example: https://incus.local:6443
+                type: string
+                x-go-name: ConnectionURL
+            description:
+                description: Description of the cluster.
+                example: Lab cluster with limited resources.
+                type: string
+                x-go-name: Description
+            properties:
+                description: |-
+                    Properties contains properties of the cluster as key/value pairs.
+                    Example (in YAML notation for readability):
+                    properties:
+                    env: lab
+                type: object
+                x-go-name: Properties
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ClusterRemoveServersPost:
+        description: |-
+            ClusterRemoveServersPost represents a remove server from a cluster request
+            containing the name of the server to be removed from the cluster.
+        properties:
+            server_names:
+                description: Name of the server to be removed from the cluster.
+                example: '"server1"'
+                items:
+                    type: string
+                type: array
+                x-go-name: ServerNames
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ClusterTemplate:
+        description: |-
+            ClusterTemplate defines a template, which can be used to form a cluster
+            of servers running Hypervisor OS.
+        properties:
+            application_config_template:
+                description: |-
+                    ApplicationConfigTemplate represents a template for the application config
+                    for cluster creation.
+                    It contains the seed configuration for the application, which is
+                    applied during post clustering. This configuration is application specific.
+                type: string
+                x-go-name: ApplicationConfigTemplate
+            description:
+                description: Description of the cluster config template.
+                example: Cluster configuration for production clusters.
+                type: string
+                x-go-name: Description
+            last_updated:
+                description: LastUpdated is the time, when this information has been updated for the last time in RFC3339 format.
+                example: "2024-11-12T16:15:00Z"
+                format: date-time
+                type: string
+                x-go-name: LastUpdated
+            name:
+                description: A human-friendly name for this cluster config template.
+                example: MyTemplate
+                type: string
+                x-go-name: Name
+            service_config_template:
+                description: |-
+                    ServiceConfigTemplate represents a template the service config for cluster
+                    creation.
+                    It contains contains the configuration for each service, which should be
+                    configured on Hypervisor OS.
+                    Operations Center is simply passing forward the settings to Hypervisor OS.
+                    For details about the configuration settings available refer to the service
+                    API definitions in https://github.com/lxc/incus-os/tree/main/incus-osd/api.
+                type: string
+                x-go-name: ServiceConfigTemplate
+            variables:
+                $ref: '#/definitions/ClusterTemplateVariables'
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ClusterTemplatePost:
+        description: |-
+            ClusterTemplatePost defines a template, which can be used to form a cluster
+            of servers running Hypervisor OS.
+        properties:
+            application_config_template:
+                description: |-
+                    ApplicationConfigTemplate represents a template for the application config
+                    for cluster creation.
+                    It contains the seed configuration for the application, which is
+                    applied during post clustering. This configuration is application specific.
+                type: string
+                x-go-name: ApplicationConfigTemplate
+            description:
+                description: Description of the cluster config template.
+                example: Cluster configuration for production clusters.
+                type: string
+                x-go-name: Description
+            name:
+                description: A human-friendly name for this cluster config template.
+                example: MyTemplate
+                type: string
+                x-go-name: Name
+            service_config_template:
+                description: |-
+                    ServiceConfigTemplate represents a template the service config for cluster
+                    creation.
+                    It contains contains the configuration for each service, which should be
+                    configured on Hypervisor OS.
+                    Operations Center is simply passing forward the settings to Hypervisor OS.
+                    For details about the configuration settings available refer to the service
+                    API definitions in https://github.com/lxc/incus-os/tree/main/incus-osd/api.
+                type: string
+                x-go-name: ServiceConfigTemplate
+            variables:
+                $ref: '#/definitions/ClusterTemplateVariables'
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ClusterTemplatePut:
+        properties:
+            application_config_template:
+                description: |-
+                    ApplicationConfigTemplate represents a template for the application config
+                    for cluster creation.
+                    It contains the seed configuration for the application, which is
+                    applied during post clustering. This configuration is application specific.
+                type: string
+                x-go-name: ApplicationConfigTemplate
+            description:
+                description: Description of the cluster config template.
+                example: Cluster configuration for production clusters.
+                type: string
+                x-go-name: Description
+            service_config_template:
+                description: |-
+                    ServiceConfigTemplate represents a template the service config for cluster
+                    creation.
+                    It contains contains the configuration for each service, which should be
+                    configured on Hypervisor OS.
+                    Operations Center is simply passing forward the settings to Hypervisor OS.
+                    For details about the configuration settings available refer to the service
+                    API definitions in https://github.com/lxc/incus-os/tree/main/incus-osd/api.
+                type: string
+                x-go-name: ServiceConfigTemplate
+            variables:
+                $ref: '#/definitions/ClusterTemplateVariables'
+        title: ClusterTemplatePut represents the fields available for update.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ClusterTemplateVariable:
+        description: |-
+            ClusterTemplateVariable defines the properties of a variable, that
+            can be used in a cluster config template.
+        properties:
+            default:
+                description: |-
+                    DefaultValue is the default value applied for a cluster config variable
+                    if no value is provided for the variable.
+                example: Incus cluster
+                type: string
+                x-go-name: DefaultValue
+            description:
+                description: Description describes a cluster config template variable.
+                example: Long name for the cluster.
+                type: string
+                x-go-name: Description
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ClusterTemplateVariables:
+        additionalProperties:
+            $ref: '#/definitions/ClusterTemplateVariable'
+        description: |-
+            ClusterTemplateVariables defines the variables, that can be used in a
+            cluster config template.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ClusterUpdateInProgress:
+        type: string
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ClusterUpdateInProgressStatus:
+        properties:
+            error:
+                description: Error contains the error description, if the cluster update failed permanently.
+                type: string
+                x-go-name: Error
+            evacuated_before:
+                description: |-
+                    EvacuatedBefore contains the list of server names of the servers, that have
+                    been manually evacuated already before the rolling update has been
+                    triggered.
+                items:
+                    type: string
+                type: array
+                x-go-name: EvacuatedBefore
+            in_progress:
+                $ref: '#/definitions/ClusterUpdateInProgress'
+            last_updated:
+                description: |-
+                    LastUpdated is the time, when this information has been updated for the
+                    last time in RFC3339 format.
+                example: "2024-11-12T16:15:00Z"
+                format: date-time
+                type: string
+                x-go-name: LastUpdated
+            status_description:
+                description: |-
+                    StatusDescription contains progress information for the user in plain text
+                    form.
+                example: '[3/20] Evacuating server xyz'
+                type: string
+                x-go-name: StatusDescription
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ClusterUpdatePost:
+        properties:
+            reboot:
+                description: |-
+                    Reboot indicates ifif after the update a rolling reboot of the servers
+                    should be triggered or not. If reboot is set to true, the servers are
+                    rebooted, otherwise only the updates are applied without reboot (OS updates
+                    will require a reboot at a later stage).
+                type: boolean
+                x-go-name: Reboot
+        title: ClusterUpdatePost represents a cluster update request.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ClusterUpdateStatus:
+        description: |-
+            ClusterUpdateStatus contains the update status of each server of the cluster
+            as well as an aggregated cluster update status.
+        properties:
+            in_maintenance:
+                description: |-
+                    InMaintenance holds the list of server names of the servers within the
+                    cluster, which are currently in a maintenance state other than
+                    `NotInMaintenance`. If InMaintenance is empty, all servers are fully
+                    operational and not in maintenance.
+                items:
+                    type: string
+                type: array
+                x-go-name: InMaintenance
+            in_progress_status:
+                $ref: '#/definitions/ClusterUpdateInProgressStatus'
+            needs_reboot:
+                description: |-
+                    NeedsReboot holds the list of server names of the servers within the
+                    cluster, which need to be rebooted. If NeedsReboot is empty, all servers
+                    are up to date and don't require a reboot.
+                items:
+                    type: string
+                type: array
+                x-go-name: NeedsReboot
+            needs_update:
+                description: |-
+                    NeedsUpdate holds the list of server names of the servers within the
+                    cluster, which need to be updated. If NeedsUpdate is empty, all servers are
+                    up to date.
+                items:
+                    type: string
+                type: array
+                x-go-name: NeedsUpdate
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
     ConfigMap:
         additionalProperties:
             type: string
@@ -996,7 +1553,7 @@ definitions:
             plain map[string]map[string]string it provides unmarshal methods for JSON and
             YAML, which gracefully handle numbers and bools.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     Distro:
         type: string
         x-go-package: github.com/FuturFusion/migration-manager/shared/api
@@ -1038,6 +1595,30 @@ definitions:
                 x-go-name: Type
         type: object
         x-go-package: github.com/lxc/incus/v7/shared/api
+    HardwareData:
+        properties:
+            cpu:
+                $ref: '#/definitions/ResourcesCPU'
+            gpu:
+                $ref: '#/definitions/ResourcesGPU'
+            load:
+                $ref: '#/definitions/ResourcesLoad'
+            memory:
+                $ref: '#/definitions/ResourcesMemory'
+            network:
+                $ref: '#/definitions/ResourcesNetwork'
+            pci:
+                $ref: '#/definitions/ResourcesPCI'
+            serial:
+                $ref: '#/definitions/ResourcesSerial'
+            storage:
+                $ref: '#/definitions/ResourcesStorage'
+            system:
+                $ref: '#/definitions/ResourcesSystem'
+            usb:
+                $ref: '#/definitions/ResourcesUSB'
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
     Image:
         description: Image represents an image
         properties:
@@ -1138,7 +1719,7 @@ definitions:
                 type: string
                 x-go-name: UploadedAt
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ImageAlias:
         description: ImageAlias represents an alias from the alias list of an image
         properties:
@@ -1153,7 +1734,7 @@ definitions:
                 type: string
                 x-go-name: Name
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ImageAliasesEntry:
         description: ImageAliasesEntry represents an image alias
         properties:
@@ -1178,7 +1759,7 @@ definitions:
                 type: string
                 x-go-name: Type
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ImageAliasesEntryPost:
         description: ImageAliasesEntryPost represents the required fields to rename an image alias
         properties:
@@ -1203,7 +1784,7 @@ definitions:
                 type: string
                 x-go-name: Target
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ImageAliasesPost:
         description: ImageAliasesPost represents a new image alias
         properties:
@@ -1228,7 +1809,7 @@ definitions:
                 type: string
                 x-go-name: Type
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ImageExportPost:
         description: ImageExportPost represents the fields required to export an image
         properties:
@@ -1305,7 +1886,7 @@ definitions:
                 type: object
                 x-go-name: Templates
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ImageMetadataTemplate:
         description: ImageMetadataTemplate represents a template entry in image metadata (used in image tarball)
         properties:
@@ -1389,7 +1970,7 @@ definitions:
                 type: boolean
                 x-go-name: Public
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ImageSource:
         description: ImageSource represents the source of an image
         properties:
@@ -1484,7 +2065,7 @@ definitions:
             source:
                 $ref: '#/definitions/ImagesPostSource'
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ImagesPostSource:
         description: ImagesPostSource represents the source of a new image
         properties:
@@ -1549,7 +2130,11 @@ definitions:
                 type: string
                 x-go-name: URL
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
+    InMaintenanceState:
+        format: int64
+        type: integer
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
     IncusNICType:
         type: string
         x-go-package: github.com/FuturFusion/migration-manager/shared/api
@@ -1599,7 +2184,7 @@ definitions:
                 x-go-name: ServerName
         title: InitClusterPreseed represents initialization configuration for the cluster.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     InitLocalPreseed:
         properties:
             certificates:
@@ -1661,7 +2246,7 @@ definitions:
                 x-go-name: StorageVolumes
         title: InitLocalPreseed represents initialization configuration.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     InitNetworksProjectPost:
         properties:
             Project:
@@ -1757,7 +2342,7 @@ definitions:
                 x-go-name: StorageVolumes
         title: InitPreseed represents initialization configuration that can be supplied to `init`.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     InitProfileProjectPost:
         properties:
             Project:
@@ -1796,7 +2381,7 @@ definitions:
                 x-go-name: Name
         title: InitProfileProjectPost represents the fields of a new profile along with its associated project.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     InitStorageVolumesProjectPost:
         properties:
             Pool:
@@ -2023,7 +2608,7 @@ definitions:
                 x-go-name: Name
         title: InstanceBackupPost represents the fields available for the renaming of a instance backup.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     InstanceBackupsPost:
         properties:
             compression_algorithm:
@@ -2088,7 +2673,7 @@ definitions:
                 x-go-name: Width
         title: InstanceConsolePost represents an instance console request.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     InstanceDebugRepairPost:
         properties:
             action:
@@ -2098,7 +2683,7 @@ definitions:
                 x-go-name: Action
         title: InstanceDebugRepairPost represents an instance repair request.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     InstanceExecPost:
         properties:
             command:
@@ -2447,7 +3032,7 @@ definitions:
                 x-go-name: Websockets
         title: InstancePostTarget represents the migration target host and operation.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     InstanceProperties:
         properties:
             architecture:
@@ -2864,7 +3449,7 @@ definitions:
                 $ref: '#/definitions/InstancePostTarget'
         title: InstanceSnapshotPost represents the fields required to rename/move an instance snapshot.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     InstanceSnapshotPut:
         properties:
             expires_at:
@@ -3005,7 +3590,7 @@ definitions:
                 x-go-name: Type
         title: InstanceSource represents the creation source for a new instance.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     InstanceState:
         properties:
             cpu:
@@ -3055,7 +3640,7 @@ definitions:
                 $ref: '#/definitions/StatusCode'
         title: InstanceState represents an instance's state.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     InstanceStateCPU:
         properties:
             allocated_time:
@@ -3072,7 +3657,7 @@ definitions:
                 x-go-name: Usage
         title: InstanceStateCPU represents the cpu information section of an instance's state.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     InstanceStateDisk:
         properties:
             total:
@@ -3163,7 +3748,7 @@ definitions:
                 x-go-name: Type
         title: InstanceStateNetwork represents the network information section of an instance's state.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     InstanceStateNetworkAddress:
         description: |-
             InstanceStateNetworkAddress represents a network address as part of the network section of an
@@ -3190,7 +3775,7 @@ definitions:
                 type: string
                 x-go-name: Scope
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     InstanceStateNetworkCounters:
         description: |-
             InstanceStateNetworkCounters represents packet counters as part of the network section of an
@@ -3245,7 +3830,7 @@ definitions:
                 type: integer
                 x-go-name: PacketsSent
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     InstanceStateOSInfo:
         properties:
             fqdn:
@@ -3275,7 +3860,7 @@ definitions:
                 x-go-name: OSVersion
         title: InstanceStateOSInfo represents the operating system information section of an instance's state.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     InstanceStatePut:
         properties:
             action:
@@ -3382,7 +3967,7 @@ definitions:
                 $ref: '#/definitions/InstanceType'
         title: InstancesPost represents the fields available for a new instance.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     InstancesPut:
         properties:
             state:
@@ -3405,7 +3990,7 @@ definitions:
             type: object
         description: MetadataConfig repreents metadata about configuration keys
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     MetadataConfigEntityName:
         description: MetadataConfigEntityName represents a main API object type
         example: instance
@@ -3427,7 +4012,7 @@ definitions:
         description: MetadataConfigGroupName represents the name of a group of config keys
         example: volatile
         type: string
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     MetadataConfigKey:
         description: MetadataConfigKey describe a configuration key
         properties:
@@ -3598,7 +4183,7 @@ definitions:
                 x-go-name: UsedBy
         title: NetworkACL used for displaying an ACL.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkACLPost:
         properties:
             name:
@@ -3692,7 +4277,7 @@ definitions:
                 x-go-name: State
         title: NetworkACLRule represents a single rule in an ACL ruleset.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkACLsPost:
         properties:
             config:
@@ -3725,7 +4310,7 @@ definitions:
                 x-go-name: Name
         title: NetworkACLsPost used for creating an ACL.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkAddressSet:
         description: Refer to doc/howto/network_address_sets.md for details.
         properties:
@@ -3772,7 +4357,7 @@ definitions:
                 x-go-name: UsedBy
         title: NetworkAddressSet represents an address set.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkAddressSetPost:
         properties:
             name:
@@ -3807,7 +4392,7 @@ definitions:
                 x-go-name: Description
         title: NetworkAddressSetPut used for updating an address set.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkAddressSetsPost:
         properties:
             addresses:
@@ -3932,7 +4517,7 @@ definitions:
                 type: string
                 x-go-name: TargetPort
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkForwardPut:
         description: NetworkForwardPut represents the modifiable fields of a network address forward
         properties:
@@ -3954,7 +4539,7 @@ definitions:
                 type: array
                 x-go-name: Ports
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkForwardsPost:
         description: NetworkForwardsPost represents the fields of a new network address forward
         properties:
@@ -4017,7 +4602,7 @@ definitions:
                 x-go-name: UsedBy
         title: NetworkIntegration represents a network integration.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkIntegrationPost:
         description: NetworkIntegrationPost represents the fields required to rename a network integration
         properties:
@@ -4027,7 +4612,7 @@ definitions:
                 type: string
                 x-go-name: Name
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkIntegrationPut:
         description: NetworkIntegrationPut represents the modifiable fields of a network integration
         properties:
@@ -4043,7 +4628,7 @@ definitions:
                 type: string
                 x-go-name: Description
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkIntegrationsPost:
         description: NetworkIntegrationsPost represents the fields of a new network integration
         properties:
@@ -4069,7 +4654,7 @@ definitions:
                 type: string
                 x-go-name: Type
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkLease:
         description: NetworkLease represents a DHCP lease
         properties:
@@ -4191,7 +4776,7 @@ definitions:
                 type: array
                 x-go-name: TargetBackend
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkLoadBalancerPut:
         description: NetworkLoadBalancerPut represents the modifiable fields of a network load balancer
         properties:
@@ -4219,7 +4804,7 @@ definitions:
                 type: array
                 x-go-name: Ports
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkLoadBalancerState:
         description: NetworkLoadBalancerState is used for showing current state of a load balancer
         properties:
@@ -4229,7 +4814,7 @@ definitions:
                 type: object
                 x-go-name: BackendHealth
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkLoadBalancerStateBackendHealth:
         description: NetworkLoadBalancerStateBackendHealth represents the health of a particular load-balancer backend
         properties:
@@ -4242,7 +4827,7 @@ definitions:
                 type: array
                 x-go-name: Ports
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkLoadBalancerStateBackendHealthPort:
         properties:
             port:
@@ -4290,7 +4875,7 @@ definitions:
                 type: array
                 x-go-name: Ports
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkPeer:
         properties:
             config:
@@ -4350,7 +4935,7 @@ definitions:
                 x-go-name: UsedBy
         title: NetworkPeer used for displaying a network peering.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkPeerPut:
         description: NetworkPeerPut represents the modifiable fields of a network peering
         properties:
@@ -4366,7 +4951,7 @@ definitions:
                 type: string
                 x-go-name: Description
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkPeersPost:
         description: NetworkPeersPost represents the fields of a new network peering
         properties:
@@ -4434,22 +5019,25 @@ definitions:
                 type: string
                 x-go-name: Name
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkPut:
-        description: |-
-            NetworkPut represents the fields available for an update of the
-            system's network configuration.
+        description: NetworkPut represents the modifiable fields of a network
         properties:
-            address:
-                description: Address of Operations Center which is used by managed servers to connect.
+            config:
+                description: Network configuration map (refer to doc/networks.md)
+                example:
+                    ipv4.address: 10.0.0.1/24
+                    ipv4.nat: "true"
+                    ipv6.address: none
+                type: object
+                x-go-name: Config
+            description:
+                description: Description of the profile
+                example: My new bridge
                 type: string
-                x-go-name: OperationsCenterAddress
-            rest_server_address:
-                description: Address and port to bind the REST API to.
-                type: string
-                x-go-name: RestServerAddress
+                x-go-name: Description
         type: object
-        x-go-package: github.com/FuturFusion/operations-center/shared/api/system
+        x-go-package: github.com/lxc/incus/v7/shared/api
     NetworkState:
         description: NetworkState represents the network state
         properties:
@@ -4516,7 +5104,7 @@ definitions:
                 type: string
                 x-go-name: Scope
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkStateBond:
         description: NetworkStateBond represents bond specific state
         properties:
@@ -4633,7 +5221,7 @@ definitions:
                 type: integer
                 x-go-name: PacketsSent
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkStateOVN:
         description: NetworkStateOVN represents OVN specific state
         properties:
@@ -4663,7 +5251,7 @@ definitions:
                 type: string
                 x-go-name: UplinkIPv6
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkStateVLAN:
         description: NetworkStateVLAN represents VLAN specific state
         properties:
@@ -4761,7 +5349,7 @@ definitions:
                 x-go-name: Name
         title: NetworkZoneRecord represents a network zone (DNS) record.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     NetworkZoneRecordEntry:
         description: NetworkZoneRecordEntry represents the fields in a record entry
         properties:
@@ -4880,10 +5468,63 @@ definitions:
                 type: string
                 x-go-name: Type
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
+    OSData:
+        properties:
+            network:
+                $ref: '#/definitions/SystemNetwork'
+            security:
+                $ref: '#/definitions/SystemSecurity'
+            storage:
+                $ref: '#/definitions/SystemStorage'
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
     OSType:
         type: string
         x-go-package: github.com/FuturFusion/migration-manager/shared/api
+    OSVersionData:
+        properties:
+            available_version:
+                description: |-
+                    AvailableVersion is the most recent version available for the OS in the
+                    update channel assigned to the respective system.
+                type: string
+                x-go-name: AvailableVersion
+            name:
+                description: Name of the software component.
+                example: IncusOS
+                type: string
+                x-go-name: Name
+            needs_reboot:
+                description: |-
+                    NeedsReboot is the "needs_reboot" state reported by the server. Currently
+                    this is only expected to be "true", if "version_next" is different than
+                    "version", but in the future, there might be other reasons for a server
+                    to report, that a reboot is required.
+                type: boolean
+                x-go-name: NeedsReboot
+            needs_update:
+                description: |-
+                    NeedsUpdate is true, if the OS needs to be updated
+                    (available_version > version_next).
+                type: boolean
+                x-go-name: NeedsUpdate
+            version:
+                description: Version string.
+                example: "202512250102"
+                type: string
+                x-go-name: Version
+            version_next:
+                description: |-
+                    Next Version string. If this version is different from "version",
+                    an update is available and applied on the system, but the system has
+                    not yet been rebooted, so the new update is not yet active.
+                example: "202512250102"
+                type: string
+                x-go-name: VersionNext
+        title: OSVersionData defines a single version information for the OS.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
     Operation:
         description: Operation represents a background operation
         properties:
@@ -5053,7 +5694,7 @@ definitions:
                 type: array
                 x-go-name: UsedBy
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ProfilePost:
         description: ProfilePost represents the fields required to rename a profile
         properties:
@@ -5093,7 +5734,7 @@ definitions:
                 type: object
                 x-go-name: Devices
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ProfilesPost:
         description: ProfilesPost represents the fields of a new profile
         properties:
@@ -5191,7 +5832,7 @@ definitions:
                 type: string
                 x-go-name: Description
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ProjectState:
         description: ProjectState represents the current running state of a project
         properties:
@@ -5210,7 +5851,7 @@ definitions:
                 type: object
                 x-go-name: Resources
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ProjectStateResource:
         description: ProjectStateResource represents the state of a particular resource in a project
         properties:
@@ -5247,7 +5888,7 @@ definitions:
                 type: string
                 x-go-name: Name
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     QueueEntry:
         properties:
             LastWorkerResponse:
@@ -5330,7 +5971,7 @@ definitions:
                 type: integer
                 x-go-name: Total
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesCPUAddressSizes:
         properties:
             physical_bits:
@@ -5365,7 +6006,7 @@ definitions:
                 type: string
                 x-go-name: Type
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesCPUCore:
         description: ResourcesCPUCore represents a CPU core on the system
         properties:
@@ -5401,7 +6042,7 @@ definitions:
                 type: array
                 x-go-name: Threads
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesCPUSocket:
         description: ResourcesCPUSocket represents a CPU socket on the system
         properties:
@@ -5454,7 +6095,7 @@ definitions:
                 type: string
                 x-go-name: Vendor
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesCPUThread:
         description: ResourcesCPUThread represents a CPU thread on the system
         properties:
@@ -5487,7 +6128,7 @@ definitions:
                 type: integer
                 x-go-name: Thread
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesGPU:
         description: ResourcesGPU represents the GPU resources available on the system
         properties:
@@ -5644,7 +6285,7 @@ definitions:
                 type: string
                 x-go-name: Name
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesGPUCardNvidia:
         description: ResourcesGPUCardNvidia represents additional information for NVIDIA GPUs
         properties:
@@ -5689,7 +6330,7 @@ definitions:
                 type: string
                 x-go-name: UUID
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesGPUCardSRIOV:
         description: ResourcesGPUCardSRIOV represents the SRIOV configuration of the GPU
         properties:
@@ -5713,7 +6354,7 @@ definitions:
                 type: array
                 x-go-name: VFs
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesLoad:
         description: ResourcesLoad represents system load information
         properties:
@@ -5780,7 +6421,7 @@ definitions:
                 type: integer
                 x-go-name: Used
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesMemoryNode:
         description: ResourcesMemoryNode represents the node-specific memory resources available on the system
         properties:
@@ -5815,7 +6456,7 @@ definitions:
                 type: integer
                 x-go-name: Used
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesNetwork:
         description: ResourcesNetwork represents the network cards available on the system
         properties:
@@ -5832,7 +6473,7 @@ definitions:
                 type: integer
                 x-go-name: Total
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesNetworkCard:
         description: ResourcesNetworkCard represents a network card on the system
         properties:
@@ -5898,7 +6539,7 @@ definitions:
                 type: string
                 x-go-name: VendorID
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesNetworkCardPort:
         description: ResourcesNetworkCardPort represents a network port on the system
         properties:
@@ -6036,7 +6677,7 @@ definitions:
                 type: array
                 x-go-name: VFs
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesNetworkCardVDPA:
         description: ResourcesNetworkCardVDPA represents the VDPA configuration of the network card
         properties:
@@ -6066,7 +6707,7 @@ definitions:
                 type: integer
                 x-go-name: Total
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesPCIDevice:
         description: ResourcesPCIDevice represents a PCI device
         properties:
@@ -6137,7 +6778,7 @@ definitions:
                 type: string
                 x-go-name: ProductName
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesSerial:
         description: ResourcesSerial represents the serial devices available on the system
         properties:
@@ -6204,7 +6845,7 @@ definitions:
                 type: string
                 x-go-name: VendorID
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesStorage:
         description: ResourcesStorage represents the local storage
         properties:
@@ -6221,7 +6862,7 @@ definitions:
                 type: integer
                 x-go-name: Total
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesStorageDisk:
         description: ResourcesStorageDisk represents a disk
         properties:
@@ -6362,7 +7003,7 @@ definitions:
             space:
                 $ref: '#/definitions/ResourcesStoragePoolSpace'
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesStoragePoolInodes:
         description: ResourcesStoragePoolInodes represents the inodes available to a given storage pool
         properties:
@@ -6396,7 +7037,7 @@ definitions:
                 type: integer
                 x-go-name: Used
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesSystem:
         description: ResourcesSystem represents the system
         properties:
@@ -6448,7 +7089,7 @@ definitions:
                 type: string
                 x-go-name: Version
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesSystemChassis:
         description: ResourcesSystemChassis represents the system chassis
         properties:
@@ -6473,7 +7114,7 @@ definitions:
                 type: string
                 x-go-name: Version
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesSystemFirmware:
         description: ResourcesSystemFirmware represents the system firmware
         properties:
@@ -6493,7 +7134,7 @@ definitions:
                 type: string
                 x-go-name: Version
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesSystemMotherboard:
         description: ResourcesSystemMotherboard represents the motherboard
         properties:
@@ -6769,6 +7410,27 @@ definitions:
                 x-go-name: TrustedTLSClientCertFingerprints
         type: object
         x-go-package: github.com/FuturFusion/operations-center/shared/api/system
+    SeedApplications:
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    SeedIncus:
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    SeedInstall:
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    SeedMigrationManager:
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    SeedNetwork:
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    SeedOperationsCenter:
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    SeedUpdate:
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
     Server:
         description: Server represents a server configuration
         properties:
@@ -6838,7 +7500,7 @@ definitions:
                 type: boolean
                 x-go-name: Public
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ServerEnvironment:
         properties:
             addresses:
@@ -6983,7 +7645,51 @@ definitions:
                 x-go-name: StorageVersion
         title: ServerEnvironment represents the read-only environment fields of a server configuration.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
+    ServerPost:
+        properties:
+            channel:
+                description: Channel the server is following for updates.
+                example: stable
+                type: string
+                x-go-name: Channel
+            connection_url:
+                description: |-
+                    URL, hostname or IP address of the server endpoint used by Operations
+                    Center for its communication.
+                example: https://incus.local:6443
+                type: string
+                x-go-name: ConnectionURL
+            description:
+                description: Description of the server.
+                example: Lab server with limited resources.
+                type: string
+                x-go-name: Description
+            name:
+                description: Name of the server.
+                example: incus.local
+                type: string
+                x-go-name: Name
+            properties:
+                description: |-
+                    Properties contains properties of the server as key/value pairs.
+                    Example (in YAML notation for readability):
+                    properties:
+                    arch: x86_64
+                    os: linux
+                type: object
+                x-go-name: Properties
+            public_connection_url:
+                description: |-
+                    Public URL, hostname or IP address of the server endpoint for user facing
+                    communication with the server. Only required, if it differs from
+                    connection_url, e.g. because the server is behind a reverse proxy.
+                example: https://incus.local:6443
+                type: string
+                x-go-name: PublicConnectionURL
+        title: ServerPost defines a new server running Hypervisor OS.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
     ServerPut:
         description: ServerPut represents the modifiable fields of a server configuration
         properties:
@@ -6997,6 +7703,21 @@ definitions:
                 x-go-name: Config
         type: object
         x-go-package: github.com/FuturFusion/migration-manager/shared/api
+    ServerSelfUpdate:
+        properties:
+            cause:
+                $ref: '#/definitions/ServerSelfUpdateCause'
+            connection_url:
+                description: URL, hostname or IP address of the server endpoint.
+                example: https://incus.local:6443
+                type: string
+                x-go-name: ConnectionURL
+        title: ServerSelfUpdate defines a self update request of a server.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ServerSelfUpdateCause:
+        type: string
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
     ServerStorageDriverInfo:
         description: ServerStorageDriverInfo represents the read-only info about a storage driver
         properties:
@@ -7013,10 +7734,22 @@ definitions:
                 example: 0.8.4-1ubuntu11
                 type: string
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     ServerUntrusted:
         description: ServerUntrusted represents a server configuration for an untrusted client
         properties:
+            api_extensions:
+                description: List of supported API extensions
+                example:
+                    - etag
+                    - patch
+                    - network
+                    - storage
+                items:
+                    type: string
+                readOnly: true
+                type: array
+                x-go-name: APIExtensions
             api_status:
                 description: Support status of the current API (one of "devel", "stable" or "deprecated")
                 example: stable
@@ -7049,17 +7782,84 @@ definitions:
                     type: string
                 description: Server configuration map (refer to doc/server.md)
                 example:
-                    core.https_address: :6443
+                    core.https_address: :8443
                 type: object
                 x-go-name: Config
-            server_version:
-                description: Server version
-                example: 1.0.0
+            public:
+                description: Whether the server is public-only (only public endpoints are implemented)
+                example: false
                 readOnly: true
-                type: string
-                x-go-name: ServerVersion
+                type: boolean
+                x-go-name: Public
         type: object
-        x-go-package: github.com/FuturFusion/migration-manager/shared/api
+        x-go-package: github.com/lxc/incus/v7/shared/api
+    ServerUpdateApplication:
+        description: |-
+            ServerUpdateApplication defines the update trigger information for a single
+            application in an update request. This is used for both, applications as well
+            as the operations system.
+        properties:
+            name:
+                description: Name of the software component.
+                example: IncusOS
+                type: string
+                x-go-name: Name
+            trigger_update:
+                description: |-
+                    TriggerUpdate triggers an update for the given application, if the provided
+                    value is set to true.
+                type: boolean
+                x-go-name: TriggerUpdate
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ServerUpdatePost:
+        description: |-
+            ServerUpdatePost defines the update trigger information for an update
+            request for a server including the OS and/or its applications.
+        properties:
+            applications:
+                description: Applications holds the update trigger information for the installed applications.
+                items:
+                    $ref: '#/definitions/ServerUpdateApplication'
+                type: array
+                x-go-name: Applications
+            os:
+                $ref: '#/definitions/ServerUpdateApplication'
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    ServerVersionData:
+        description: |-
+            ServerVersionData defines the version information for a server including
+            the OS and all its applications.
+        properties:
+            applications:
+                description: Applications holds the version information for the installed applications.
+                items:
+                    $ref: '#/definitions/ApplicationVersionData'
+                type: array
+                x-go-name: Applications
+            in_maintenance:
+                $ref: '#/definitions/InMaintenanceState'
+            needs_reboot:
+                description: |-
+                    NeedsReboot is the aggregated state over OS and all applications indicating
+                    if there is any component, where a reboot is required.
+                type: boolean
+                x-go-name: NeedsReboot
+            needs_update:
+                description: |-
+                    NeedsUpdate is the aggregated state over OS and all applications indicating
+                    if there is any component, where an update is available.
+                type: boolean
+                x-go-name: NeedsUpdate
+            os:
+                $ref: '#/definitions/OSVersionData'
+            update_channel:
+                description: The channel the system is following for updates.
+                type: string
+                x-go-name: UpdateChannel
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
     Settings:
         properties:
             log_level:
@@ -7267,7 +8067,7 @@ definitions:
                 x-go-name: S3URL
         title: StorageBucketFull is a combination of StorageBucket, StorageBucketBackup and StorageBucketKey.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     StorageBucketKey:
         description: StorageBucketKey represents the fields of a storage pool bucket key
         properties:
@@ -7352,7 +8152,7 @@ definitions:
                 type: string
                 x-go-name: SecretKey
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     StorageBucketPut:
         description: StorageBucketPut represents the modifiable fields of a storage pool bucket
         properties:
@@ -7368,7 +8168,7 @@ definitions:
                 type: string
                 x-go-name: Description
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     StorageBucketsPost:
         description: StorageBucketsPost represents the fields of a new storage pool bucket
         properties:
@@ -7774,7 +8574,7 @@ definitions:
                 x-go-name: UsedBy
         title: StorageVolumeFull is a combination of StorageVolume, StorageVolumeBackup, StorageVolumeSnapshot and StorageVolumeState.
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     StorageVolumePost:
         description: StorageVolumePost represents the fields required to rename a storage pool volume
         properties:
@@ -7808,7 +8608,7 @@ definitions:
                 type: boolean
                 x-go-name: VolumeOnly
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     StorageVolumePostTarget:
         description: StorageVolumePostTarget represents the migration target host and operation
         properties:
@@ -7853,7 +8653,7 @@ definitions:
                 type: string
                 x-go-name: Restore
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     StorageVolumeSnapshot:
         description: StorageVolumeSnapshot represents a storage volume snapshot
         properties:
@@ -7892,7 +8692,7 @@ definitions:
                 type: string
                 x-go-name: Name
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     StorageVolumeSnapshotPost:
         description: StorageVolumeSnapshotPost represents the fields required to rename/move a storage volume snapshot
         properties:
@@ -7909,7 +8709,7 @@ definitions:
             target:
                 $ref: '#/definitions/StorageVolumePostTarget'
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     StorageVolumeSnapshotPut:
         description: StorageVolumeSnapshotPut represents the modifiable fields of a storage volume
         properties:
@@ -8009,7 +8809,7 @@ definitions:
                 type: boolean
                 x-go-name: VolumeOnly
         type: object
-        x-go-package: github.com/lxc/incus/v7/shared/api
+        x-go-package: github.com/lxc/incus/v6/shared/api
     StorageVolumeState:
         description: StorageVolumeState represents the live state of the volume
         properties:
@@ -8109,40 +8909,591 @@ definitions:
         x-go-package: github.com/FuturFusion/migration-manager/shared/api
     SystemNetwork:
         properties:
-            rest_server_address:
-                description: Address and port to bind the REST API to.
-                type: string
-                x-go-name: Address
-            worker_endpoint:
-                description: URL used by Migration Manager workers to connect to the Migration Manager daemon.
-                type: string
-                x-go-name: WorkerEndpoint
-        title: SystemNetwork represents the system's network configuration.
+            config:
+                $ref: '#/definitions/SystemNetworkConfig'
+            state:
+                $ref: '#/definitions/SystemNetworkState'
+        title: SystemNetwork defines a struct to hold the three types of supported network configuration.
         type: object
-        x-go-package: github.com/FuturFusion/migration-manager/shared/api
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkBond:
+        properties:
+            addresses:
+                items:
+                    type: string
+                type: array
+                x-go-name: Addresses
+            ethernet:
+                $ref: '#/definitions/SystemNetworkEthernet'
+            firewall_rules:
+                items:
+                    $ref: '#/definitions/SystemNetworkFirewallRule'
+                type: array
+                x-go-name: FirewallRules
+            hwaddr:
+                type: string
+                x-go-name: Hwaddr
+            lldp:
+                type: boolean
+                x-go-name: LLDP
+            members:
+                items:
+                    type: string
+                type: array
+                x-go-name: Members
+            mode:
+                type: string
+                x-go-name: Mode
+            mtu:
+                format: int64
+                type: integer
+                x-go-name: MTU
+            name:
+                type: string
+                x-go-name: Name
+            required_for_online:
+                type: string
+                x-go-name: RequiredForOnline
+            roles:
+                items:
+                    type: string
+                type: array
+                x-go-name: Roles
+            routes:
+                items:
+                    $ref: '#/definitions/SystemNetworkRoute'
+                type: array
+                x-go-name: Routes
+            vlan_tags:
+                items:
+                    format: int64
+                    type: integer
+                type: array
+                x-go-name: VLANTags
+        title: SystemNetworkBond contains information about a network bond.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkConfig:
+        properties:
+            bonds:
+                items:
+                    $ref: '#/definitions/SystemNetworkBond'
+                type: array
+                x-go-name: Bonds
+            confirmation_timeout:
+                description: |-
+                    If defined, automatically roll back the new network changes after the
+                    specified timeout has elapsed unless those changes are confirmed before then.
+                type: string
+                x-go-name: ConfirmationTimeout
+            dns:
+                $ref: '#/definitions/SystemNetworkDNS'
+            interfaces:
+                items:
+                    $ref: '#/definitions/SystemNetworkInterface'
+                type: array
+                x-go-name: Interfaces
+            proxy:
+                $ref: '#/definitions/SystemNetworkProxy'
+            time:
+                $ref: '#/definitions/SystemNetworkTime'
+            vlans:
+                items:
+                    $ref: '#/definitions/SystemNetworkVLAN'
+                type: array
+                x-go-name: VLANs
+            wireguard:
+                items:
+                    $ref: '#/definitions/SystemNetworkWireguard'
+                type: array
+                x-go-name: Wireguard
+        title: SystemNetworkConfig represents the user modifiable network configuration.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkDNS:
+        properties:
+            dns_over_tls:
+                type: boolean
+                x-go-name: DNSOverTLS
+            domain:
+                type: string
+                x-go-name: Domain
+            hostname:
+                type: string
+                x-go-name: Hostname
+            nameservers:
+                items:
+                    type: string
+                type: array
+                x-go-name: Nameservers
+            search_domains:
+                items:
+                    type: string
+                type: array
+                x-go-name: SearchDomains
+        title: SystemNetworkDNS defines DNS configuration options.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkEthernet:
+        properties:
+            disable_energy_efficient:
+                type: boolean
+                x-go-name: DisableEnergyEfficient
+            disable_gro:
+                type: boolean
+                x-go-name: DisableGRO
+            disable_gso:
+                type: boolean
+                x-go-name: DisableGSO
+            disable_ipv4_tso:
+                type: boolean
+                x-go-name: DisableIPv4TSO
+            disable_ipv6_tso:
+                type: boolean
+                x-go-name: DisableIPv6TSO
+            wakeonlan:
+                type: boolean
+                x-go-name: WakeOnLAN
+            wakeonlan_modes:
+                items:
+                    type: string
+                type: array
+                x-go-name: WakeOnLANModes
+            wakeonlan_password:
+                type: string
+                x-go-name: WakeOnLANPassword
+        title: SystemNetworkEthernet contains Ethernet-specific configuration details (offloading and other features).
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkFirewallRule:
+        properties:
+            action:
+                type: string
+                x-go-name: Action
+            port:
+                format: int64
+                type: integer
+                x-go-name: Port
+            protocol:
+                type: string
+                x-go-name: Protocol
+            source:
+                type: string
+                x-go-name: Source
+        title: SystemNetworkFirewallRule defines a firewall rule.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkInterface:
+        properties:
+            addresses:
+                items:
+                    type: string
+                type: array
+                x-go-name: Addresses
+            ethernet:
+                $ref: '#/definitions/SystemNetworkEthernet'
+            firewall_rules:
+                items:
+                    $ref: '#/definitions/SystemNetworkFirewallRule'
+                type: array
+                x-go-name: FirewallRules
+            hwaddr:
+                type: string
+                x-go-name: Hwaddr
+            lldp:
+                type: boolean
+                x-go-name: LLDP
+            mtu:
+                format: int64
+                type: integer
+                x-go-name: MTU
+            name:
+                type: string
+                x-go-name: Name
+            required_for_online:
+                type: string
+                x-go-name: RequiredForOnline
+            roles:
+                items:
+                    type: string
+                type: array
+                x-go-name: Roles
+            routes:
+                items:
+                    $ref: '#/definitions/SystemNetworkRoute'
+                type: array
+                x-go-name: Routes
+            strict_hwaddr:
+                type: boolean
+                x-go-name: StrictHwaddr
+            vlan_tags:
+                items:
+                    format: int64
+                    type: integer
+                type: array
+                x-go-name: VLANTags
+        title: SystemNetworkInterface contains information about a network interface.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkInterfaceState:
+        properties:
+            addresses:
+                items:
+                    type: string
+                type: array
+                x-go-name: Addresses
+            hwaddr:
+                type: string
+                x-go-name: Hwaddr
+            lacp:
+                $ref: '#/definitions/SystemNetworkLACPState'
+            lldp:
+                items:
+                    $ref: '#/definitions/SystemNetworkLLDPState'
+                type: array
+                x-go-name: LLDP
+            members:
+                additionalProperties:
+                    $ref: '#/definitions/SystemNetworkInterfaceState'
+                type: object
+                x-go-name: Members
+            mtu:
+                format: int64
+                type: integer
+                x-go-name: MTU
+            roles:
+                items:
+                    type: string
+                type: array
+                x-go-name: Roles
+            routes:
+                items:
+                    $ref: '#/definitions/SystemNetworkRoute'
+                type: array
+                x-go-name: Routes
+            speed:
+                type: string
+                x-go-name: Speed
+            state:
+                type: string
+                x-go-name: State
+            stats:
+                $ref: '#/definitions/SystemNetworkInterfaceStats'
+            type:
+                type: string
+                x-go-name: Type
+            wireguard:
+                $ref: '#/definitions/SystemNetworkWireguardState'
+        title: SystemNetworkInterfaceState holds state information about a specific network interface.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkInterfaceStats:
+        properties:
+            rx_bytes:
+                format: int64
+                type: integer
+                x-go-name: RXBytes
+            rx_errors:
+                format: int64
+                type: integer
+                x-go-name: RXErrors
+            tx_bytes:
+                format: int64
+                type: integer
+                x-go-name: TXBytes
+            tx_errors:
+                format: int64
+                type: integer
+                x-go-name: TXErrors
+        title: SystemNetworkInterfaceStats holds RX/TX stats for an interface.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkLACPState:
+        properties:
+            local_mac:
+                type: string
+                x-go-name: LocalMAC
+            remote_mac:
+                type: string
+                x-go-name: RemoteMAC
+        title: SystemNetworkLACPState holds information about a bond's LACP state.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkLLDPState:
+        properties:
+            chassis_id:
+                type: string
+                x-go-name: ChassisID
+            name:
+                type: string
+                x-go-name: Name
+            port:
+                type: string
+                x-go-name: Port
+            port_id:
+                type: string
+                x-go-name: PortID
+        title: SystemNetworkLLDPState holds information about the LLDP state.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkProxy:
+        properties:
+            rules:
+                items:
+                    $ref: '#/definitions/SystemNetworkProxyRule'
+                type: array
+                x-go-name: Rules
+            servers:
+                additionalProperties:
+                    $ref: '#/definitions/SystemNetworkProxyServer'
+                type: object
+                x-go-name: Servers
+        title: SystemNetworkProxy defines proxy configuration.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkProxyRule:
+        properties:
+            destination:
+                type: string
+                x-go-name: Destination
+            target:
+                type: string
+                x-go-name: Target
+        title: SystemNetworkProxyRule defines a proxy rule.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkProxyServer:
+        properties:
+            auth:
+                type: string
+                x-go-name: Auth
+            host:
+                type: string
+                x-go-name: Host
+            password:
+                type: string
+                x-go-name: Password
+            realm:
+                type: string
+                x-go-name: Realm
+            use_tls:
+                type: boolean
+                x-go-name: UseTLS
+            username:
+                type: string
+                x-go-name: Username
+        title: SystemNetworkProxyServer defines a proxy server configuration.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkRoute:
+        properties:
+            to:
+                type: string
+                x-go-name: To
+            via:
+                type: string
+                x-go-name: Via
+        title: SystemNetworkRoute defines a route.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkState:
+        properties:
+            interfaces:
+                additionalProperties:
+                    $ref: '#/definitions/SystemNetworkInterfaceState'
+                type: object
+                x-go-name: Interfaces
+        title: SystemNetworkState holds information about the current network state.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkTime:
+        properties:
+            ntp_servers:
+                items:
+                    type: string
+                type: array
+                x-go-name: NTPServers
+            timezone:
+                type: string
+                x-go-name: Timezone
+        title: SystemNetworkTime defines various time related configuration options (NTP servers, timezone, etc).
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkVLAN:
+        properties:
+            addresses:
+                items:
+                    type: string
+                type: array
+                x-go-name: Addresses
+            firewall_rules:
+                items:
+                    $ref: '#/definitions/SystemNetworkFirewallRule'
+                type: array
+                x-go-name: FirewallRules
+            id:
+                format: int64
+                type: integer
+                x-go-name: ID
+            mtu:
+                format: int64
+                type: integer
+                x-go-name: MTU
+            name:
+                type: string
+                x-go-name: Name
+            parent:
+                type: string
+                x-go-name: Parent
+            required_for_online:
+                type: string
+                x-go-name: RequiredForOnline
+            roles:
+                items:
+                    type: string
+                type: array
+                x-go-name: Roles
+            routes:
+                items:
+                    $ref: '#/definitions/SystemNetworkRoute'
+                type: array
+                x-go-name: Routes
+        title: SystemNetworkVLAN contains information about a network vlan.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkWireguard:
+        properties:
+            addresses:
+                items:
+                    type: string
+                type: array
+                x-go-name: Addresses
+            firewall_rules:
+                items:
+                    $ref: '#/definitions/SystemNetworkFirewallRule'
+                type: array
+                x-go-name: FirewallRules
+            mtu:
+                format: int64
+                type: integer
+                x-go-name: MTU
+            name:
+                type: string
+                x-go-name: Name
+            peers:
+                items:
+                    $ref: '#/definitions/SystemNetworkWireguardPeer'
+                type: array
+                x-go-name: Peers
+            port:
+                format: int64
+                type: integer
+                x-go-name: Port
+            private_key:
+                type: string
+                x-go-name: PrivateKey
+            required_for_online:
+                type: string
+                x-go-name: RequiredForOnline
+            roles:
+                items:
+                    type: string
+                type: array
+                x-go-name: Roles
+            routes:
+                items:
+                    $ref: '#/definitions/SystemNetworkRoute'
+                type: array
+                x-go-name: Routes
+        title: SystemNetworkWireguard contains information about a wireguard interface.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkWireguardPeer:
+        properties:
+            allowed_ips:
+                items:
+                    type: string
+                type: array
+                x-go-name: AllowedIPs
+            endpoint:
+                type: string
+                x-go-name: Endpoint
+            persistent_keepalive:
+                format: int64
+                type: integer
+                x-go-name: PersistentKeepalive
+            preshared_key:
+                type: string
+                x-go-name: PresharedKey
+            public_key:
+                type: string
+                x-go-name: PublicKey
+        title: SystemNetworkWireguardPeer defines wireguard peer.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkWireguardPeerState:
+        properties:
+            allowed_ips:
+                items:
+                    type: string
+                type: array
+                x-go-name: AllowedIPs
+            endpoint:
+                type: string
+                x-go-name: EndPoint
+            latest_handshake:
+                type: string
+                x-go-name: LatestHandshake
+            persistent_keepalive:
+                type: string
+                x-go-name: PersistentKeepalive
+            public_key:
+                type: string
+                x-go-name: PublicKey
+            stats:
+                $ref: '#/definitions/SystemNetworkInterfaceStats'
+        title: SystemNetworkWireguardPeerState holds state information about a specific wireguard peer.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemNetworkWireguardState:
+        properties:
+            listening_port:
+                format: int64
+                type: integer
+                x-go-name: ListeningPort
+            peers:
+                items:
+                    $ref: '#/definitions/SystemNetworkWireguardPeerState'
+                type: array
+                x-go-name: Peers
+            public_key:
+                type: string
+                x-go-name: PublicKey
+        title: SystemNetworkWireguardState holds state information about a specific wireguard interface.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemProviderConfig:
+        properties:
+            config:
+                additionalProperties:
+                    type: string
+                type: object
+                x-go-name: Config
+            name:
+                type: string
+                x-go-name: Name
+        title: SystemProviderConfig holds the modifiable part of the provider data.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
     SystemSecurity:
         properties:
-            acme:
-                $ref: '#/definitions/SystemSecurityACME'
-            oidc:
-                $ref: '#/definitions/SystemSecurityOIDC'
-            openfga:
-                $ref: '#/definitions/SystemSecurityOpenFGA'
-            trusted_https_proxies:
-                description: An array of trusted HTTPS proxy addresses.
-                items:
-                    type: string
-                type: array
-                x-go-name: TrustedHTTPSProxies
-            trusted_tls_client_cert_fingerprints:
-                description: An array of SHA256 certificate fingerprints that belong to trusted TLS clients.
-                items:
-                    type: string
-                type: array
-                x-go-name: TrustedTLSClientCertFingerprints
-        title: SystemSecurity represents the system's security configuration.
+            config:
+                $ref: '#/definitions/SystemSecurityConfig'
+            state:
+                $ref: '#/definitions/SystemSecurityState'
+        title: SystemSecurity defines a struct to hold information about the system's security state.
         type: object
-        x-go-package: github.com/FuturFusion/migration-manager/shared/api
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
     SystemSecurityACME:
         properties:
             agree_tos:
@@ -8185,6 +9536,32 @@ definitions:
                 x-go-name: ProviderResolvers
         type: object
         x-go-package: github.com/FuturFusion/migration-manager/shared/api
+    SystemSecurityConfig:
+        properties:
+            custom_ca_certs:
+                items:
+                    type: string
+                type: array
+                x-go-name: CustomCACerts
+            encryption_recovery_keys:
+                items:
+                    type: string
+                type: array
+                x-go-name: EncryptionRecoveryKeys
+        title: SystemSecurityConfig holds additional security configuration settings.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemSecurityEncryptedVolume:
+        properties:
+            state:
+                type: string
+                x-go-name: State
+            volume:
+                type: string
+                x-go-name: Volume
+        title: SystemSecurityEncryptedVolume defines a struct that holds basic information about an encrypted volume.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
     SystemSecurityOIDC:
         properties:
             audience:
@@ -8227,6 +9604,60 @@ definitions:
         title: SystemSecurityOpenFGA is the OpenFGA related part of the system's security configuration.
         type: object
         x-go-package: github.com/FuturFusion/migration-manager/shared/api
+    SystemSecuritySecureBootCertificate:
+        properties:
+            fingerprint:
+                type: string
+                x-go-name: Fingerprint
+            issuer:
+                type: string
+                x-go-name: Issuer
+            subject:
+                type: string
+                x-go-name: Subject
+            type:
+                type: string
+                x-go-name: Type
+        title: SystemSecuritySecureBootCertificate defines a struct that holds information about Secure Boot keys present on the host.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemSecurityState:
+        properties:
+            drive_recovery_keys:
+                additionalProperties:
+                    type: string
+                type: object
+                x-go-name: DriveRecoveryKeys
+            encrypted_volumes:
+                items:
+                    $ref: '#/definitions/SystemSecurityEncryptedVolume'
+                type: array
+                x-go-name: EncryptedVolumes
+            encryption_recovery_keys_retrieved:
+                type: boolean
+                x-go-name: EncryptionRecoveryKeysRetrieved
+            pool_recovery_keys:
+                additionalProperties:
+                    type: string
+                type: object
+                x-go-name: PoolRecoveryKeys
+            secure_boot_certificates:
+                items:
+                    $ref: '#/definitions/SystemSecuritySecureBootCertificate'
+                type: array
+                x-go-name: SecureBootCertificates
+            secure_boot_enabled:
+                type: boolean
+                x-go-name: SecureBootEnabled
+            system_state_is_trusted:
+                type: boolean
+                x-go-name: SystemStateIsTrusted
+            tpm_status:
+                type: string
+                x-go-name: TPMStatus
+        title: SystemSecurityState holds information about the current security state.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
     SystemSettings:
         properties:
             disable_auto_sync:
@@ -8296,6 +9727,288 @@ definitions:
         title: SystemSettingsLog represents configuration for a logging target.
         type: object
         x-go-package: github.com/FuturFusion/migration-manager/shared/api
+    SystemStorage:
+        properties:
+            config:
+                $ref: '#/definitions/SystemStorageConfig'
+            state:
+                $ref: '#/definitions/SystemStorageState'
+        title: SystemStorage defines a struct to hold information about the system's local storage.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemStorageConfig:
+        properties:
+            pools:
+                items:
+                    $ref: '#/definitions/SystemStoragePool'
+                type: array
+                x-go-name: Pools
+            scrub_schedule:
+                type: string
+                x-go-name: ScrubSchedule
+        title: SystemStorageConfig represents additional configuration for the system's local storage.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemStorageDrive:
+        properties:
+            boot:
+                type: boolean
+                x-go-name: Boot
+            bus:
+                type: string
+                x-go-name: Bus
+            capacity_in_bytes:
+                format: int64
+                type: integer
+                x-go-name: CapacityInBytes
+            encrypted:
+                type: boolean
+                x-go-name: Encrypted
+            encrypted_id:
+                type: string
+                x-go-name: EncryptedID
+            id:
+                type: string
+                x-go-name: ID
+            member_pool:
+                type: string
+                x-go-name: MemberPool
+            model_family:
+                type: string
+                x-go-name: ModelFamily
+            model_name:
+                type: string
+                x-go-name: ModelName
+            multipath:
+                type: boolean
+                x-go-name: Multipath
+            remote:
+                type: boolean
+                x-go-name: Remote
+            removable:
+                type: boolean
+                x-go-name: Removable
+            serial_number:
+                type: string
+                x-go-name: SerialNumber
+            smart:
+                $ref: '#/definitions/SystemStorageDriveSMART'
+            wwn:
+                type: string
+                x-go-name: WWN
+            wwn_id:
+                type: string
+                x-go-name: WWNID
+        title: SystemStorageDrive defines a struct that holds information about a specific drive.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemStorageDriveSMART:
+        properties:
+            available_spare:
+                format: int64
+                type: integer
+                x-go-name: AvailableSpare
+            data_units_read:
+                format: int64
+                type: integer
+                x-go-name: DataUnitsRead
+            data_units_written:
+                format: int64
+                type: integer
+                x-go-name: DataUnitsWritten
+            enabled:
+                type: boolean
+                x-go-name: Enabled
+            error:
+                type: string
+                x-go-name: Error
+            passed:
+                type: boolean
+                x-go-name: Passed
+            percentage_used:
+                format: int64
+                type: integer
+                x-go-name: PercentageUsed
+            power_on_hours:
+                format: int64
+                type: integer
+                x-go-name: PowerOnHours
+            raw_read_error_rate:
+                format: int64
+                type: integer
+                x-go-name: RawReadErrorRate
+            reallocated_sectors:
+                format: int64
+                type: integer
+                x-go-name: ReallocatedSectors
+            seek_error_rate:
+                format: int64
+                type: integer
+                x-go-name: SeekErrorRate
+        title: SystemStorageDriveSMART defines a struct to return basic SMART information about a specific device.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemStoragePool:
+        properties:
+            allow_mixed_dev_sizes:
+                description: If true, allow creation of a pool with devices of different sizes.
+                type: boolean
+                x-go-name: AllowMixedDevSizes
+            cache:
+                items:
+                    type: string
+                type: array
+                x-go-name: Cache
+            cache_degraded:
+                items:
+                    type: string
+                type: array
+                x-go-name: CacheDegraded
+            devices:
+                description: Devices, Cache, Log, and Special can be modified to add/remove/replace devices in the pool.
+                items:
+                    type: string
+                type: array
+                x-go-name: Devices
+            devices_degraded:
+                items:
+                    type: string
+                type: array
+                x-go-name: DevicesDegraded
+            encryption_key_status:
+                type: string
+                x-go-name: EncryptionKeyStatus
+            last_scrub:
+                $ref: '#/definitions/SystemStoragePoolScrubStatus'
+            log:
+                items:
+                    type: string
+                type: array
+                x-go-name: Log
+            log_degraded:
+                items:
+                    type: string
+                type: array
+                x-go-name: LogDegraded
+            name:
+                description: Name and Type cannot be changed after pool creation.
+                type: string
+                x-go-name: Name
+            pool_allocated_space_in_bytes:
+                format: int64
+                type: integer
+                x-go-name: PoolAllocatedSpaceInBytes
+            raw_pool_size_in_bytes:
+                format: int64
+                type: integer
+                x-go-name: RawPoolSizeInBytes
+            special:
+                $ref: '#/definitions/SystemStoragePoolSpecial'
+            special_degraded:
+                items:
+                    type: string
+                type: array
+                x-go-name: SpecialDegraded
+            state:
+                description: Read-only fields returned from the server with additional pool information.
+                type: string
+                x-go-name: State
+            type:
+                description: 'Supported pool types: zfs-raid0, zfs-raid1, zfs-raid10, zfs-raidz1, zfs-raidz2, zfs-raidz3.'
+                type: string
+                x-go-name: Type
+            usable_pool_size_in_bytes:
+                format: int64
+                type: integer
+                x-go-name: UsablePoolSizeInBytes
+            volumes:
+                items:
+                    $ref: '#/definitions/SystemStoragePoolVolume'
+                type: array
+                x-go-name: Volumes
+        title: SystemStoragePool defines a struct that is used to create or update a storage pool and return its current state.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemStoragePoolScrubState:
+        title: SystemStoragePoolScrubState represents the state of a scan in a pool.
+        type: string
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemStoragePoolScrubStatus:
+        properties:
+            end_time:
+                format: date-time
+                type: string
+                x-go-name: EndTime
+            errors:
+                format: int64
+                type: integer
+                x-go-name: Errors
+            progress:
+                type: string
+                x-go-name: Progress
+            start_time:
+                format: date-time
+                type: string
+                x-go-name: StartTime
+            state:
+                $ref: '#/definitions/SystemStoragePoolScrubState'
+        title: SystemStoragePoolScrubStatus represents the status of a scrub in a pool.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemStoragePoolSpecial:
+        properties:
+            devices:
+                description: One or more physical devices to create the pool's special vdev.
+                items:
+                    type: string
+                type: array
+                x-go-name: Devices
+            special_small_blocks_size_in_kb:
+                description: If non-zero, will be used when setting the pool's special_small_blocks property.
+                format: int64
+                type: integer
+                x-go-name: SpecialSmallBlocksSizeInKB
+            type:
+                description: 'Supported special device types: zfs-raid0, zfs-raid1, zfs-raid10, zfs-raidz1, zfs-raidz2, zfs-raidz3.'
+                type: string
+                x-go-name: Type
+        title: SystemStoragePoolSpecial defines a struct that is used to create or update a pool's special vdev.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemStoragePoolVolume:
+        properties:
+            name:
+                type: string
+                x-go-name: Name
+            quota_in_bytes:
+                format: int64
+                type: integer
+                x-go-name: QuotaInBytes
+            usage_in_bytes:
+                format: int64
+                type: integer
+                x-go-name: UsageInBytes
+            use:
+                type: string
+                x-go-name: Use
+        title: SystemStoragePoolVolume represents a single IncusOS-managed volume in a pool.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
+    SystemStorageState:
+        properties:
+            drives:
+                items:
+                    $ref: '#/definitions/SystemStorageDrive'
+                type: array
+                x-go-name: Drives
+            pools:
+                items:
+                    $ref: '#/definitions/SystemStoragePool'
+                type: array
+                x-go-name: Pools
+        title: SystemStorageState represents additional state for the system's local storage.
+        type: object
+        x-go-package: github.com/lxc/incus-os/incus-osd/api
     Target:
         properties:
             name:
@@ -8329,6 +10042,352 @@ definitions:
     TargetType:
         type: string
         x-go-package: github.com/FuturFusion/migration-manager/shared/api
+    Token:
+        properties:
+            channel:
+                description: |-
+                    Channel, used to seed images as well as which gets assigned to servers
+                    using this token during provisioning.
+                example: '"stable"'
+                type: string
+                x-go-name: Channel
+            description:
+                description: Description of this token.
+                example: '"Test Environment"'
+                type: string
+                x-go-name: Description
+            expire_at:
+                description: The time at which the token expires in RFC3339 format with seconds precision.
+                example: '"2025-02-04T07:25:47Z"'
+                format: date-time
+                type: string
+                x-go-name: ExpireAt
+            uses_remaining:
+                description: Value indicating, how many times the token might be used for registration.
+                example: 10
+                format: int64
+                type: integer
+                x-go-name: UsesRemaining
+            uuid:
+                description: UUID of the token, which serves as the the token.
+                example: b32d0079-c48b-4957-b1cb-bef54125c861
+                format: uuid
+                type: string
+                x-go-name: UUID
+        title: Token defines a registration token for use during registration.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    TokenImagePost:
+        description: |-
+            Operations Center just passes through the provided configuration for
+            applications.yaml, install.yaml and network.yaml as is without any validation
+            of the provided configuration besides of ensuring it to be valid yaml.
+        properties:
+            architecture:
+                $ref: '#/definitions/UpdateFileArchitecture'
+            seeds:
+                $ref: '#/definitions/TokenSeedConfigs'
+            type:
+                description: |-
+                    Type contains the type of image to be generated.
+                    Possible values for status are: iso, raw
+                example: iso
+                type: string
+                x-go-name: Type
+                x-go-type: github.com/FuturFusion/operations-center/shared/api.ImageType
+        title: |-
+            TokenImagePost defines the configuration to generate a pre-seeded ISO or raw
+            image for a given Token.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    TokenProviderConfig:
+        properties:
+            config:
+                additionalProperties:
+                    type: string
+                type: object
+                x-go-name: Config
+            name:
+                type: string
+                x-go-name: Name
+            version:
+                type: string
+                x-go-name: Version
+        title: TokenProviderConfig defines the provider configuration for a given token.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    TokenPut:
+        properties:
+            channel:
+                description: |-
+                    Channel, used to seed images as well as which gets assigned to servers
+                    using this token during provisioning.
+                example: '"stable"'
+                type: string
+                x-go-name: Channel
+            description:
+                description: Description of this token.
+                example: '"Test Environment"'
+                type: string
+                x-go-name: Description
+            expire_at:
+                description: The time at which the token expires in RFC3339 format with seconds precision.
+                example: '"2025-02-04T07:25:47Z"'
+                format: date-time
+                type: string
+                x-go-name: ExpireAt
+            uses_remaining:
+                description: Value indicating, how many times the token might be used for registration.
+                example: 10
+                format: int64
+                type: integer
+                x-go-name: UsesRemaining
+        title: TokenPut defines the configurable properties of Token.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    TokenSeed:
+        description: |-
+            Operations Center just passes through the provided configuration for
+            application.yaml, install.yaml and network.yaml as is without any validation
+            of the provided configuration besides of ensuring it to be valid yaml.
+        properties:
+            description:
+                description: Description contains the description of the token seed configuration.
+                example: Configuration for lab servers.
+                type: string
+                x-go-name: Description
+            last_updated:
+                description: LastUpdated is the time, when this information has been updated for the last time in RFC3339 format.
+                example: "2024-11-12T16:15:00Z"
+                format: date-time
+                type: string
+                x-go-name: LastUpdated
+            name:
+                description: Name contains the name of the token seed configuration.
+                example: MyConfig
+                type: string
+                x-go-name: Name
+            public:
+                description: |-
+                    Public defines, if images generated based on the given token seed
+                    configuration can be retrieved without authentication. If public is set to
+                    `true`, no authentication is necessary, otherwise authentication is
+                    required.
+                example: true
+                type: boolean
+                x-go-name: Public
+            seeds:
+                $ref: '#/definitions/TokenSeedConfigs'
+            token_uuid:
+                description: UUID of the token.
+                example: b32d0079-c48b-4957-b1cb-bef54125c861
+                format: uuid
+                type: string
+                x-go-name: Token
+        title: |-
+            TokenSeed defines a named token seed configuration, for which a
+            pre-seeded ISO or raw image can be fetched later.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    TokenSeedConfigs:
+        properties:
+            applications:
+                $ref: '#/definitions/SeedApplications'
+            incus:
+                $ref: '#/definitions/SeedIncus'
+            install:
+                $ref: '#/definitions/SeedInstall'
+            migration_manager:
+                $ref: '#/definitions/SeedMigrationManager'
+            network:
+                $ref: '#/definitions/SeedNetwork'
+            operations_center:
+                $ref: '#/definitions/SeedOperationsCenter'
+            update:
+                $ref: '#/definitions/SeedUpdate'
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    TokenSeedPost:
+        description: |-
+            Operations Center just passes through the provided configuration for
+            application.yaml, install.yaml and network.yaml as is without any validation
+            of the provided configuration besides of ensuring it to be valid yaml.
+        properties:
+            description:
+                description: Description contains the description of the token seed configuration.
+                example: Configuration for lab servers.
+                type: string
+                x-go-name: Description
+            name:
+                description: Name contains the name of the token seed configuration.
+                example: MyConfig
+                type: string
+                x-go-name: Name
+            public:
+                description: |-
+                    Public defines, if images generated based on the given token seed
+                    configuration can be retrieved without authentication. If public is set to
+                    `true`, no authentication is necessary, otherwise authentication is
+                    required.
+                example: true
+                type: boolean
+                x-go-name: Public
+            seeds:
+                $ref: '#/definitions/TokenSeedConfigs'
+        title: |-
+            TokenSeedPost defines a named token seed configuration, for which a
+            pre-seeded ISO or raw image can be fetched later.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    TokenSeedPut:
+        description: |-
+            Operations Center just passes through the provided configuration for
+            application.yaml, install.yaml and network.yaml as is without any validation
+            of the provided configuration besides of ensuring it to be valid yaml.
+        properties:
+            description:
+                description: Description contains the description of the token seed configuration.
+                example: Configuration for lab servers.
+                type: string
+                x-go-name: Description
+            public:
+                description: |-
+                    Public defines, if images generated based on the given token seed
+                    configuration can be retrieved without authentication. If public is set to
+                    `true`, no authentication is necessary, otherwise authentication is
+                    required.
+                example: true
+                type: boolean
+                x-go-name: Public
+            seeds:
+                $ref: '#/definitions/TokenSeedConfigs'
+        title: |-
+            TokenSeedPut defines the updateable part of a named token seed
+            configuration, for which a pre-seeded ISO or raw image can be fetched later.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    Update:
+        properties:
+            channels:
+                description: Channels holds the name of the channels the update is assigned to.
+                example: stable
+                items:
+                    type: string
+                type: array
+                x-go-name: Channels
+            origin:
+                description: Origin of the Update.
+                example: linuxcontainers.org
+                type: string
+                x-go-name: Origin
+            published_at:
+                description: PublishedAt is the date, when the Update has been published in RFC3339 format.
+                example: "2025-02-12T09:59:00Z"
+                format: date-time
+                type: string
+                x-go-name: PublishedAt
+            severity:
+                $ref: '#/definitions/UpdateSeverity'
+            update_status:
+                description: |-
+                    Status contains the status the update is currently in.
+                    Possible values for status are: pending, ready
+                example: ready
+                type: string
+                x-go-name: Status
+                x-go-type: github.com/FuturFusion/operations-center/shared/api.UpdateStatus
+            upstream_channels:
+                description: |-
+                    UpstreamChannels holds the name of the channels from upstream (source)
+                    the update is part of.
+                example: stable
+                items:
+                    type: string
+                type: array
+                x-go-name: UpstreamChannels
+            url:
+                description: URL of the File.
+                example: releases/download/202501311418/
+                type: string
+                x-go-name: URL
+            uuid:
+                description: UUID of the update.
+                format: uuid
+                type: string
+                x-go-name: UUID
+            version:
+                description: Version of the Update as opaque string.
+                example: "202501311418"
+                type: string
+                x-go-name: Version
+        title: Update defines an update.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    UpdateChangelog:
+        title: UpdateChangelog defines a changelog for an update.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    UpdateChangelogs:
+        items:
+            $ref: '#/definitions/UpdateChangelog'
+        title: UpdateChangelogs represents a series of changelogs, e.g. for all the updates of a channel.
+        type: array
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    UpdateFile:
+        properties:
+            architecture:
+                $ref: '#/definitions/UpdateFileArchitecture'
+            component:
+                $ref: '#/definitions/UpdateFileComponent'
+            filename:
+                description: Filename of the File.
+                example: IncusOS_202501311418.efi.gz
+                type: string
+                x-go-name: Filename
+            sha256:
+                description: Sha256 checksum of the file in hex encoding (64 ascii characters in the alphabet [0-9A-Fa-f])
+                example: 11465a836ce54a8f293ac9234aa51050094cfbb8906c1a10ab9487dd92088643
+                type: string
+                x-go-name: Sha256
+            size:
+                description: Size of the File in bytes.
+                example: 54300000
+                format: int64
+                type: integer
+                x-go-name: Size
+            type:
+                $ref: '#/definitions/UpdateFileType'
+        title: UpdateFile defines an update file.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    UpdateFileArchitecture:
+        title: UpdateFileArchitecture represents the architecture for a given file.
+        type: string
+        x-go-package: github.com/lxc/incus-os/incus-osd/api/images
+    UpdateFileComponent:
+        title: UpdateFileComponent represents the component affected by an update.
+        type: string
+        x-go-package: github.com/lxc/incus-os/incus-osd/api/images
+    UpdateFileType:
+        title: UpdateFileType represents the type in an update file.
+        type: string
+        x-go-package: github.com/lxc/incus-os/incus-osd/api/images
+    UpdatePut:
+        properties:
+            channels:
+                description: Channels holds the name of the channels the update is assigned to.
+                example: stable
+                items:
+                    type: string
+                type: array
+                x-go-name: Channels
+        title: UpdatePut defines the updateable part of an update.
+        type: object
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
+    UpdateSeverity:
+        title: UpdateSeverity represents the severity field in an update.
+        type: string
+        x-go-package: github.com/lxc/incus-os/incus-osd/api/images
     Updates:
         properties:
             file_filter_expression:
@@ -8522,7 +10581,10 @@ definitions:
         properties:
             status:
                 $ref: '#/definitions/WarningStatus'
+                description: Status of the warning (new, acknowledged, or resolved)
+                example: new
                 type: string
+                x-go-name: Status
         title: WarningPut represents the modifiable fields of a warning.
         type: object
         x-go-package: github.com/lxc/incus/v7/shared/api
@@ -8549,11 +10611,11 @@ definitions:
     WarningStatus:
         title: WarningStatus is the acknowledgement status of a warning.
         type: string
-        x-go-package: github.com/FuturFusion/migration-manager/shared/api
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
     WarningType:
         title: WarningType represents a warning message group.
         type: string
-        x-go-package: github.com/FuturFusion/migration-manager/shared/api
+        x-go-package: github.com/FuturFusion/operations-center/shared/api
 paths:
     /:
         get:
@@ -8720,6 +10782,7 @@ paths:
                                         available_versions:
                                             - "202511041601"
                                             - "202511041800"
+                                        friendly_version: 7.0.0 [202511041800]
                                         initialized: true
                                         version: "202511041800"
                                 type: json

--- a/incus-osd/api/application.go
+++ b/incus-osd/api/application.go
@@ -10,6 +10,7 @@ type ApplicationConfig struct{}
 // ApplicationState represents the state of a generic application.
 type ApplicationState struct {
 	Initialized       bool       `json:"initialized"             yaml:"initialized"`
+	FriendlyVersion   string     `json:"friendly_version"        yaml:"friendly_version"`
 	Version           string     `json:"version"                 yaml:"version"`
 	AvailableVersions []string   `json:"available_versions"      yaml:"available_versions"`
 	LastRestored      *time.Time `json:"last_restored,omitempty" yaml:"last_restored,omitempty"` // In system's timezone.

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -359,7 +359,7 @@ func shutdown(ctx context.Context, s *state.State) error {
 	// Run shutdown actions for each installed application.
 	for _, app := range apps {
 		// Stop the application.
-		slog.InfoContext(ctx, "Stopping application", "name", app.Name(), "version", app.Version())
+		slog.InfoContext(ctx, "Stopping application", "name", app.Name(), "version", app.FriendlyVersion())
 
 		err = app.Stop(ctx)
 		if err != nil {

--- a/incus-osd/internal/applications/app_common.go
+++ b/incus-osd/internal/applications/app_common.go
@@ -50,6 +50,11 @@ func (*common) FactoryReset(_ context.Context) error {
 	return errors.New("not supported")
 }
 
+// FriendlyVersion returns the friendly version of the application.
+func (a *common) FriendlyVersion() string {
+	return a.appState.FriendlyVersion
+}
+
 // GetBackup returns a tar archive backup of the application's configuration and/or state.
 func (*common) GetBackup(_ io.Writer, _ bool) error {
 	return errors.New("not supported")

--- a/incus-osd/internal/applications/app_debug.go
+++ b/incus-osd/internal/applications/app_debug.go
@@ -18,6 +18,13 @@ func (*debug) Name() string {
 	return "debug"
 }
 
+// SetFriendlyVersion records the friendly version.
+func (d *debug) SetFriendlyVersion(_ context.Context) error {
+	d.appState.FriendlyVersion = d.appState.Version
+
+	return nil
+}
+
 func (*debug) Struct() any {
 	return &api.Application{}
 }

--- a/incus-osd/internal/applications/app_gpu_support.go
+++ b/incus-osd/internal/applications/app_gpu_support.go
@@ -29,6 +29,18 @@ func (*gpuSupport) Name() string {
 	return "gpu-support"
 }
 
+// SetFriendlyVersion records the friendly version.
+func (g *gpuSupport) SetFriendlyVersion(_ context.Context) error {
+	version, err := os.ReadFile("/usr/lib/firmware/linux-firmware-gpu-version")
+	if err != nil {
+		return err
+	}
+
+	g.appState.FriendlyVersion = string(version) + " [" + g.appState.Version + "]"
+
+	return nil
+}
+
 func (*gpuSupport) Start(ctx context.Context) error {
 	// Reload the modules if loaded.
 	for _, module := range []string{"amdgpu", "i915", "intel_vpu", "nouveau", "xe"} {

--- a/incus-osd/internal/applications/app_incus.go
+++ b/incus-osd/internal/applications/app_incus.go
@@ -237,6 +237,18 @@ func (a *incus) RestoreBackup(ctx context.Context, archive io.Reader) error {
 	return nil
 }
 
+// SetFriendlyVersion records the friendly version.
+func (a *incus) SetFriendlyVersion(ctx context.Context) error {
+	output, err := subprocess.RunCommandContext(ctx, "incus", "--version")
+	if err != nil {
+		return err
+	}
+
+	a.appState.FriendlyVersion = strings.TrimSuffix(output, "\n") + " [" + a.appState.Version + "]"
+
+	return nil
+}
+
 func (*incus) Struct() any {
 	return &api.ApplicationIncus{}
 }

--- a/incus-osd/internal/applications/app_incus_services.go
+++ b/incus-osd/internal/applications/app_incus_services.go
@@ -2,6 +2,10 @@ package applications
 
 import (
 	"context"
+	"errors"
+	"strings"
+
+	"github.com/lxc/incus/v7/shared/subprocess"
 
 	"github.com/lxc/incus-os/incus-osd/api"
 )
@@ -21,6 +25,22 @@ func (*incusCeph) GetDependencies() []string {
 
 func (*incusCeph) Name() string {
 	return "incus-ceph"
+}
+
+// SetFriendlyVersion records the friendly version.
+func (i *incusCeph) SetFriendlyVersion(ctx context.Context) error {
+	output, err := subprocess.RunCommandContext(ctx, "ceph", "--version")
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasPrefix(output, "ceph version ") {
+		return errors.New("unable to determine ceph version")
+	}
+
+	i.appState.FriendlyVersion = strings.Split(output, " ")[2] + " [" + i.appState.Version + "]"
+
+	return nil
 }
 
 func (*incusCeph) Struct() any {
@@ -46,6 +66,23 @@ func (*incusLinstor) GetDependencies() []string {
 
 func (*incusLinstor) Name() string {
 	return "incus-linstor"
+}
+
+// SetFriendlyVersion records the friendly version.
+func (i *incusLinstor) SetFriendlyVersion(ctx context.Context) error {
+	output, err := subprocess.RunCommandContext(ctx, "/usr/share/linstor-server/bin/Satellite", "--version")
+	if err != nil {
+		return err
+	}
+
+	s := strings.Split(output, "\n")
+	if !strings.HasPrefix(s[len(s)-2], "LINSTOR Satellite ") {
+		return errors.New("unable to determine Linstor version")
+	}
+
+	i.appState.FriendlyVersion = strings.Split(s[len(s)-2], " ")[2] + " [" + i.appState.Version + "]"
+
+	return nil
 }
 
 func (*incusLinstor) Struct() any {

--- a/incus-osd/internal/applications/app_migration_manager.go
+++ b/incus-osd/internal/applications/app_migration_manager.go
@@ -11,9 +11,11 @@ import (
 	"net/http"
 	"os"
 	"slices"
+	"strings"
 	"time"
 
 	mmapi "github.com/FuturFusion/migration-manager/shared/api"
+	"github.com/lxc/incus/v7/shared/subprocess"
 	"golang.org/x/sys/unix"
 
 	"github.com/lxc/incus-os/incus-osd/api"
@@ -296,6 +298,18 @@ func (mm *migrationManager) RestoreBackup(ctx context.Context, archive io.Reader
 	// Record when the application was restored.
 	now := time.Now()
 	mm.appState.LastRestored = &now
+
+	return nil
+}
+
+// SetFriendlyVersion records the friendly version.
+func (mm *migrationManager) SetFriendlyVersion(ctx context.Context) error {
+	output, err := subprocess.RunCommandContext(ctx, "migration-managerd", "--version")
+	if err != nil {
+		return err
+	}
+
+	mm.appState.FriendlyVersion = strings.TrimSuffix(output, "\n") + " [" + mm.appState.Version + "]"
 
 	return nil
 }

--- a/incus-osd/internal/applications/app_operations_center.go
+++ b/incus-osd/internal/applications/app_operations_center.go
@@ -11,9 +11,11 @@ import (
 	"net/http"
 	"os"
 	"slices"
+	"strings"
 	"time"
 
 	ocapi "github.com/FuturFusion/operations-center/shared/api/system"
+	"github.com/lxc/incus/v7/shared/subprocess"
 	"golang.org/x/sys/unix"
 
 	"github.com/lxc/incus-os/incus-osd/api"
@@ -319,6 +321,18 @@ func (oc *operationsCenter) RestoreBackup(ctx context.Context, archive io.Reader
 	// Record when the application was restored.
 	now := time.Now()
 	oc.appState.LastRestored = &now
+
+	return nil
+}
+
+// SetFriendlyVersion records the friendly version.
+func (oc *operationsCenter) SetFriendlyVersion(ctx context.Context) error {
+	output, err := subprocess.RunCommandContext(ctx, "operations-centerd", "--version")
+	if err != nil {
+		return err
+	}
+
+	oc.appState.FriendlyVersion = strings.TrimSuffix(output, "\n") + " [" + oc.appState.Version + "]"
 
 	return nil
 }

--- a/incus-osd/internal/applications/helpers.go
+++ b/incus-osd/internal/applications/helpers.go
@@ -99,7 +99,7 @@ func StartInitialize(ctx context.Context, s *state.State, appName string) error 
 	}
 
 	// Start the application.
-	slog.InfoContext(ctx, "Starting application", "name", appName, "version", app.Version())
+	slog.InfoContext(ctx, "Starting application", "name", appName, "version", app.FriendlyVersion())
 
 	err = app.Start(ctx)
 	if err != nil {
@@ -108,7 +108,7 @@ func StartInitialize(ctx context.Context, s *state.State, appName string) error 
 
 	// Run initialization if needed.
 	if !app.IsInitialized() { //nolint:nestif
-		slog.InfoContext(ctx, "Initializing application", "name", appName, "version", app.Version())
+		slog.InfoContext(ctx, "Initializing application", "name", appName, "version", app.FriendlyVersion())
 
 		err = app.Initialize(ctx)
 		if err != nil {

--- a/incus-osd/internal/applications/struct.go
+++ b/incus-osd/internal/applications/struct.go
@@ -16,6 +16,7 @@ type Application interface { //nolint:interfacebloat
 	Debug(ctx context.Context, data any) response.Response
 	DebugStruct() any
 	FactoryReset(ctx context.Context) error
+	FriendlyVersion() string
 	Get(ctx context.Context) (any, error)
 	GetBackup(archive io.Writer, complete bool) error
 	GetClientCertificate() (*tls.Certificate, error)
@@ -30,6 +31,7 @@ type Application interface { //nolint:interfacebloat
 	NeedsLateUpdateCheck() bool
 	Restart(ctx context.Context) error
 	RestoreBackup(ctx context.Context, archive io.Reader) error
+	SetFriendlyVersion(ctx context.Context) error
 	SetVersions(version string, availableVersions []string)
 	Struct() any
 	Start(ctx context.Context) error

--- a/incus-osd/internal/applications/sysext.go
+++ b/incus-osd/internal/applications/sysext.go
@@ -115,9 +115,14 @@ func RefreshExtensions(ctx context.Context, s *state.State) error {
 	// and don't unexpectedly try to force-reset application versions.
 	priorBootRelease = s.OS.RunningRelease
 
-	// Remove any old versions of each application.
+	// Remove any old versions of each application and update their friendly version.
 	for _, app := range apps {
 		err := removeStaleSysextImages(app.Name(), app.AvailableVersions())
+		if err != nil {
+			return err
+		}
+
+		err = app.SetFriendlyVersion(ctx)
 		if err != nil {
 			return err
 		}

--- a/incus-osd/internal/rest/api_applications.go
+++ b/incus-osd/internal/rest/api_applications.go
@@ -209,7 +209,7 @@ func (s *Server) apiApplications(w http.ResponseWriter, r *http.Request) {
 //	        metadata:
 //	          type: json
 //	          description: State and configuration for the application
-//	          example: {"state":{"initialized":true,"version":"202511041800","available_versions":["202511041601","202511041800"]},"config":{}}
+//	          example: {"state":{"initialized":true,"friendly_version":"7.0.0 [202511041800]","version":"202511041800","available_versions":["202511041601","202511041800"]},"config":{}}
 //	  "404":
 //	    $ref: "#/responses/NotFound"
 //	  "500":

--- a/incus-osd/internal/tui/tui.go
+++ b/incus-osd/internal/tui/tui.go
@@ -329,7 +329,7 @@ func (t *TUI) redrawScreen() {
 
 		appStatus := []string{}
 		for _, app := range apps {
-			appStatus = append(appStatus, app.Name()+"("+app.Version()+")")
+			appStatus = append(appStatus, app.Name()+"("+app.FriendlyVersion()+")")
 		}
 
 		slices.Sort(appStatus)

--- a/incus-osd/internal/update/update.go
+++ b/incus-osd/internal/update/update.go
@@ -462,7 +462,7 @@ func applyUpdate(ctx context.Context, s *state.State, t *tui.TUI, update provide
 		targetPath = filepath.Join(systemd.LocalExtensionsPath, update.Version())
 
 		slog.InfoContext(ctx, "Downloading application update", "application", appName, "version", update.Version())
-		updateModal.Update("Downloading application update " + appName + " update " + update.Version())
+		updateModal.Update("Downloading application update " + appName + " version " + update.Version())
 	default:
 		// An invalid update type has been handled previously in checkDownloadUpdate().
 	}

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_applications.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_applications.py
@@ -265,7 +265,7 @@ def TestIncusOSAPIApplicationsIncusLinstor(install_image):
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
         vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus-linstor version="+os_version)
-        vm.WaitExpectedLog("incus-osd", "Initializing application name=incus-linstor version="+os_version)
+        vm.WaitExpectedLog("incus-osd", "Initializing application name=incus-linstor version=.+ \\["+os_version+"\\]", regex=True)
 
         result = vm.APIRequest("/1.0/applications")
         if result["status_code"] != 200:

--- a/incus-osd/tests/incusos_tests/tests_recovery.py
+++ b/incus-osd/tests/incusos_tests/tests_recovery.py
@@ -98,8 +98,8 @@ def _recoveryChecks(vm, os_version):
     vm.WaitExpectedLog("incus-osd", "Recovery actions completed")
     vm.WaitExpectedLog("incus-osd", "Bringing up the network")
     vm.WaitExpectedLog("incus-osd", "systemd-timesyncd failed to perform NTP synchronization, system time may be incorrect")
-    vm.WaitExpectedLog("incus-osd", "Starting application name=incus version="+os_version)
-    vm.WaitExpectedLog("incus-osd", "Initializing application name=incus version="+os_version)
+    vm.WaitExpectedLog("incus-osd", "Starting application name=incus version=.+ \\["+os_version+"\\]", regex=True)
+    vm.WaitExpectedLog("incus-osd", "Initializing application name=incus version=.+ \\["+os_version+"\\]", regex=True)
     vm.WaitExpectedLog("incus-osd", "System is ready version="+os_version)
 
     # Verity the incus application is installed.

--- a/incus-osd/tests/incusos_tests/tests_upgrade.py
+++ b/incus-osd/tests/incusos_tests/tests_upgrade.py
@@ -130,8 +130,8 @@ def TestBaselineUpgradeApplicationOnly(install_image):
                 vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+os_version)
                 vm.WaitExpectedLog("incus-osd", "Recovery actions completed")
                 vm.WaitExpectedLog("incus-osd", "Bringing up the network")
-                vm.WaitExpectedLog("incus-osd", "Starting application name=incus version="+os_version)
-                vm.WaitExpectedLog("incus-osd", "Initializing application name=incus version="+os_version)
+                vm.WaitExpectedLog("incus-osd", "Starting application name=incus version=.+ \\["+os_version+"\\]", regex=True)
+                vm.WaitExpectedLog("incus-osd", "Initializing application name=incus version=.+ \\["+os_version+"\\]", regex=True)
                 vm.WaitExpectedLog("incus-osd", "System is ready version="+os_version)
 
                 vm.LogDoesntContain("incus-osd", "Downloading OS update")


### PR DESCRIPTION
This adds the ability for applications to report a "friendly" version as a free form string. For Incus, it might look something like "7.0.0 [202605191531]", reporting the actual application version and the build version in brackets. This field isn't intended to be parsed, and its format may change at any time.

<img width="2307" height="1441" alt="image" src="https://github.com/user-attachments/assets/84a8b39d-2b3d-4f3d-b11a-f2007e78fbec" />

Closes #1094