### PR TITLE
Add ability to configure serial console(s)

### DIFF
--- a/doc/reference/seed.md
+++ b/doc/reference/seed.md
@@ -71,6 +71,17 @@ and references Incus' [`InitPreseed` API](https://github.com/lxc/incus/blob/main
 - `preseed`: Additional preseed information to be passed to Incus during
   install.
 
+### `kernel.{json,yml,yaml}`
+This file defines kernel configuration options that may need to be set before the
+installation process begins or the IncusOS API is available to fully configure
+available kernel options.
+
+The structure is defined in [`api/seed/kernel.go`](https://github.com/lxc/incus-os/blob/main/incus-osd/api/seed/kernel.go):
+
+- `console`: An array of console devices that should be used by the IncusOS
+  terminal user interface. Optionally, a baud rate may be specified to configure
+  the speed of that specific console device.
+
 ### `network.{json,yml,yaml}`
 This file defines what network configuration should be applied when IncusOS
 boots. If not specified, IncusOS will attempt automatic {abbr}`DHCP (Dynamic Host Configuration Protocol)`/{abbr}`SLAAC (Stateless Address Configuration)`

--- a/incus-osd/api/seed/kernel.go
+++ b/incus-osd/api/seed/kernel.go
@@ -1,0 +1,12 @@
+package seed
+
+import (
+	"github.com/lxc/incus-os/incus-osd/api"
+)
+
+// Kernel represents the kernel seed.
+type Kernel struct {
+	Console []api.SystemKernelConfigConsole `json:"console,omitempty" yaml:"console,omitempty"`
+
+	Version string `json:"version" yaml:"version"`
+}

--- a/incus-osd/api/system_kernel.go
+++ b/incus-osd/api/system_kernel.go
@@ -2,10 +2,17 @@ package api
 
 // SystemKernelConfig holds the kernel-level configuration data.
 type SystemKernelConfig struct {
-	BlacklistModules []string                   `json:"blacklist_modules,omitempty" yaml:"blacklist_modules,omitempty"`
-	Memory           *SystemKernelConfigMemory  `json:"memory,omitempty"            yaml:"memory,omitempty"`
-	Network          *SystemKernelConfigNetwork `json:"network,omitempty"           yaml:"network,omitempty"`
-	PCI              *SystemKernelConfigPCI     `json:"pci,omitempty"               yaml:"pci,omitempty"`
+	Console          []SystemKernelConfigConsole `json:"console,omitempty"           yaml:"console,omitempty"`
+	BlacklistModules []string                    `json:"blacklist_modules,omitempty" yaml:"blacklist_modules,omitempty"`
+	Memory           *SystemKernelConfigMemory   `json:"memory,omitempty"            yaml:"memory,omitempty"`
+	Network          *SystemKernelConfigNetwork  `json:"network,omitempty"           yaml:"network,omitempty"`
+	PCI              *SystemKernelConfigPCI      `json:"pci,omitempty"               yaml:"pci,omitempty"`
+}
+
+// SystemKernelConfigConsole holds console-specific kernel configuration.
+type SystemKernelConfigConsole struct {
+	Device   string `json:"device"              yaml:"device"`
+	BaudRate int    `json:"baud_rate,omitempty" yaml:"baud_rate,omitempty"`
 }
 
 // SystemKernelConfigMemory holds memory-specific kernel configuration.

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -81,6 +82,13 @@ func main() {
 	s, err := state.LoadOrCreate(filepath.Join(varPath, "state.txt"))
 	if err != nil {
 		tui.EarlyError("unable to load state file: "+err.Error(), osName)
+		os.Exit(1)
+	}
+
+	// Configure console devices with custom baud rates, if defined.
+	err = configureConsoleDevices(ctx, s)
+	if err != nil {
+		tui.EarlyError("unable to configure console baud rates: "+err.Error(), osName)
 		os.Exit(1)
 	}
 
@@ -1174,6 +1182,31 @@ func startFallbackListener(ctx context.Context, s *state.State) error {
 	go func() {
 		_ = server.Serve()
 	}()
+
+	return nil
+}
+
+func configureConsoleDevices(ctx context.Context, s *state.State) error {
+	// Get the kernel seed if it exists.
+	kernelSeed, err := seed.GetKernel(ctx)
+	if err != nil && !seed.IsMissing(err) {
+		return err
+	}
+
+	// If no console configuration already exists, copy any existing value from the seed.
+	if len(s.System.Kernel.Config.Console) == 0 {
+		s.System.Kernel.Config.Console = kernelSeed.Console
+	}
+
+	// Set any configured baud speeds.
+	for _, console := range s.System.Kernel.Config.Console {
+		if console.BaudRate != 0 {
+			_, err := subprocess.RunCommandContext(ctx, "/usr/bin/stty", "-F", console.Device, strconv.Itoa(console.BaudRate))
+			if err != nil {
+				return err
+			}
+		}
+	}
 
 	return nil
 }

--- a/incus-osd/internal/seed/kernel.go
+++ b/incus-osd/internal/seed/kernel.go
@@ -1,0 +1,20 @@
+package seed
+
+import (
+	"context"
+
+	apiseed "github.com/lxc/incus-os/incus-osd/api/seed"
+)
+
+// GetKernel extracts the kernel configuration from the seed data.
+func GetKernel(_ context.Context) (*apiseed.Kernel, error) {
+	// Get the kernel configuration.
+	var config apiseed.Kernel
+
+	err := parseFileContents(getSeedPath(), "kernel", &config)
+	if err != nil && !IsMissing(err) {
+		return nil, err
+	}
+
+	return &config, nil
+}

--- a/incus-osd/internal/tui/tui.go
+++ b/incus-osd/internal/tui/tui.go
@@ -70,6 +70,13 @@ func GetTUI(s *state.State) (*TUI, error) {
 		ttyDevs = append(ttyDevs, "/dev/ttyS0")
 	}
 
+	// Add any additional user-provided console devices.
+	for _, console := range s.System.Kernel.Config.Console {
+		if !slices.Contains(ttyDevs, console.Device) {
+			ttyDevs = append(ttyDevs, console.Device)
+		}
+	}
+
 	// Get information about the system's resources. Since we only display CPU
 	// and RAM, caching the results at creation time should be sufficient.
 	singletonTUI.systemResources, err = resources.GetResources()


### PR DESCRIPTION
Add a `Console` option to the existing system kernel config struct that allows specifying additional consoles for the TUI to use, as well as optionally configuring a baud rate.

A new minimal kernel seed is also defined for cases where setting a console baud rate is required to actually see any output:

```
console:
  - device: /dev/ttyS0
    baud_rate: 11520
```

Closes #940