### PR TITLE
incus-osd/appliations: Only consider application installed if its sysext exists

### DIFF
--- a/incus-osd/internal/applications/app_common.go
+++ b/incus-osd/internal/applications/app_common.go
@@ -86,11 +86,6 @@ func (a *common) Initialize(_ context.Context) error {
 	return nil
 }
 
-// IsInstalled reports whether the application has been installed.
-func (a *common) IsInstalled() bool {
-	return a.appState.Version != ""
-}
-
 // IsInitialized reports whether the application has been initialized.
 func (a *common) IsInitialized() bool {
 	return a.appState.Initialized

--- a/incus-osd/internal/applications/app_debug.go
+++ b/incus-osd/internal/applications/app_debug.go
@@ -14,6 +14,15 @@ func (d *debug) Get(_ context.Context) (any, error) {
 	return d.state.Applications.Debug, nil
 }
 
+// IsInstalled reports whether the application has been installed.
+func (d *debug) IsInstalled() bool {
+	if d.appState.Version == "" {
+		return false
+	}
+
+	return sysextImageExists(d.Name(), d.appState.Version)
+}
+
 func (*debug) Name() string {
 	return "debug"
 }

--- a/incus-osd/internal/applications/app_gpu_support.go
+++ b/incus-osd/internal/applications/app_gpu_support.go
@@ -21,6 +21,15 @@ func (g *gpuSupport) Get(_ context.Context) (any, error) {
 	return g.state.Applications.GPUSupport, nil
 }
 
+// IsInstalled reports whether the application has been installed.
+func (g *gpuSupport) IsInstalled() bool {
+	if g.appState.Version == "" {
+		return false
+	}
+
+	return sysextImageExists(g.Name(), g.appState.Version)
+}
+
 func (*gpuSupport) IsRunning(_ context.Context) bool {
 	return true
 }

--- a/incus-osd/internal/applications/app_incus.go
+++ b/incus-osd/internal/applications/app_incus.go
@@ -199,6 +199,15 @@ func (a *incus) Initialize(ctx context.Context) error {
 	return nil
 }
 
+// IsInstalled reports whether the application has been installed.
+func (a *incus) IsInstalled() bool {
+	if a.appState.Version == "" {
+		return false
+	}
+
+	return sysextImageExists(a.Name(), a.appState.Version)
+}
+
 // IsPrimary reports if the application is a primary application.
 func (*incus) IsPrimary() bool {
 	return true

--- a/incus-osd/internal/applications/app_incus_services.go
+++ b/incus-osd/internal/applications/app_incus_services.go
@@ -23,6 +23,15 @@ func (*incusCeph) GetDependencies() []string {
 	return []string{"incus"}
 }
 
+// IsInstalled reports whether the application has been installed.
+func (i *incusCeph) IsInstalled() bool {
+	if i.appState.Version == "" {
+		return false
+	}
+
+	return sysextImageExists(i.Name(), i.appState.Version)
+}
+
 func (*incusCeph) Name() string {
 	return "incus-ceph"
 }
@@ -62,6 +71,15 @@ func (i *incusLinstor) Get(_ context.Context) (any, error) {
 // GetDependencies returns a list of other applications this application depends on.
 func (*incusLinstor) GetDependencies() []string {
 	return []string{"incus"}
+}
+
+// IsInstalled reports whether the application has been installed.
+func (i *incusLinstor) IsInstalled() bool {
+	if i.appState.Version == "" {
+		return false
+	}
+
+	return sysextImageExists(i.Name(), i.appState.Version)
 }
 
 func (*incusLinstor) Name() string {

--- a/incus-osd/internal/applications/app_migration_manager.go
+++ b/incus-osd/internal/applications/app_migration_manager.go
@@ -263,6 +263,15 @@ func (mm *migrationManager) Initialize(ctx context.Context) error {
 	return nil
 }
 
+// IsInstalled reports whether the application has been installed.
+func (mm *migrationManager) IsInstalled() bool {
+	if mm.appState.Version == "" {
+		return false
+	}
+
+	return sysextImageExists(mm.Name(), mm.appState.Version)
+}
+
 // IsPrimary reports if the application is a primary application.
 func (*migrationManager) IsPrimary() bool {
 	return true

--- a/incus-osd/internal/applications/app_operations_center.go
+++ b/incus-osd/internal/applications/app_operations_center.go
@@ -284,6 +284,15 @@ func (oc *operationsCenter) Initialize(ctx context.Context) error {
 	return nil
 }
 
+// IsInstalled reports whether the application has been installed.
+func (oc *operationsCenter) IsInstalled() bool {
+	if oc.appState.Version == "" {
+		return false
+	}
+
+	return sysextImageExists(oc.Name(), oc.appState.Version)
+}
+
 // IsPrimary reports if the application is a primary application.
 func (*operationsCenter) IsPrimary() bool {
 	return true


### PR DESCRIPTION
Previously, we had been relying on an application's version string being set, but if the download fails for some reason we might encounter an edge case where we have application state but no corresponding sysext image.

Unfortunately this is a bit more verbose, but a specific application's name isn't available in the application common code.