### PR TITLE
Add an `incus-lts-7.0` application

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,7 @@ jobs:
           mv mkosi.output/debug.raw upload/
           mv mkosi.output/gpu-support.raw upload/
           mv mkosi.output/incus.raw upload/
+          mv mkosi.output/incus-lts-7.0.raw upload/
           mv mkosi.output/incus-ceph.raw upload/
           mv mkosi.output/incus-linstor.raw upload/
           mv mkosi.output/migration-manager.raw upload/

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,7 @@ test-applications:
 	incus file push mkosi.output/debug.raw test-incus-os/root/updates/
 	incus file push mkosi.output/gpu-support.raw test-incus-os/root/updates/
 	incus file push mkosi.output/incus.raw test-incus-os/root/updates/
+	incus file push mkosi.output/incus-lts-7.0.raw test-incus-os/root/updates/
 	incus file push mkosi.output/incus-ceph.raw test-incus-os/root/updates/
 	incus file push mkosi.output/incus-linstor.raw test-incus-os/root/updates/
 	incus file push mkosi.output/migration-manager.raw test-incus-os/root/updates/
@@ -208,6 +209,7 @@ test-update:
 	incus file push mkosi.output/debug.raw test-incus-os/root/updates/
 	incus file push mkosi.output/gpu-support.raw test-incus-os/root/updates/
 	incus file push mkosi.output/incus.raw test-incus-os/root/updates/
+	incus file push mkosi.output/incus-lts-7.0.raw test-incus-os/root/updates/
 	incus file push mkosi.output/incus-ceph.raw test-incus-os/root/updates/
 	incus file push mkosi.output/incus-linstor.raw test-incus-os/root/updates/
 	incus file push mkosi.output/migration-manager.raw test-incus-os/root/updates/

--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -65,6 +65,7 @@ libvirt
 Linstor
 LLDP
 LLMs
+LTS
 LUKS
 LVM
 MAC

--- a/doc/reference/applications/debug.md
+++ b/doc/reference/applications/debug.md
@@ -5,8 +5,9 @@ The Debug (`debug`) application provides several additional tools that can be us
 * `htop`
 * `ifstat`
 * `iputils-ping`
-* `nano`
+* `jq`
 * `mtr-tiny`
+* `nano`
 * `net-tools`
 * `netcat-openbsd`
 * `procps`

--- a/doc/reference/applications/incus.md
+++ b/doc/reference/applications/incus.md
@@ -1,8 +1,28 @@
 # Incus
 
-The Incus application includes the current Incus feature release as packaged from the [Zabbly stable channel](https://github.com/zabbly/incus). It includes everything needed to run containers, OCI images, and virtual machines.
+The Incus application includes Incus as packaged by [Zabbly](https://github.com/zabbly/incus). It includes everything needed to run containers, OCI images, and virtual machines.
 
+```{warning}
 At least one trusted client certificate must be provided in the Incus preseed, otherwise it will be impossible to authenticate to any API endpoint or the web UI post-install.
+```
+
+There are currently two "flavors" of the Incus application which can be installed:
+
+* The current stable (aka "monthly" or "feature") release is available as the `incus` application and receives new features and bug fixes on a regular monthly schedule. This is the default version of Incus selected by IncusOS if not otherwise configured.
+
+* The {abbr}`LTS (Long Term Support)` 7.0 series of releases is available as the `incus-lts-7.0` application. The LTS series of Incus is recommended for enterprise environments and will receive only bug and security fixes for the duration of its five year support cycle.
+
+```{note}
+It is possible to switch between the stable and LTS Incus release tracks under certain conditions:
+
+* It is always possible to switch from a LTS release to the current stable release.
+
+* It is possible to switch from a stable release to the LTS series, but _only_ from versions of Incus less than or equal to the first LTS release of that LTS series. For example, it's possible to switch both Incus versions 6.23.0 and 7.0.0 to the 7.0 LTS series, but it is NOT possible to switch Incus version 7.1.0 to the 7.0 LTS series.
+
+These limitations are due to how Incus tracks internal database schema changes. It's always possible to move forward, but rolling back to a prior schema version is not supported.
+
+IncusOS can switch the installed release of Incus, if supported, by running `incus admin os application add -d '{"name":"<desired incus application>"}'`.
+```
 
 ## Default configuration
 

--- a/incus-osd/cmd/flasher-tool/main.go
+++ b/incus-osd/cmd/flasher-tool/main.go
@@ -197,7 +197,7 @@ func mainMenu(ctx context.Context, asker ask.Asker, imageFilename string) error 
 		menuSelectionOptions = append(menuSelectionOptions, strconv.Itoa(len(menuOptions)))
 
 		if applicationsSeed != nil && slices.ContainsFunc(applicationsSeed.Applications, func(a apiseed.Application) bool {
-			return a.Name == "incus"
+			return a.Name == "incus" || a.Name == "incus-lts-7.0"
 		}) {
 			menuOptions = append(menuOptions, "Configure Incus seed")
 			menuSelectionOptions = append(menuSelectionOptions, strconv.Itoa(len(menuOptions)))
@@ -335,7 +335,7 @@ func toggleInstallRunningMode(ctx context.Context, asker ask.Asker, imageFilenam
 }
 
 func selectApplications(asker ask.Asker) error {
-	menuOptions := []string{"Incus", "Migration Manager", "Operations Center", "None"}
+	menuOptions := []string{"Incus", "Incus (LTS 7.0)", "Migration Manager", "Operations Center", "None"}
 
 	var menuPrompt strings.Builder
 
@@ -347,7 +347,7 @@ func selectApplications(asker ask.Asker) error {
 	_, _ = menuPrompt.WriteString("\nSelection: ")
 
 	// Prompt the user for a selection.
-	selection, err := asker.AskChoice(menuPrompt.String(), []string{"1", "2", "3", "4"}, strconv.Itoa(len(menuOptions)))
+	selection, err := asker.AskChoice(menuPrompt.String(), []string{"1", "2", "3", "4", "5"}, strconv.Itoa(len(menuOptions)))
 	if err != nil {
 		return err
 	}
@@ -357,10 +357,16 @@ func selectApplications(asker ask.Asker) error {
 	applicationsSeed = &apiseed.Applications{}
 
 	switch menuOptions[selectionInt-1] {
-	case "Incus":
-		applicationsSeed.Applications = append(applicationsSeed.Applications, apiseed.Application{
-			Name: "incus",
-		})
+	case "Incus", "Incus (LTS 7.0)":
+		if menuOptions[selectionInt-1] == "Incus" {
+			applicationsSeed.Applications = append(applicationsSeed.Applications, apiseed.Application{
+				Name: "incus",
+			})
+		} else {
+			applicationsSeed.Applications = append(applicationsSeed.Applications, apiseed.Application{
+				Name: "incus-lts-7.0",
+			})
+		}
 
 		installIncusCeph, err := asker.AskBool("Install Incus Ceph add-on? [y/N] ", "n")
 		if err != nil {

--- a/incus-osd/cmd/image-customizer/html/index.html
+++ b/incus-osd/cmd/image-customizer/html/index.html
@@ -127,6 +127,11 @@
                                 </div>
 
                                 <div class="mb-3">
+                                    <input class="form-check-input" type="radio" name="imageApplication" id="imageApplicationIncusLTS">
+                                    <label class="form-check-label" for="imageApplicationIncusLTS">Incus (LTS 7.0) - Container and VM private cloud platform</label>
+                                </div>
+
+                                <div class="mb-3">
                                     <input class="form-check-input" type="radio" name="imageApplication" id="imageApplicationOperationsCenter">
                                     <label class="form-check-label" for="imageApplicationOperationsCenter">Operations Center - Central deployment and tracking of Incus clusters</label>
                                 </div>

--- a/incus-osd/cmd/image-customizer/html/js/local.js
+++ b/incus-osd/cmd/image-customizer/html/js/local.js
@@ -76,6 +76,8 @@ function download() {
     app = "";
     if (document.getElementById("imageApplicationIncus").checked) {
         app = "incus";
+    } else if (document.getElementById("imageApplicationIncusLTS").checked) {
+        app = "incus-lts-7.0";
     } else if (document.getElementById("imageApplicationOperationsCenter").checked) {
         app = "operations-center";
     } else if (document.getElementById("imageApplicationMigrationManager").checked) {

--- a/incus-osd/cmd/image-publisher/main_sync.go
+++ b/incus-osd/cmd/image-publisher/main_sync.go
@@ -383,8 +383,17 @@ func (*cmdSync) downloadImage(ctx context.Context, archName string, releaseURL *
 		case strings.HasSuffix(assetName, "debug.manifest.json.gz"):
 			assetComponent = apiupdate.UpdateFileComponentDebug
 			assetType = apiupdate.UpdateFileTypeImageManifest
+		case strings.HasSuffix(assetName, "gpu-support.manifest.json.gz"):
+			assetComponent = apiupdate.UpdateFileComponentGPUSupport
+			assetType = apiupdate.UpdateFileTypeImageManifest
 		case strings.HasSuffix(assetName, "incus.manifest.json.gz"):
 			assetComponent = apiupdate.UpdateFileComponentIncus
+			assetType = apiupdate.UpdateFileTypeImageManifest
+		case strings.HasSuffix(assetName, "incus-ceph.manifest.json.gz"):
+			assetComponent = apiupdate.UpdateFileComponentIncusCeph
+			assetType = apiupdate.UpdateFileTypeImageManifest
+		case strings.HasSuffix(assetName, "incus-linstor.manifest.json.gz"):
+			assetComponent = apiupdate.UpdateFileComponentIncusLinstor
 			assetType = apiupdate.UpdateFileTypeImageManifest
 		case strings.HasSuffix(assetName, "migration-manager.manifest.json.gz"):
 			assetComponent = apiupdate.UpdateFileComponentMigrationManager
@@ -392,10 +401,9 @@ func (*cmdSync) downloadImage(ctx context.Context, archName string, releaseURL *
 		case strings.HasSuffix(assetName, "operations-center.manifest.json.gz"):
 			assetComponent = apiupdate.UpdateFileComponentOperationsCenter
 			assetType = apiupdate.UpdateFileTypeImageManifest
-		case strings.HasSuffix(assetName, ".manifest.json.gz"):
-			assetComponent = apiupdate.UpdateFileComponentOS
-			assetType = apiupdate.UpdateFileTypeImageManifest
 		default:
+			slog.WarnContext(ctx, "Skipping unrecognized asset", "filename", assetName)
+
 			continue
 		}
 

--- a/incus-osd/cmd/image-publisher/main_sync.go
+++ b/incus-osd/cmd/image-publisher/main_sync.go
@@ -350,6 +350,9 @@ func (*cmdSync) downloadImage(ctx context.Context, archName string, releaseURL *
 		case assetName == "incus.raw.gz":
 			assetComponent = apiupdate.UpdateFileComponentIncus
 			assetType = apiupdate.UpdateFileTypeApplication
+		case assetName == "incus-lts-7.0.raw.gz":
+			assetComponent = apiupdate.UpdateFileComponentIncus
+			assetType = apiupdate.UpdateFileTypeApplication
 		case assetName == "incus-ceph.raw.gz":
 			assetComponent = apiupdate.UpdateFileComponentIncusCeph
 			assetType = apiupdate.UpdateFileTypeApplication
@@ -387,6 +390,9 @@ func (*cmdSync) downloadImage(ctx context.Context, archName string, releaseURL *
 			assetComponent = apiupdate.UpdateFileComponentGPUSupport
 			assetType = apiupdate.UpdateFileTypeImageManifest
 		case strings.HasSuffix(assetName, "incus.manifest.json.gz"):
+			assetComponent = apiupdate.UpdateFileComponentIncus
+			assetType = apiupdate.UpdateFileTypeImageManifest
+		case strings.HasSuffix(assetName, "incus-lts-7.0.manifest.json.gz"):
 			assetComponent = apiupdate.UpdateFileComponentIncus
 			assetType = apiupdate.UpdateFileTypeImageManifest
 		case strings.HasSuffix(assetName, "incus-ceph.manifest.json.gz"):

--- a/incus-osd/internal/applications/app_common.go
+++ b/incus-osd/internal/applications/app_common.go
@@ -28,6 +28,11 @@ func (a *common) AvailableVersions() []string {
 	return a.appState.AvailableVersions
 }
 
+// CanBeReplaced checks if it is possible to replace the installed application with an equivalent one.
+func (*common) CanBeReplaced(_ context.Context, _ string) error {
+	return errors.New("not supported")
+}
+
 // ConfigureLocalStorage configures local storage for the application.
 func (*common) ConfigureLocalStorage(_ context.Context) error {
 	return nil

--- a/incus-osd/internal/applications/app_incus.go
+++ b/incus-osd/internal/applications/app_incus.go
@@ -24,12 +24,26 @@ import (
 	"github.com/lxc/incus-os/incus-osd/internal/systemd"
 )
 
+// IncusOS supports both stable (aka "feature" or "monthly") and 7.0 LTS versions
+// of the Incus application. When the application is loaded, the appropriate
+// version constant defined below is used, which then sets the reported name and
+// expected sysext filepath. The actual logic for initializing/starting/etc of the
+// Incus application is currently identical regardless of version; down the road if
+// needed code can refer to the "incusVersion" field to determine which version of
+// Incus is running to properly handle any differences.
+const (
+	incusVersionStable = "incus"
+	incusVersionLTS70  = "incus-lts-7.0"
+)
+
 type incusDebug struct {
 	Action string `json:"action"`
 }
 
 type incus struct {
 	common
+
+	incusVersion string
 }
 
 // AddTrustedCertificate adds a new trusted certificate to the application.
@@ -213,8 +227,8 @@ func (*incus) IsRunning(ctx context.Context) bool {
 	return systemd.IsActive(ctx, "incus.service")
 }
 
-func (*incus) Name() string {
-	return "incus"
+func (a *incus) Name() string {
+	return a.incusVersion
 }
 
 // NeedsLateUpdateCheck reports if the application depends on a delayed provider update check.

--- a/incus-osd/internal/applications/app_incus.go
+++ b/incus-osd/internal/applications/app_incus.go
@@ -122,11 +122,6 @@ func (a *incus) GetClientCertificate() (*tls.Certificate, error) {
 	return a.getCertificate("server")
 }
 
-// GetDependencies returns a list of other applications this application depends on.
-func (*incus) GetDependencies() []string {
-	return nil
-}
-
 // GetServerCertificate returns the keypair for the server certificate.
 func (a *incus) GetServerCertificate() (*tls.Certificate, error) {
 	cert, err := a.getCertificate("cluster")

--- a/incus-osd/internal/applications/app_incus.go
+++ b/incus-osd/internal/applications/app_incus.go
@@ -68,6 +68,46 @@ func (*incus) AddTrustedCertificate(_ context.Context, name string, cert string)
 	return nil
 }
 
+// CanBeReplaced checks if it is possible to replace the installed application with an equivalent one.
+func (a *incus) CanBeReplaced(ctx context.Context, otherAppName string) error {
+	if a.Name() == otherAppName {
+		return errors.New("can't replace application '" + a.Name() + "' with itself")
+	}
+
+	// Check if it's possible to switch application editions.
+	switch a.Name() {
+	case incusVersionStable:
+		// Currently running stable, attempt to switch to LTS branch.
+		if otherAppName != incusVersionLTS70 {
+			return errors.New("unable to replace application '" + a.Name() + "' with '" + otherAppName + "': unsupported application")
+		}
+
+		// Get the current Incus application version.
+		output, err := subprocess.RunCommandContext(ctx, "incus", "--version")
+		if err != nil {
+			return err
+		}
+
+		currentVersion := strings.TrimSuffix(output, "\n")
+
+		if currentVersion != "7.0.0" {
+			return errors.New("unable to replace application '" + a.Name() + "' with '" + otherAppName + "': current Incus version (" + currentVersion + ") is too new to rollback to older LTS branch")
+		}
+	case incusVersionLTS70:
+		// Currently running LTS, attempt to switch to stable branch.
+		if otherAppName != "incus" {
+			return errors.New("can't replace application '" + a.Name() + "' with a non-Incus application")
+		}
+
+		// Nothing else to check; it's always possible to move from LTS to the current feature release.
+	default:
+		return errors.New("unable to check replacement of application '" + a.Name() + "': unsupported application branch")
+	}
+
+	// It is possible to replace the current Incus application.
+	return nil
+}
+
 // Debug runs a debug action.
 func (*incus) Debug(ctx context.Context, data any) response.Response {
 	req, ok := data.(*incusDebug)

--- a/incus-osd/internal/applications/app_incus_services.go
+++ b/incus-osd/internal/applications/app_incus_services.go
@@ -20,7 +20,7 @@ func (i *incusCeph) Get(_ context.Context) (any, error) {
 
 // GetDependencies returns a list of other applications this application depends on.
 func (*incusCeph) GetDependencies() []string {
-	return []string{"incus"}
+	return []string{incusVersionStable + " OR " + incusVersionLTS70}
 }
 
 // IsInstalled reports whether the application has been installed.
@@ -70,7 +70,7 @@ func (i *incusLinstor) Get(_ context.Context) (any, error) {
 
 // GetDependencies returns a list of other applications this application depends on.
 func (*incusLinstor) GetDependencies() []string {
-	return []string{"incus"}
+	return []string{incusVersionStable + " OR " + incusVersionLTS70}
 }
 
 // IsInstalled reports whether the application has been installed.

--- a/incus-osd/internal/applications/app_migration_manager.go
+++ b/incus-osd/internal/applications/app_migration_manager.go
@@ -125,11 +125,6 @@ func (mm *migrationManager) GetClientCertificate() (*tls.Certificate, error) {
 	return mm.GetServerCertificate()
 }
 
-// GetDependencies returns a list of other applications this application depends on.
-func (*migrationManager) GetDependencies() []string {
-	return nil
-}
-
 // GetServerCertificate returns the keypair for the server certificate.
 func (*migrationManager) GetServerCertificate() (*tls.Certificate, error) {
 	// Load the certificate.

--- a/incus-osd/internal/applications/app_operations_center.go
+++ b/incus-osd/internal/applications/app_operations_center.go
@@ -131,11 +131,6 @@ func (oc *operationsCenter) GetClientCertificate() (*tls.Certificate, error) {
 	return oc.GetServerCertificate()
 }
 
-// GetDependencies returns a list of other applications this application depends on.
-func (*operationsCenter) GetDependencies() []string {
-	return nil
-}
-
 // GetServerCertificate returns the keypair for the server certificate.
 func (*operationsCenter) GetServerCertificate() (*tls.Certificate, error) {
 	// Load the certificate.

--- a/incus-osd/internal/applications/helpers.go
+++ b/incus-osd/internal/applications/helpers.go
@@ -66,7 +66,7 @@ func UninstallApplication(ctx context.Context, s *state.State, name string) erro
 		s.Applications.Debug = api.Application{}
 	case "gpu-support":
 		s.Applications.GPUSupport = api.Application{}
-	case "incus":
+	case incusVersionStable, incusVersionLTS70:
 		s.Applications.Incus = api.ApplicationIncus{}
 	case "incus-ceph":
 		s.Applications.IncusCeph = api.Application{}

--- a/incus-osd/internal/applications/load.go
+++ b/incus-osd/internal/applications/load.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Supported lists all supported applications.
-var Supported = []string{"debug", "gpu-support", "incus", "incus-ceph", "incus-linstor", "migration-manager", "operations-center"}
+var Supported = []string{"debug", "gpu-support", incusVersionStable, incusVersionLTS70, "incus-ceph", "incus-linstor", "migration-manager", "operations-center"}
 
 // ErrNoPrimary is returned when the system doesn't yet have a primary application.
 var ErrNoPrimary = errors.New("no primary application")
@@ -30,8 +30,10 @@ func Load(_ context.Context, s *state.State, name string) (Application, error) {
 		app = &debug{common: common{state: s, appState: &s.Applications.Debug.State}}
 	case "gpu-support":
 		app = &gpuSupport{common: common{state: s, appState: &s.Applications.GPUSupport.State}}
-	case "incus":
-		app = &incus{common: common{state: s, appState: &s.Applications.Incus.State.ApplicationState}}
+	case incusVersionStable:
+		app = &incus{common: common{state: s, appState: &s.Applications.Incus.State.ApplicationState}, incusVersion: incusVersionStable}
+	case incusVersionLTS70:
+		app = &incus{common: common{state: s, appState: &s.Applications.Incus.State.ApplicationState}, incusVersion: incusVersionLTS70}
 	case "incus-ceph":
 		app = &incusCeph{common: common{state: s, appState: &s.Applications.IncusCeph.State}}
 	case "incus-linstor":

--- a/incus-osd/internal/applications/load.go
+++ b/incus-osd/internal/applications/load.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"strings"
 
 	"github.com/lxc/incus-os/incus-osd/internal/seed"
 	"github.com/lxc/incus-os/incus-osd/internal/state"
@@ -159,6 +160,24 @@ func GetInstallApplications(ctx context.Context, s *state.State) ([]string, erro
 	// Sort and remove any duplicates.
 	slices.Sort(toInstall)
 	toInstall = slices.Compact(toInstall)
+
+	// Ensure that only one primary application is in the list of applications to install.
+	numPrimaryApps := 0
+
+	for _, appName := range toInstall {
+		app, err := Load(ctx, s, appName)
+		if err != nil {
+			return nil, errors.New("failed to load application '" + appName + "': " + err.Error())
+		}
+
+		if app.IsPrimary() {
+			numPrimaryApps++
+		}
+	}
+
+	if numPrimaryApps > 1 {
+		return nil, errors.New("more than one primary application present in installation list: " + strings.Join(toInstall, ", "))
+	}
 
 	return toInstall, nil
 }

--- a/incus-osd/internal/applications/load.go
+++ b/incus-osd/internal/applications/load.go
@@ -153,8 +153,23 @@ func GetInstallApplications(ctx context.Context, s *state.State) ([]string, erro
 		}
 
 		for _, dep := range app.GetDependencies() {
-			if !slices.Contains(toInstall, dep) {
-				toInstall = append(toInstall, dep)
+			// Each individual dependency is required, but some dependencies can be satisfied
+			// by more than one application, such as the incus stable or incus lts versions.
+			deps := strings.Split(dep, " OR ")
+			foundDep := false
+
+			// Check if the dependency exists in the list of applications to install.
+			for _, d := range deps {
+				if slices.Contains(toInstall, d) {
+					foundDep = true
+
+					break
+				}
+			}
+
+			// Add dependency to list of applications to install if needed.
+			if !foundDep {
+				toInstall = append(toInstall, deps[0])
 			}
 		}
 	}

--- a/incus-osd/internal/applications/load.go
+++ b/incus-osd/internal/applications/load.go
@@ -19,6 +19,11 @@ var ErrNoPrimary = errors.New("no primary application")
 func Load(_ context.Context, s *state.State, name string) (Application, error) {
 	var app Application
 
+	// Ensure the requested application is one of the known, supported ones.
+	if !slices.Contains(Supported, name) {
+		return nil, errors.New("unknown application '" + name + "'")
+	}
+
 	switch name {
 	case "debug":
 		app = &debug{common: common{state: s, appState: &s.Applications.Debug.State}}
@@ -35,7 +40,7 @@ func Load(_ context.Context, s *state.State, name string) (Application, error) {
 	case "operations-center":
 		app = &operationsCenter{common: common{state: s, appState: &s.Applications.OperationsCenter.State}}
 	default:
-		return nil, errors.New("unknown application")
+		return nil, errors.New("unknown application '" + name + "'")
 	}
 
 	return app, nil

--- a/incus-osd/internal/applications/struct.go
+++ b/incus-osd/internal/applications/struct.go
@@ -12,6 +12,7 @@ import (
 type Application interface { //nolint:interfacebloat
 	AddTrustedCertificate(ctx context.Context, name string, cert string) error
 	AvailableVersions() []string
+	CanBeReplaced(ctx context.Context, otherAppName string) error
 	ConfigureLocalStorage(ctx context.Context) error
 	Debug(ctx context.Context, data any) response.Response
 	DebugStruct() any

--- a/incus-osd/internal/rest/api_applications.go
+++ b/incus-osd/internal/rest/api_applications.go
@@ -149,10 +149,19 @@ func (s *Server) apiApplications(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Don't allow more than one primary application to be installed.
-		if actualApp.IsPrimary() {
-			_ = response.BadRequest(errors.New("a primary application is already installed")).Render(w)
+		apps, err := applications.GetInstalled(r.Context(), s.state)
+		if err != nil {
+			_ = response.InternalError(err).Render(w)
 
 			return
+		}
+
+		for _, installedApp := range apps {
+			if actualApp.IsPrimary() && installedApp.IsPrimary() {
+				_ = response.BadRequest(errors.New("a primary application is already installed")).Render(w)
+
+				return
+			}
 		}
 
 		// Install the application.

--- a/incus-osd/internal/rest/api_applications.go
+++ b/incus-osd/internal/rest/api_applications.go
@@ -1,13 +1,17 @@
 package rest
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"slices"
+	"strings"
 
+	"github.com/lxc/incus-os/incus-osd/api"
 	"github.com/lxc/incus-os/incus-osd/internal/applications"
 	"github.com/lxc/incus-os/incus-osd/internal/rest/response"
 	"github.com/lxc/incus-os/incus-osd/internal/update"
@@ -158,6 +162,56 @@ func (s *Server) apiApplications(w http.ResponseWriter, r *http.Request) {
 
 		for _, installedApp := range apps {
 			if actualApp.IsPrimary() && installedApp.IsPrimary() {
+				// If the currently installed primary application is some version of incus and the app we're
+				// trying to install is a different version of incus, attempt to replace the existing application.
+				if strings.HasPrefix(installedApp.Name(), "incus") && strings.HasPrefix(app.Name, "incus") {
+					err := installedApp.CanBeReplaced(r.Context(), app.Name)
+					if err != nil {
+						_ = response.BadRequest(err).Render(w)
+
+						return
+					}
+
+					// It is possible to replace the currently installed version of incus,
+					// so let's attempt to do so.
+					slog.InfoContext(r.Context(), "Preparing to replace Incus application '"+installedApp.Name()+"' with '"+app.Name+"'")
+
+					// Perform the replacement of the incus application in its own gofunc. Without doing
+					// this, an error occurs when attempting to restart incus.service.
+					go func() { //nolint:contextcheck,gosec
+						// We must use our own context here, since the request's context will quickly go away.
+						ctx := context.Background()
+
+						// Clear the current incus application state. We do manually set its
+						// initialized state to true, since we shouldn't try to re-initialize
+						// the incus application when installing the different version.
+						s.state.Applications.Incus = api.ApplicationIncus{}
+						s.state.Applications.Incus.State.Initialized = true
+
+						// Remove the existing sysext image(s).
+						err = applications.RemoveExtension(ctx, installedApp)
+						if err != nil {
+							slog.ErrorContext(ctx, "Failed to remove sysext images for application '"+installedApp.Name()+"'", "error", err)
+
+							return
+						}
+
+						// At this point, the prior incus application is gone, although any local data
+						// is still preserved. Install the "new" incus application to complete the
+						// version switch.
+						err = update.InstallUpdateApp(ctx, s.state, app.Name, false)
+						if err != nil {
+							slog.ErrorContext(ctx, "Failed to install new application '"+app.Name+"'", "error", err)
+
+							return
+						}
+					}()
+
+					_ = response.EmptySyncResponse.Render(w)
+
+					return
+				}
+
 				_ = response.BadRequest(errors.New("a primary application is already installed")).Render(w)
 
 				return

--- a/mkosi.images/base/mkosi.conf.d/01-kernel-drbd.sh
+++ b/mkosi.images/base/mkosi.conf.d/01-kernel-drbd.sh
@@ -1,5 +1,4 @@
-#!/bin/sh
-set -eux
+#!/bin/sh -eux
 
 KERNEL="$(ls /buildroot/usr/lib/modules/)"
 

--- a/mkosi.images/base/mkosi.conf.d/01-kernel-zfs.sh
+++ b/mkosi.images/base/mkosi.conf.d/01-kernel-zfs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -eux
 KERNEL="$(ls /buildroot/usr/lib/modules/)"
 
 mkdir -p "${DESTDIR}/usr/lib/modules/${KERNEL}/updates/dkms/"

--- a/mkosi.images/incus-ceph/install.sh
+++ b/mkosi.images/incus-ceph/install.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+set -eu
+
 [ "$1" = "final" ] || exit 0
 
 # Install the packages.

--- a/mkosi.images/incus-linstor/install.sh
+++ b/mkosi.images/incus-linstor/install.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+set -eu
+
 [ "$1" = "final" ] || exit 0
 
 # Install the packages.

--- a/mkosi.images/incus-lts-7.0/build.sh
+++ b/mkosi.images/incus-lts-7.0/build.sh
@@ -1,0 +1,1 @@
+../incus/build.sh

--- a/mkosi.images/incus-lts-7.0/install.sh
+++ b/mkosi.images/incus-lts-7.0/install.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -eu
+
+[ "$1" = "final" ] || exit 0
+
+# This is a terrible hack. mkosi doesn't support subimage-specific sandboxes,
+# which would be the most correct solution as we could cleanly define an apt
+# pinning configuration for this specific subimage. Alternatively, if apt
+# supported getting pinning configuration from the command line, we could
+# add that in a slightly-ugly apt-get command. However, we're stuck with creating
+# the pinning configuration under /run/, since the actual file system that
+# we have access to at this stage is read-only. It works, but I don't like it.
+
+mkdir -p /run/apt/preferences.d/
+cat <<EOF > /run/apt/preferences.d/zabbly
+Package: *
+Pin: release l=incus-lts-7.0
+Pin-Priority: 900
+EOF
+
+# Install the incus packages.
+apt-get -o Dir::Etc::PreferencesParts="/run/apt/preferences.d/" install incus incus-ui-canonical --yes
+
+exit 0

--- a/mkosi.images/incus-lts-7.0/mkosi.conf
+++ b/mkosi.images/incus-lts-7.0/mkosi.conf
@@ -1,0 +1,1 @@
+../incus/mkosi.conf

--- a/mkosi.images/incus-lts-7.0/mkosi.extra
+++ b/mkosi.images/incus-lts-7.0/mkosi.extra
@@ -1,0 +1,1 @@
+../incus/mkosi.extra/

--- a/mkosi.images/incus/install.sh
+++ b/mkosi.images/incus/install.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+set -eu
+
 [ "$1" = "final" ] || exit 0
 
 # Get the repository keyring key.

--- a/mkosi.images/incus/install.sh
+++ b/mkosi.images/incus/install.sh
@@ -4,23 +4,6 @@ set -eu
 
 [ "$1" = "final" ] || exit 0
 
-# Get the repository keyring key.
-if [ ! -e /etc/apt/keyrings/zabbly.asc ]; then
-    mkdir -p /etc/apt/keyrings/
-    curl -fsSL https://pkgs.zabbly.com/key.asc -o /etc/apt/keyrings/zabbly.asc
-fi
-
-# Add the repository.
-cat <<EOF > /etc/apt/sources.list.d/zabbly-incus-stable.sources
-Enabled: yes
-Types: deb
-URIs: https://pkgs.zabbly.com/incus/stable
-Suites: trixie
-Components: main
-Signed-By: /etc/apt/keyrings/zabbly.asc
-
-EOF
-
 # Install the incus packages.
 apt-get update
 apt-get install incus incus-ui-canonical --yes

--- a/mkosi.images/incus/install.sh
+++ b/mkosi.images/incus/install.sh
@@ -4,11 +4,22 @@ set -eu
 
 [ "$1" = "final" ] || exit 0
 
-# Install the incus packages.
-apt-get update
-apt-get install incus incus-ui-canonical --yes
+# This is a terrible hack. mkosi doesn't support subimage-specific sandboxes,
+# which would be the most correct solution as we could cleanly define an apt
+# pinning configuration for this specific subimage. Alternatively, if apt
+# supported getting pinning configuration from the command line, we could
+# add that in a slightly-ugly apt-get command. However, we're stuck with creating
+# the pinning configuration under /run/, since the actual file system that
+# we have access to at this stage is read-only. It works, but I don't like it.
 
-# Install additional dependencies/recommends.
-apt-get install btrfs-progs xfsprogs --yes
+mkdir -p /run/apt/preferences.d/
+cat <<EOF > /run/apt/preferences.d/zabbly
+Package: *
+Pin: release l=incus-stable
+Pin-Priority: 900
+EOF
+
+# Install the incus packages.
+apt-get -o Dir::Etc::PreferencesParts="/run/apt/preferences.d/" install incus incus-ui-canonical --yes
 
 exit 0

--- a/mkosi.images/incus/mkosi.conf
+++ b/mkosi.images/incus/mkosi.conf
@@ -10,6 +10,9 @@ ImageVersion=
 [Content]
 BaseTrees=%O/base
 PrepareScripts=install.sh
+Packages=
+    btrfs-progs
+    xfsprogs
 BuildPackages=
     build-essential
     make

--- a/mkosi.sandbox/etc/apt/sources.list.d/zabbly-incus-lts-7.0.sources
+++ b/mkosi.sandbox/etc/apt/sources.list.d/zabbly-incus-lts-7.0.sources
@@ -1,0 +1,6 @@
+Enabled: yes
+Types: deb
+URIs: https://pkgs.zabbly.com/incus/lts-7.0
+Suites: trixie
+Components: main
+Signed-By: /etc/apt/keyrings/zabbly.asc


### PR DESCRIPTION
Add an `incus-lts-7.0` application to allow users the choice between running the feature or LTS versions of Incus.

Logic is present to allow switching between versions of the Incus application, so long as it's possible to properly do so.

Closes #1114