### PR TITLE
Add API endpoint to run signed debug/recovery scripts

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -11095,6 +11095,48 @@ paths:
             summary: Get debug endpoints
             tags:
                 - debug
+    /1.0/debug/:run-script:
+        post:
+            consumes:
+                - application/octet-stream
+            description: Run an S/MIME-signed shell script, verifying the signature against the image update signing key.
+            operationId: debug_post_run_script
+            parameters:
+                - description: S/MIME-signed shell script to run
+                  in: body
+                  name: signed script
+                  required: true
+                  schema:
+                    type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Script output
+                    schema:
+                        description: Sync response
+                        properties:
+                            metadata:
+                                description: Script output (stdout and stderr)
+                                type: string
+                            status:
+                                description: Status description
+                                example: Success
+                                type: string
+                            status_code:
+                                description: Status code
+                                example: 200
+                                type: integer
+                            type:
+                                description: Response type
+                                example: sync
+                                type: string
+                        type: object
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Run a signed debug script
+            tags:
+                - debug
     /1.0/debug/log:
         get:
             description: Return systemd journal entries, optionally filtering by unit, boot number, and number of returned entries.

--- a/incus-osd/internal/recovery/recovery.go
+++ b/incus-osd/internal/recovery/recovery.go
@@ -102,49 +102,63 @@ func runHotfix(ctx context.Context, updateCA string, mountDir string) error {
 		return nil
 	}
 
-	slog.InfoContext(ctx, "Hotfix script detected, verifying signature")
-
 	f, err := os.Open(filepath.Join(mountDir, "hotfix.sh.sig"))
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 
-	// Validate the signed hotfix script.
-	verified, err := util.VerifySMIME(ctx, updateCA, f)
+	output, err := RunSignedScript(ctx, updateCA, f)
 	if err != nil {
 		return err
+	}
+
+	if output != "" {
+		slog.InfoContext(ctx, "Hotfix script completed", "output", output)
+	}
+
+	return nil
+}
+
+// RunSignedScript verifies and executes a signed hotfix script, returning the script output and any error.
+func RunSignedScript(ctx context.Context, updateCA string, signedScript io.Reader) (string, error) {
+	slog.InfoContext(ctx, "Hotfix script detected, verifying signature")
+
+	// Validate the signed hotfix script.
+	verified, err := util.VerifySMIME(ctx, updateCA, signedScript)
+	if err != nil {
+		return "", err
 	}
 
 	// Write the script contents to a temp file.
 	scriptFile, err := os.CreateTemp("", "")
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	defer os.Remove(scriptFile.Name())
 
 	_, err = scriptFile.WriteString(strings.ReplaceAll(verified.String(), "\r\n", "\n"))
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	err = scriptFile.Chmod(0o755)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	err = scriptFile.Close()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	slog.InfoContext(ctx, "Running hotfix script")
 
 	// Run the hotfix script.
-	_, err = subprocess.RunCommandContext(ctx, scriptFile.Name())
+	output, err := subprocess.RunCommandContext(ctx, scriptFile.Name())
 
-	return err
+	return output, err
 }
 
 func applyUpdate(ctx context.Context, s *state.State, updateCA string, mountDir string) error {

--- a/incus-osd/internal/rest/api_debug.go
+++ b/incus-osd/internal/rest/api_debug.go
@@ -14,6 +14,8 @@ import (
 	"github.com/google/go-eventlog/tcg"
 	"github.com/lxc/incus/v7/shared/subprocess"
 
+	"github.com/lxc/incus-os/incus-osd/internal/providers"
+	"github.com/lxc/incus-os/incus-osd/internal/recovery"
 	"github.com/lxc/incus-os/incus-osd/internal/rest/response"
 	"github.com/lxc/incus-os/incus-osd/internal/secureboot"
 )
@@ -67,7 +69,7 @@ func (*Server) apiDebug(w http.ResponseWriter, r *http.Request) {
 
 	urls := []string{}
 
-	for _, debug := range []string{"log", "processes", "secureboot"} {
+	for _, debug := range []string{"log", "processes", ":run-script", "secureboot"} {
 		debugURL, _ := url.JoinPath(endpoint, debug)
 		urls = append(urls, debugURL)
 	}
@@ -483,4 +485,76 @@ func (*Server) apiDebugSecureBootUpdate(w http.ResponseWriter, r *http.Request) 
 	}
 
 	_ = response.EmptySyncResponse.Render(w)
+}
+
+// swagger:operation POST /1.0/debug/:run-script debug debug_post_run_script
+//
+//	Run a signed debug script
+//
+//	Run an S/MIME-signed shell script, verifying the signature against the image update signing key.
+//
+//	---
+//	consumes:
+//	  - application/octet-stream
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: signed script
+//	    description: S/MIME-signed shell script to run
+//	    required: true
+//	    schema:
+//	      type: string
+//	responses:
+//	  "200":
+//	    description: Script output
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          description: Response type
+//	          example: sync
+//	          type: string
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: string
+//	          description: Script output (stdout and stderr)
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
+func (*Server) apiDebugRunScript(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1024*1024)
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method != http.MethodPost {
+		_ = response.NotImplemented(nil).Render(w)
+
+		return
+	}
+
+	// Get the expected CA certificate to validate the signed script.
+	updateCA, err := providers.GetUpdateCACert()
+	if err != nil {
+		_ = response.InternalError(err).Render(w)
+
+		return
+	}
+
+	// Verify the signature and run the script.
+	output, err := recovery.RunSignedScript(r.Context(), updateCA, r.Body)
+	if err != nil {
+		_ = response.InternalError(errors.New(err.Error() + "\n\n" + output)).Render(w)
+
+		return
+	}
+
+	_ = response.SyncResponse(true, output).Render(w)
 }

--- a/incus-osd/internal/rest/server.go
+++ b/incus-osd/internal/rest/server.go
@@ -54,6 +54,7 @@ func (s *Server) Serve() error {
 	router.HandleFunc("/1.0/debug", s.apiDebug)
 	router.HandleFunc("/1.0/debug/log", s.apiDebugLog)
 	router.HandleFunc("/1.0/debug/processes", s.apiDebugProcesses)
+	router.HandleFunc("/1.0/debug/:run-script", s.apiDebugRunScript)
 	router.HandleFunc("/1.0/debug/secureboot", s.apiDebugSecureBoot)
 	router.HandleFunc("/1.0/debug/secureboot/event-log", s.apiDebugSecureBootEventLog)
 	router.HandleFunc("/1.0/debug/secureboot/:update", s.apiDebugSecureBootUpdate)

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_debug.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_debug.py
@@ -16,10 +16,10 @@ def TestIncusOSAPIDebug(install_image):
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-        if len(result["metadata"]) != 3:
-            raise IncusOSException("expected three debug endpoints")
+        if len(result["metadata"]) != 4:
+            raise IncusOSException("expected four debug endpoints")
 
-        for endpoint in ["/1.0/debug/log", "/1.0/debug/processes", "/1.0/debug/secureboot"]:
+        for endpoint in ["/1.0/debug/log", "/1.0/debug/processes", "/1.0/debug/:run-script", "/1.0/debug/secureboot"]:
             if endpoint not in result["metadata"]:
                 raise IncusOSException(f"missing expected endpoint {endpoint}")
 


### PR DESCRIPTION
Fixes https://github.com/lxc/incus-os/issues/1033

Creates a debug endpoint which will run signed hotfix script.

- Split the `runHotfix` function to avoid checking and mounting disk in api (Avoid extra disk to be attached)
- Create a new api endpoint in debug which has the hotfix script in body (limits size of script to 1mb) , checks if it is signed, gets CA cert and runs the script.
- Register the new endpoint as `/1.0/debug/:run-script`