### PR TITLE
Add other OS version to /1.0 endpoint

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -10646,6 +10646,7 @@ paths:
                                         machine_id: af94e64e199341b68f10a8eebb828fce
                                         os_name: IncusOS
                                         os_version: "202511041601"
+                                        os_version_alternate: "202511162345"
                                         os_version_next: "202511152230"
                                         system_is_ready: true
                                         uptime: "3237039"

--- a/incus-osd/internal/rest/api_root.go
+++ b/incus-osd/internal/rest/api_root.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/lxc/incus-os/incus-osd/internal/rest/response"
+	"github.com/lxc/incus-os/incus-osd/internal/util"
 )
 
 // If the request contains a X-IncusOS-Proxy header, prepend that to
@@ -110,7 +111,7 @@ func (*Server) apiRoot(w http.ResponseWriter, r *http.Request) {
 //	        metadata:
 //	          type: json
 //	          description: Basic server information
-//	          example: {"environment":{"hostname":"af94e64e-1993-41b6-8f10-a8eebb828fce","machine_id":"af94e64e199341b68f10a8eebb828fce","os_name":"IncusOS","os_version":"202511041601","os_version_next":"202511152230","system_is_ready":true,"uptime":"3237039"}}
+//	          example: {"environment":{"hostname":"af94e64e-1993-41b6-8f10-a8eebb828fce","machine_id":"af94e64e199341b68f10a8eebb828fce","os_name":"IncusOS","os_version":"202511041601","os_version_alternate":"202511162345","os_version_next":"202511152230","system_is_ready":true,"uptime":"3237039"}}
 func (s *Server) apiRoot10(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -151,16 +152,29 @@ func (s *Server) apiRoot10(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ukiVersions, err := util.GetUKIVersions()
+	if err != nil {
+		_ = response.InternalError(err).Render(w)
+
+		return
+	}
+
+	environment := map[string]any{
+		"hostname":        s.state.Hostname(),
+		"machine_id":      machineID,
+		"os_name":         s.state.OS.Name,
+		"os_version":      s.state.OS.RunningRelease,
+		"os_version_next": s.state.OS.NextRelease,
+		"system_is_ready": s.state.OS.SystemIsReady,
+		"uptime":          uptime,
+	}
+
+	if ukiVersions.OtherVersion != "" {
+		environment["os_version_alternate"] = ukiVersions.OtherVersion
+	}
+
 	resp := map[string]any{
-		"environment": map[string]any{
-			"hostname":        s.state.Hostname(),
-			"machine_id":      machineID,
-			"os_name":         s.state.OS.Name,
-			"os_version":      s.state.OS.RunningRelease,
-			"os_version_next": s.state.OS.NextRelease,
-			"system_is_ready": s.state.OS.SystemIsReady,
-			"uptime":          uptime,
-		},
+		"environment": environment,
 	}
 
 	_ = response.SyncResponse(true, resp).Render(w)


### PR DESCRIPTION
Resolves https://github.com/lxc/incus-os/issues/1136 , Report other installed version of IncusOS.

`GetUkIVersions()` returns current version, if a second version is present (can be prior version of IncusOS/update that is pending a system reboot) its information will be returned as well.