### PR TITLE
Fix legacy system updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ test:
 	# Wait for installation to complete
 	incus start test-incus-os --console
 	@sleep 5 # Wait for VM self-reboot
+	incus config set test-incus-os volatile.vm.needs_reset=true # Ensure the VM performs a full reset after the install completes
 	incus console test-incus-os
 	@sleep 5 # Wait for VM self-reboot
 	@clear # Clear the console
@@ -170,6 +171,7 @@ test-iso:
 	# Wait for installation to complete
 	incus start test-incus-os --console
 	@sleep 5 # Wait for VM self-reboot
+	incus config set test-incus-os volatile.vm.needs_reset=true # Ensure the VM performs a full reset after the install completes
 	incus console test-incus-os
 	@sleep 5 # Wait for VM self-reboot
 	@clear # Clear the console

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -589,17 +589,21 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 
 	migratedApps := false
 
-	apps, err := applications.GetInstalled(ctx, s)
-	if err != nil {
-		return err
-	}
+	for _, appName := range applications.Supported {
+		app, err := applications.Load(ctx, s, appName)
+		if err != nil {
+			return err
+		}
 
-	for _, app := range apps {
 		oldPath := filepath.Join(systemd.SystemExtensionsPath, app.Name()+".raw")
 		newPath := filepath.Join(systemd.LocalExtensionsPath, app.Version(), app.Name()+".raw")
 
 		fileStat, err := os.Lstat(oldPath)
 		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+
 			return err
 		}
 
@@ -798,7 +802,7 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 	}
 
 	// Run application startup actions. Must be done after storage pools are loaded.
-	apps, err = applications.GetInstalled(ctx, s)
+	apps, err := applications.GetInstalled(ctx, s)
 	if err != nil {
 		return err
 	}

--- a/incus-osd/internal/applications/sysext.go
+++ b/incus-osd/internal/applications/sysext.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -81,7 +82,11 @@ func RefreshExtensions(ctx context.Context, s *state.State) error {
 		// Create the new symlink.
 		err := os.Symlink(filepath.Join(systemd.LocalExtensionsPath, bestVersion, app.Name()+".raw"), filepath.Join(systemd.SystemExtensionsPath, app.Name()+".raw"))
 		if err != nil {
-			return err
+			if !os.IsExist(err) {
+				return err
+			}
+
+			slog.WarnContext(ctx, "Existing file '"+filepath.Join(systemd.SystemExtensionsPath, app.Name()+".raw")+"' was not a symlink as expected, refusing to replace.")
 		}
 
 		// Update the application's state to reflect the on-disk version.


### PR DESCRIPTION
This will fix old IncusOS systems currently running version 202604070253 or earlier attempting to update to the current release. Affected systems that have already applied an update, rebooted, and are displaying no applications will need to be rebooted once a new IncusOS version is available so that the update check can fetch the OS update first, automatically reboot, then fetch application updates.