### PR TITLE
Fix application restore

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -36,10 +36,12 @@ jobs:
           sudo apt-get install --yes \
             linux-headers-$(uname -r)
           sudo --preserve-env=DEBIAN_FRONTEND apt-get install --yes \
+            curl \
             dosfstools \
             gdisk \
             genisoimage \
             mtools \
+            openssl \
             zfsutils-linux
 
       - name: Setup Incus

--- a/incus-osd/internal/applications/app_common.go
+++ b/incus-osd/internal/applications/app_common.go
@@ -117,7 +117,7 @@ func (*common) Restart(_ context.Context) error {
 }
 
 // RestoreBackup restores a tar archive backup of the application's configuration and/or state.
-func (*common) RestoreBackup(_ context.Context, _ io.Reader) error {
+func (*common) RestoreBackup(_ io.Reader) error {
 	return errors.New("not supported")
 }
 

--- a/incus-osd/internal/applications/app_incus.go
+++ b/incus-osd/internal/applications/app_incus.go
@@ -278,8 +278,8 @@ func (*incus) Restart(ctx context.Context) error {
 }
 
 // RestoreBackup restores a tar archive backup of the application's configuration and/or state.
-func (a *incus) RestoreBackup(ctx context.Context, archive io.Reader) error {
-	err := extractTarArchive(ctx, "/var/lib/incus/", []string{"incus-startup.service", "incus.socket", "incus.service", "incus-lxcfs.service"}, archive)
+func (a *incus) RestoreBackup(archive io.Reader) error {
+	err := extractTarArchive("/var/lib/incus/", []string{"incus-startup.service", "incus.socket", "incus.service", "incus-lxcfs.service"}, archive)
 	if err != nil {
 		return err
 	}

--- a/incus-osd/internal/applications/app_migration_manager.go
+++ b/incus-osd/internal/applications/app_migration_manager.go
@@ -289,8 +289,8 @@ func (*migrationManager) Restart(ctx context.Context) error {
 }
 
 // RestoreBackup restores a tar archive backup of the application's configuration and/or state.
-func (mm *migrationManager) RestoreBackup(ctx context.Context, archive io.Reader) error {
-	err := extractTarArchive(ctx, "/var/lib/migration-manager/", []string{"migration-manager.service"}, archive)
+func (mm *migrationManager) RestoreBackup(archive io.Reader) error {
+	err := extractTarArchive("/var/lib/migration-manager/", []string{"migration-manager.service"}, archive)
 	if err != nil {
 		return err
 	}

--- a/incus-osd/internal/applications/app_operations_center.go
+++ b/incus-osd/internal/applications/app_operations_center.go
@@ -331,8 +331,8 @@ func (*operationsCenter) Restart(ctx context.Context) error {
 }
 
 // RestoreBackup restores a tar archive backup of the application's configuration and/or state.
-func (oc *operationsCenter) RestoreBackup(ctx context.Context, archive io.Reader) error {
-	err := extractTarArchive(ctx, "/var/lib/operations-center/", []string{"operations-center.service"}, archive)
+func (oc *operationsCenter) RestoreBackup(archive io.Reader) error {
+	err := extractTarArchive("/var/lib/operations-center/", []string{"operations-center.service"}, archive)
 	if err != nil {
 		return err
 	}

--- a/incus-osd/internal/applications/helpers.go
+++ b/incus-osd/internal/applications/helpers.go
@@ -399,7 +399,7 @@ func createTarArchive(archiveRoot string, excludePaths []string, archive io.Writ
 	return zw.Close()
 }
 
-func extractTarArchive(ctx context.Context, archiveRoot string, restartUnits []string, archive io.Reader) error {
+func extractTarArchive(archiveRoot string, restartUnits []string, archive io.Reader) error {
 	reverter := revert.New()
 	defer reverter.Fail()
 
@@ -494,66 +494,96 @@ func extractTarArchive(ctx context.Context, archiveRoot string, restartUnits []s
 		}
 	}
 
-	// Stop unit(s).
-	err = systemd.StopUnit(ctx, restartUnits...)
-	if err != nil {
-		return err
-	}
+	// Beyond this point we commit to restoring the application's state
+	// from the extracted tar archive contents.
+	reverter.Success()
 
-	// Clean out the existing directory.
-	entries, err := os.ReadDir(archiveRoot)
-	if err != nil {
-		return err
-	}
+	// Run the remainder of the archive restore logic in its own gofunc.
+	// This is required when restoring a primary application, because
+	// stopping it will cause the proxied client request to error out
+	// when the HTTPS server is stopped.
+	go func() {
+		time.Sleep(1 * time.Second)
 
-	for _, entry := range entries {
-		err := os.RemoveAll(filepath.Join(archiveRoot, entry.Name()))
+		ctx := context.Background()
+
+		// Stop unit(s).
+		err := systemd.StopUnit(ctx, restartUnits...)
 		if err != nil {
-			return err
+			slog.WarnContext(ctx, "Failed to stop "+strings.Join(restartUnits, ", "), "error", err)
+
+			return
 		}
-	}
 
-	// Attempt to remove the now-empty existing directory.
-	err = os.Remove(archiveRoot)
-	switch {
-	case err == nil:
-		// Easy case, simply rename the new directory.
-		err := os.Rename(newArchiveRoot, archiveRoot)
+		// Clean out the existing directory.
+		entries, err := os.ReadDir(archiveRoot)
 		if err != nil {
-			return err
-		}
-	case errors.Is(err, syscall.EBUSY):
-		// The directory is empty, but attempting to remove it returned -EBUSY, so
-		// it's likely a zfs dataset that's been mounted for the application.
-		// Manually move contents from the new archive root to the existing one.
-		entries, err := os.ReadDir(newArchiveRoot)
-		if err != nil {
-			return err
+			slog.WarnContext(ctx, "Failed to read directory "+archiveRoot, "error", err)
+
+			return
 		}
 
 		for _, entry := range entries {
-			_, err := subprocess.RunCommandContext(ctx, "mv", filepath.Join(newArchiveRoot, entry.Name()), filepath.Join(archiveRoot, entry.Name()))
+			err := os.RemoveAll(filepath.Join(archiveRoot, entry.Name()))
 			if err != nil {
-				return err
+				slog.WarnContext(ctx, "Failed to remove "+filepath.Join(archiveRoot, entry.Name()), "error", err)
+
+				return
 			}
 		}
 
-		// Remove the empty new root directory.
-		err = os.Remove(newArchiveRoot)
-		if err != nil {
-			return err
+		// Attempt to remove the now-empty existing directory.
+		err = os.Remove(archiveRoot)
+		switch {
+		case err == nil:
+			// Easy case, simply rename the new directory.
+			err := os.Rename(newArchiveRoot, archiveRoot)
+			if err != nil {
+				slog.WarnContext(ctx, "Failed to rename "+newArchiveRoot+" to "+archiveRoot, "error", err)
+
+				return
+			}
+		case errors.Is(err, syscall.EBUSY):
+			// The directory is empty, but attempting to remove it returned -EBUSY, so
+			// it's likely a zfs dataset that's been mounted for the application.
+			// Manually move contents from the new archive root to the existing one.
+			entries, err := os.ReadDir(newArchiveRoot)
+			if err != nil {
+				slog.WarnContext(ctx, "Failed to read directory "+newArchiveRoot, "error", err)
+
+				return
+			}
+
+			for _, entry := range entries {
+				_, err := subprocess.RunCommandContext(ctx, "mv", filepath.Join(newArchiveRoot, entry.Name()), filepath.Join(archiveRoot, entry.Name()))
+				if err != nil {
+					slog.WarnContext(ctx, "Failed to move files", "error", err)
+
+					return
+				}
+			}
+
+			// Remove the empty new root directory.
+			err = os.Remove(newArchiveRoot)
+			if err != nil {
+				slog.WarnContext(ctx, "Failed to remove directory "+newArchiveRoot, "error", err)
+
+				return
+			}
+		default:
+			slog.WarnContext(ctx, "Failed to remove directory "+archiveRoot, "error", err)
+
+			return
 		}
-	default:
-		return err
-	}
 
-	// Start unit(s).
-	err = systemd.StartUnit(ctx, restartUnits...)
-	if err != nil {
-		return err
-	}
+		// Start unit(s).
+		err = systemd.StartUnit(ctx, restartUnits...)
+		if err != nil {
+			slog.WarnContext(ctx, "Failed to start "+strings.Join(restartUnits, ", "), "error", err)
 
-	reverter.Success()
+			return
+		}
+	}()
 
 	return nil
 }

--- a/incus-osd/internal/applications/struct.go
+++ b/incus-osd/internal/applications/struct.go
@@ -31,7 +31,7 @@ type Application interface { //nolint:interfacebloat
 	Name() string
 	NeedsLateUpdateCheck() bool
 	Restart(ctx context.Context) error
-	RestoreBackup(ctx context.Context, archive io.Reader) error
+	RestoreBackup(archive io.Reader) error
 	SetFriendlyVersion(ctx context.Context) error
 	SetVersions(version string, availableVersions []string)
 	Struct() any

--- a/incus-osd/internal/rest/api_applications.go
+++ b/incus-osd/internal/rest/api_applications.go
@@ -683,7 +683,7 @@ func (s *Server) apiApplicationsRestore(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Restore the application's backup.
-	err = app.RestoreBackup(r.Context(), r.Body)
+	err = app.RestoreBackup(r.Body)
 	if err != nil {
 		_ = response.InternalError(err).Render(w)
 

--- a/incus-osd/internal/rest/api_applications.go
+++ b/incus-osd/internal/rest/api_applications.go
@@ -463,13 +463,19 @@ func (s *Server) apiApplicationsFactoryReset(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Do the factory reset.
-	err = app.FactoryReset(r.Context())
-	if err != nil {
-		_ = response.InternalError(err).Render(w)
+	// Do the factory reset. Run in a gofunc with its own context so the calling HTTP
+	// request can cleanly return to the client in the cases when we're resetting
+	// a primary application.
+	go func() { //nolint:contextcheck,gosec
+		time.Sleep(1 * time.Second)
 
-		return
-	}
+		ctx := context.Background() // Must use our own context here.
+
+		err := app.FactoryReset(ctx)
+		if err != nil {
+			slog.WarnContext(ctx, "Failed to perform factory reset of application '"+name+"'", "error", err)
+		}
+	}()
 
 	_ = response.EmptySyncResponse.Render(w)
 }
@@ -788,13 +794,19 @@ func (s *Server) apiApplicationsCheckUpdate(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Check for and apply application update.
-	err = update.InstallUpdateApp(r.Context(), s.state, name, true)
-	if err != nil {
-		_ = response.InternalError(err).Render(w)
+	// Check for and apply application update. Run in its own gofunc to allow the
+	// HTTP request time to properly return without causing an EOF on the client-side
+	// if the primary application is restarted.
+	go func() { //nolint:contextcheck,gosec
+		time.Sleep(1 * time.Second)
 
-		return
-	}
+		ctx := context.Background() // Must use our own context here.
+
+		err := update.InstallUpdateApp(ctx, s.state, name, true)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to check for updates for application '"+name+"'", "error", err)
+		}
+	}()
 
 	_ = response.EmptySyncResponse.Render(w)
 }

--- a/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
+++ b/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
@@ -12,13 +12,15 @@ class IncusOSException(Exception):
     pass
 
 class IncusTestVM:
-    def __init__(self, os_name, vm_name_base, install_image, root_size="50GiB", readonly_install_image="false"):
+    def __init__(self, os_name, vm_name_base, install_image, client_cert_file, root_size="50GiB", readonly_install_image="false"):
         self.os_name = os_name
         self.vm_name = vm_name_base + "-" + util._get_random_string()
+        self.vm_ip = None
         self.root_size = root_size
         self.install_image = install_image
         self.readonly_install_image = readonly_install_image
         self.is_raw_image = self.install_image.endswith(".img")
+        self.client_cert_file = client_cert_file
         self.isos = []
 
     def __enter__(self):
@@ -50,6 +52,9 @@ class IncusTestVM:
 
         for iso in self.isos:
             subprocess.run(["incus", "storage", "volume", "delete", "default", iso], capture_output=True)
+
+        if self.client_cert_file != "":
+            os.remove(self.client_cert_file)
 
     def AddDevice(self, device, *args):
         """Add a device to the VM."""
@@ -149,11 +154,30 @@ class IncusTestVM:
         if log in str(result.stdout):
             raise IncusOSException(f"wasn't expecting log entry '{log}' to appear")
 
-    def APIRequest(self, path, method="GET", body=None, content_type=None, return_raw_content=False):
+    def APIRequest(self, path, method="GET", body=None, content_type=None, return_raw_content=False, use_unix_socket=False):
         """Perform a HTTP REST API call, and return the result."""
-
-        args = ["incus", "exec", self.vm_name, "--", "curl", "--unix-socket", "/run/incus-os/unix.socket", "http://localhost"+path, "-X", method]
+        args = []
         cmd_input = None
+
+        if use_unix_socket:
+            args = ["incus", "exec", self.vm_name, "--", "curl", "--unix-socket", "/run/incus-os/unix.socket", "http://localhost"+path]
+        else:
+            if self.vm_ip is None:
+                result = subprocess.run(["incus", "list", self.vm_name, "--columns", "4", "--format", "csv"], capture_output=True, check=True)
+                match = re.search(r"(\d+\.\d+\.\d+\.\d+) \(_venp5s0\)", str(result.stdout))
+                if match is None:
+                    raise IncusOSException("failed to get IP address for VM")
+
+                self.vm_ip = match.group(1)
+
+            args = ["curl", "-k", "https://" + self.vm_ip + ":8443/os" + path, "-H", "X-IncusOS-Proxy: /"]
+
+            if self.client_cert_file != "":
+                args.append("--cert")
+                args.append(self.client_cert_file)
+
+        args.append("-X")
+        args.append(method)
 
         if body is not None:
             if isinstance(body, str):

--- a/incus-osd/tests/incusos_tests/incus_test_vm/util.py
+++ b/incus-osd/tests/incusos_tests/incus_test_vm/util.py
@@ -6,6 +6,7 @@ import shutil
 import string
 import subprocess
 import tarfile
+import tempfile
 import urllib.request
 
 def _get_random_string():
@@ -21,23 +22,90 @@ def _prepare_test_image(image, seed):
     # Create a copy of the install image.
     shutil.copy(image, test_image)
 
-    # Inject seed data, if any.
-    if seed is not None:
-        with open(test_image, "rb+") as f:
-            f.seek(4196352*512)
+    client_cert_name = None
+    client_cert_pub = None
 
-            with tarfile.open(mode="w", fileobj=f) as tar:
-                for filename, contents in seed.items():
-                    raw = contents.encode("utf-8")
-                    buf = io.BytesIO(raw)
-                    ti = tarfile.TarInfo(name=filename)
-                    ti.size = len(raw)
+    # Generate a temporary client TLS certificate
+    with tempfile.NamedTemporaryFile(dir=os.getcwd(), delete=False, delete_on_close=True) as cert_file:
+        client_cert_name = cert_file.name
 
-                    tar.addfile(ti, buf)
+        output = subprocess.run(["openssl", "req", "-new", "-newkey", "ec", "-pkeyopt", "ec_paramgen_curve:secp384r1", "-x509", "-addext", "extendedKeyUsage = clientAuth", "-nodes", "-days", "365", "-subj", "/OU=Linux Containers/CN=test@localhost", "-out", client_cert_name, "-keyout", "-"], capture_output=True, check=True)
 
-    # Return the path of the customized install image, the OS name, and the OS version.
+        cert_file.seek(0)
+        client_cert_pub = cert_file.read()
+        client_cert_key = output.stdout
+
+        cert_file.seek(0)
+        cert_file.write(client_cert_key)
+        cert_file.write(client_cert_pub)
+
+    if seed is None:
+        seed = {}
+
+    # Set incus client TLS certificate
+    if "incus.json" not in seed:
+        seed["incus.json"] = "{}"
+
+    incus_json = json.loads(seed["incus.json"])
+
+    if "apply_defaults" not in incus_json:
+        incus_json["apply_defaults"] = True
+
+    if "preseed" not in incus_json:
+        incus_json["preseed"] = {}
+
+    if "certificates" not in incus_json["preseed"]:
+        incus_json["preseed"]["certificates"] = []
+
+    incus_json["preseed"]["certificates"].append({
+        "type": "client",
+        "certificate": client_cert_pub.decode("UTF-8")
+    })
+
+    seed["incus.json"] = json.dumps(incus_json)
+
+    # Set migration manager client TLS certificate
+    if "migration-manager.json" not in seed:
+        seed["migration-manager.json"] = "{}"
+
+    mm_json = json.loads(seed["migration-manager.json"])
+
+    if "trusted_client_certificates" not in mm_json:
+        mm_json["trusted_client_certificates"] = []
+
+    mm_json["trusted_client_certificates"].append(client_cert_pub.decode("UTF-8"))
+
+    seed["migration-manager.json"] = json.dumps(mm_json)
+
+    # Set operations center client TLS certificate
+    if "operations-center.json" not in seed:
+        seed["operations-center.json"] = "{}"
+
+    oc_json = json.loads(seed["operations-center.json"])
+
+    if "trusted_client_certificates" not in oc_json:
+        oc_json["trusted_client_certificates"] = []
+
+    oc_json["trusted_client_certificates"].append(client_cert_pub.decode("UTF-8"))
+
+    seed["operations-center.json"] = json.dumps(oc_json)
+
+    # Inject seed data.
+    with open(test_image, "rb+") as f:
+        f.seek(4196352*512)
+
+        with tarfile.open(mode="w", fileobj=f) as tar:
+            for filename, contents in seed.items():
+                raw = contents.encode("utf-8")
+                buf = io.BytesIO(raw)
+                ti = tarfile.TarInfo(name=filename)
+                ti.size = len(raw)
+
+                tar.addfile(ti, buf)
+
+    # Return the path of the customized install image, the OS name, the OS version, and a path to the temporary TLS client certificate.
     parts = basename.split("_")
-    return test_image, parts[0], parts[1].replace(ext, "")
+    return test_image, parts[0], parts[1].replace(ext, ""), client_cert_name
 
 def _manual_download_application(directory, name, version):
     os.mkdir(directory+"/update")

--- a/incus-osd/tests/incusos_tests/tests_flasher_tool.py
+++ b/incus-osd/tests/incusos_tests/tests_flasher_tool.py
@@ -12,7 +12,7 @@ def TestFlasherToolStableIMG(_):
 
     os_name, test_image = _flasher_download_image("stable", "img")
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, "") as vm:
         vm.StartVM()
         vm.WaitAgentRunning()
         vm.WaitExpectedLog("incus-osd", "Installing " + os_name + " source=/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0 target=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root")
@@ -23,7 +23,7 @@ def TestFlasherToolTestingISO(_):
 
     os_name, test_image = _flasher_download_image("testing", "iso")
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, "") as vm:
         vm.StartVM()
         vm.WaitAgentRunning()
         vm.WaitExpectedLog("incus-osd", "Installing " + os_name + " source=/dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_incus_boot--media target=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root")

--- a/incus-osd/tests/incusos_tests/tests_incusos_api.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api.py
@@ -6,9 +6,9 @@ def TestIncusOSAPI(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Test top-level /1.0 endpoint.

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_applications.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_applications.py
@@ -8,9 +8,9 @@ def TestIncusOSAPIApplicationsIncus(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Test top-level /1.0/applications endpoint.
@@ -75,9 +75,9 @@ def TestIncusOSAPIApplicationsMigrationManager(install_image):
         "applications.json": """{"applications":[{"name":"migration-manager"}]}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version, application="migration-manager")
 
         # Test top-level /1.0/applications endpoint.
@@ -134,9 +134,9 @@ def TestIncusOSAPIApplicationsOperationsCenter(install_image):
         "applications.json": """{"applications":[{"name":"operations-center"}]}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version, application="operations-center")
 
         # Test top-level /1.0/applications endpoint.
@@ -193,9 +193,9 @@ def TestIncusOSAPIApplicationsIncusCeph(install_image):
         "applications.json": """{"applications":[{"name":"incus-ceph"}]}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version, application="incus-ceph")
 
         # Test top-level /1.0/applications endpoint.
@@ -231,9 +231,9 @@ def TestIncusOSAPIApplicationsIncusLinstor(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Test top-level /1.0/applications endpoint.
@@ -299,9 +299,9 @@ def TestIncusOSAPIApplicationsRemove(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Test top-level /1.0/applications endpoint.

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_debug.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_debug.py
@@ -6,9 +6,9 @@ def TestIncusOSAPIDebug(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Test top-level /1.0/debug endpoint.
@@ -33,13 +33,13 @@ def TestIncusOSAPIDebug(install_image):
             raise IncusOSException("got unexpected final log line: '" + lines[-1] + "'")
 
         # Test sending log messages via API.
-        result = vm.APIRequest("/internal/tui/:write-message", method="POST", body='{"level":"INFO","message":"Test message one"}')
+        result = vm.APIRequest("/internal/tui/:write-message", method="POST", body='{"level":"INFO","message":"Test message one"}', use_unix_socket=True)
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
-        result = vm.APIRequest("/internal/tui/:write-message", method="POST", body='{"level":"WARN","message":"Test message two"}')
+        result = vm.APIRequest("/internal/tui/:write-message", method="POST", body='{"level":"WARN","message":"Test message two"}', use_unix_socket=True)
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
-        result = vm.APIRequest("/internal/tui/:write-message", method="POST", body='{"level":"ERROR","message":"Test message three"}')
+        result = vm.APIRequest("/internal/tui/:write-message", method="POST", body='{"level":"ERROR","message":"Test message three"}', use_unix_socket=True)
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_network.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_network.py
@@ -12,9 +12,9 @@ def TestIncusOSAPISystemNetworkDefaults(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Allow the network state to settle
@@ -69,9 +69,9 @@ def TestIncusOSAPISystemNetworkBadMAC(install_image):
         "network.json": """{"interfaces":[{"addresses":["dhcp4"],"hwaddr":"00:11:22:33:44:55","name":"eth0"},{"addresses":["slaac"],"hwaddr":"ff:ee:dd:cc:bb:aa","name":"eth1"}]}""",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         # Perform IncusOS install.
         vm.StartVM()
         vm.WaitAgentRunning()
@@ -99,9 +99,9 @@ def TestIncusOSAPISystemNetworkRollback(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Allow the network state to settle

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_services.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_services.py
@@ -8,9 +8,9 @@ def TestIncusOSAPIServices(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Test top-level /1.0/services endpoint.

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system.py
@@ -8,9 +8,9 @@ def TestIncusOSAPISystem(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Test top-level /1.0/system endpoint.
@@ -32,9 +32,9 @@ def TestIncusOSAPISystemPoweroff(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Command the system to poweroff.
@@ -58,9 +58,9 @@ def TestIncusOSAPISystemReboot(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Command the system to reboot.

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_backup.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_backup.py
@@ -9,9 +9,9 @@ def TestIncusOSAPISystemBackup(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Allow the network state to settle

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_logging.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_logging.py
@@ -8,9 +8,9 @@ def TestIncusOSAPISystemLogging(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Get current logging configuration.

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_provider.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_provider.py
@@ -6,9 +6,9 @@ def TestIncusOSAPISystemProviderImages(install_image):
         "install.json": "{}"
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Get current provider configuration.
@@ -29,9 +29,9 @@ def TestIncusOSAPISystemProviderOperationsCenter(install_image):
         "applications.json": """{"applications":[{"name":"operations-center"}]}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version, application="operations-center")
 
         # Get current provider configuration.

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_reset.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_reset.py
@@ -11,9 +11,9 @@ def TestIncusOSAPISystemReset(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Command the system to perform a factory reset.
@@ -40,9 +40,9 @@ def TestIncusOSAPISystemResetSWTPM(install_image):
         "install.json": """{"security":{"missing_tpm":true}}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         # Remove the tpm
         vm.RemoveDevice("vtpm")
 
@@ -81,9 +81,9 @@ def TestIncusOSAPISystemResetSWTPMToTPM(install_image):
         "install.json": """{"security":{"missing_tpm":true}}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         # Remove the tpm
         vm.RemoveDevice("vtpm")
 
@@ -121,10 +121,10 @@ def TestIncusOSAPISystemResetSecureBootDisabled(install_image):
         "install.json": """{"security":{"missing_secure_boot":true}}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
     util._remove_secureboot_keys(test_image)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version, secureboot_disabled=True)
 
         # Should see a log message about SecureBoot being disabled
@@ -152,13 +152,13 @@ def TestIncusOSAPISystemResetSecureBootDisabledToSB(install_image):
         "install.json": """{"security":{"missing_secure_boot":true}}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmp_dir:
         util._extract_secureboot_keys(test_image, tmp_dir)
         util._remove_secureboot_keys(test_image)
 
-        with IncusTestVM(os_name, test_name, test_image) as vm:
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
             vm.WaitSystemReady(os_version, secureboot_disabled=True)
 
             # Should see a log message about SecureBoot being disabled

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_resources.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_resources.py
@@ -6,9 +6,9 @@ def TestIncusOSAPISystemResources(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Perform a basic sanity check of the returned data.

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_security.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_security.py
@@ -8,9 +8,9 @@ def TestIncusOSAPISystemSecurity(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Get current security configuration and state.
@@ -53,9 +53,9 @@ def TestIncusOSAPISystemSecurityTPMRebind(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # By default, forcing a TPM rebind will fail unless the system is in a changed state.

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_storage.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_storage.py
@@ -11,12 +11,12 @@ def TestIncusOSAPISystemStorageImportPool(install_image):
         "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}""",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img:
         disk_img.truncate(10*1024*1024*1024)
 
-        with IncusTestVM(os_name, test_name, test_image) as vm:
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
             vm.AddDevice("disk1", "disk", "source="+disk_img.name)
 
             vm.WaitSystemReady(os_version)
@@ -73,12 +73,12 @@ def TestIncusOSAPISystemStorageLUKSRawDevice(install_image):
         "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}""",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img:
         disk_img.truncate(10*1024*1024*1024)
 
-        with IncusTestVM(os_name, test_name, test_image) as vm:
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
             vm.AddDevice("disk1", "disk", "source="+disk_img.name)
 
             vm.WaitSystemReady(os_version)
@@ -196,7 +196,7 @@ def TestIncusOSAPISystemStorageMixedDeviceSize(install_image):
         "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}""",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img1:
         with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img2:
@@ -205,7 +205,7 @@ def TestIncusOSAPISystemStorageMixedDeviceSize(install_image):
                 disk_img2.truncate(10*1024*1024*1024)
                 disk_img3.truncate(11*1024*1024*1024)
 
-                with IncusTestVM(os_name, test_name, test_image) as vm:
+                with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
                     vm.AddDevice("disk1", "disk", "source="+disk_img1.name)
                     vm.AddDevice("disk2", "disk", "source="+disk_img2.name)
                     vm.AddDevice("disk3", "disk", "source="+disk_img3.name)
@@ -246,14 +246,14 @@ def TestIncusOSAPISystemStorageConvertToMirror(install_image):
         "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}""",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img1:
         with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img2:
             disk_img1.truncate(10*1024*1024*1024)
             disk_img2.truncate(10*1024*1024*1024)
 
-            with IncusTestVM(os_name, test_name, test_image) as vm:
+            with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
                 vm.AddDevice("disk1", "disk", "source="+disk_img1.name)
                 vm.AddDevice("disk2", "disk", "source="+disk_img2.name)
 
@@ -311,7 +311,7 @@ def TestIncusOSAPISystemStoragePoolLogDevices(install_image):
         "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}""",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img1:
         with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img2:
@@ -320,7 +320,7 @@ def TestIncusOSAPISystemStoragePoolLogDevices(install_image):
                 disk_img2.truncate(10*1024*1024*1024)
                 disk_img3.truncate(10*1024*1024*1024)
 
-                with IncusTestVM(os_name, test_name, test_image) as vm:
+                with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
                     vm.AddDevice("disk1", "disk", "source="+disk_img1.name)
                     vm.AddDevice("disk2", "disk", "source="+disk_img2.name)
                     vm.AddDevice("disk3", "disk", "source="+disk_img3.name)
@@ -416,7 +416,7 @@ def TestIncusOSAPISystemStoragePoolDeleteReplaceDevices(install_image):
         "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}""",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img1:
         with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img2:
@@ -427,7 +427,7 @@ def TestIncusOSAPISystemStoragePoolDeleteReplaceDevices(install_image):
                     disk_img3.truncate(10*1024*1024*1024)
                     disk_img4.truncate(10*1024*1024*1024)
 
-                    with IncusTestVM(os_name, test_name, test_image) as vm:
+                    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
                         vm.AddDevice("disk1", "disk", "source="+disk_img1.name)
                         vm.AddDevice("disk2", "disk", "source="+disk_img2.name)
                         vm.AddDevice("disk3", "disk", "source="+disk_img3.name)
@@ -563,7 +563,7 @@ def TestIncusOSAPISystemStoragePoolExpansionTests(install_image):
         "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}""",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img1:
         with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img2:
@@ -578,7 +578,7 @@ def TestIncusOSAPISystemStoragePoolExpansionTests(install_image):
                             disk_img5.truncate(10*1024*1024*1024)
                             disk_img6.truncate(10*1024*1024*1024)
 
-                            with IncusTestVM(os_name, test_name, test_image) as vm:
+                            with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
                                 vm.AddDevice("disk1", "disk", "source="+disk_img1.name)
                                 vm.AddDevice("disk2", "disk", "source="+disk_img2.name)
                                 vm.AddDevice("disk3", "disk", "source="+disk_img3.name)
@@ -866,7 +866,7 @@ def TestIncusOSAPISystemStoragePoolSpecialDevice(install_image):
         "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}""",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img1:
         with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img2:
@@ -881,7 +881,7 @@ def TestIncusOSAPISystemStoragePoolSpecialDevice(install_image):
                             disk_img5.truncate(10*1024*1024*1024)
                             disk_img6.truncate(10*1024*1024*1024)
 
-                            with IncusTestVM(os_name, test_name, test_image) as vm:
+                            with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
                                 vm.AddDevice("disk1", "disk", "source="+disk_img1.name)
                                 vm.AddDevice("disk2", "disk", "source="+disk_img2.name)
                                 vm.AddDevice("disk3", "disk", "source="+disk_img3.name)

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_storage_local_pool.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_storage_local_pool.py
@@ -11,9 +11,9 @@ def TestIncusOSAPISystemStorageLocalPool(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Get current storage state.
@@ -48,12 +48,12 @@ def TestIncusOSAPISystemStorageLocalPoolExpandRAID0(install_image):
         "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}""",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img:
         disk_img.truncate(50*1024*1024*1024)
 
-        with IncusTestVM(os_name, test_name, test_image) as vm:
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
             vm.AddDevice("disk1", "disk", "source="+disk_img.name)
 
             vm.WaitSystemReady(os_version)
@@ -190,14 +190,14 @@ def TestIncusOSAPISystemStorageLocalPoolExpandRAID1(install_image):
         "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}""",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk1_img:
         with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk2_img:
             disk1_img.truncate(50*1024*1024*1024)
             disk2_img.truncate(50*1024*1024*1024)
 
-            with IncusTestVM(os_name, test_name, test_image) as vm:
+            with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
                 vm.AddDevice("disk1", "disk", "source="+disk1_img.name)
                 vm.AddDevice("disk2", "disk", "source="+disk2_img.name)
 
@@ -361,10 +361,10 @@ def TestIncusOSAPISystemStorageLocalPoolRecoverFreshInstall(install_image):
 
         encryption_key = ""
 
-        test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+        test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
         # First, configure an existing "local" pool
-        with IncusTestVM(os_name, test_name, test_image) as vm:
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
             vm.AddDevice("disk1", "disk", "source="+disk_img.name)
 
             vm.WaitSystemReady(os_version)
@@ -381,8 +381,8 @@ def TestIncusOSAPISystemStorageLocalPoolRecoverFreshInstall(install_image):
             encryption_key = result["metadata"]["state"]["pool_recovery_keys"]["local"]
 
         # Second, install a new VM and recover the existing "local" pool
-        test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
-        with IncusTestVM(os_name, test_name, test_image) as vm:
+        test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
             vm.AddDevice("disk1", "disk", "source="+disk_img.name)
 
             vm.WaitSystemReady(os_version)
@@ -399,9 +399,9 @@ def TestIncusOSAPISystemStorageLocalPoolScrub(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Get current storage state.
@@ -455,9 +455,9 @@ def TestIncusOSAPISystemStorageLocalPoolScrubSchedule(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Get current storage state.
@@ -490,14 +490,14 @@ def TestIncusOSAPISystemStorageLocalPoolDegraded(install_image):
         "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}""",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk1_img:
         with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk2_img:
             disk1_img.truncate(50*1024*1024*1024)
             disk2_img.truncate(50*1024*1024*1024)
 
-            with IncusTestVM(os_name, test_name, test_image) as vm:
+            with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
                 vm.AddDevice("disk1", "disk", "source="+disk1_img.name)
                 vm.AddDevice("disk2", "disk", "source="+disk2_img.name)
 
@@ -601,9 +601,9 @@ def TestIncusOSAPISystemStorageLocalAutoexpand(install_image):
         "install.json": "{}",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version)
 
         # Get current storage state.

--- a/incus-osd/tests/incusos_tests/tests_incusos_live.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_live.py
@@ -7,9 +7,9 @@ def TestIncusOSLive(install_image):
     test_name = "incusos-live"
     test_seed = None
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image, root_size="1MiB") as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name, root_size="1MiB") as vm:
         # Remove the install image, enlarge its size and re-attach it
         vm.RemoveDevice("boot-media")
 
@@ -42,9 +42,9 @@ def TestIncusOSLiveSWTPM(install_image):
     test_name = "incusos-live-swtpm"
     test_seed = None
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image, root_size="1MiB") as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name, root_size="1MiB") as vm:
         # Remove the install image, enlarge its size and re-attach it
         vm.RemoveDevice("boot-media")
 
@@ -100,10 +100,10 @@ def TestIncusOSLiveNoSecureBoot(install_image):
     test_name = "incusos-live-no-secure-boot"
     test_seed = None
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
     util._remove_secureboot_keys(test_image)
 
-    with IncusTestVM(os_name, test_name, test_image, root_size="1MiB") as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name, root_size="1MiB") as vm:
         # Remove the install image, enlarge its size and re-attach it
         vm.RemoveDevice("boot-media")
 

--- a/incus-osd/tests/incusos_tests/tests_install_multipath.py
+++ b/incus-osd/tests/incusos_tests/tests_install_multipath.py
@@ -10,13 +10,13 @@ def TestInstallMultipath(install_image):
         "install.json": """{"target":{"id":"scsi-3500577a4300c1e34"}}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img:
         # Truncate the disk image file to 50GiB.
         disk_img.truncate(50*1024*1024*1024)
 
-        with IncusTestVM(os_name, test_name, test_image) as vm:
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
             _commonMultipathChecks(vm, os_version, disk_img.name)
 
             # Shouldn't see any mention of a TPM or SecureBoot degraded security state
@@ -29,13 +29,13 @@ def TestInstallMultipathUseSWTPM(install_image):
         "install.json": """{"target":{"id":"scsi-3500577a4300c1e34"},"security":{"missing_tpm":true}}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img:
         # Truncate the disk image file to 50GiB.
         disk_img.truncate(50*1024*1024*1024)
 
-        with IncusTestVM(os_name, test_name, test_image) as vm:
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
             vm.RemoveDevice("vtpm")
 
             _commonMultipathChecks(vm, os_version, disk_img.name)

--- a/incus-osd/tests/incusos_tests/tests_install_secureboot_disabled.py
+++ b/incus-osd/tests/incusos_tests/tests_install_secureboot_disabled.py
@@ -8,10 +8,10 @@ def TestInstallSecureBootDisabled(install_image):
         "install.json": """{"security":{"missing_secure_boot":true}}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
     util._remove_secureboot_keys(test_image)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version, secureboot_disabled=True)
 
         # Should see a log message about SecureBoot being disabled

--- a/incus-osd/tests/incusos_tests/tests_install_smoke.py
+++ b/incus-osd/tests/incusos_tests/tests_install_smoke.py
@@ -6,9 +6,9 @@ def TestInstallDontRemoveInstallMedia(install_image):
         "install.json": "{}"
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         # Perform IncusOS install.
         vm.StartVM()
         vm.WaitAgentRunning()
@@ -29,9 +29,9 @@ def TestBaselineInstall(install_image):
         "install.json": "{}"
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version, source="/dev/disk/by-id/(usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0|scsi-0QEMU_QEMU_CD-ROM_incus_boot--media)")
 
         # Shouldn't see any mention of a TPM or SecureBoot degraded security state
@@ -53,9 +53,9 @@ def TestBaselineInstallReadonlyImage(install_image):
         "install.json": "{}"
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image, readonly_install_image="true") as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name, readonly_install_image="true") as vm:
         vm.WaitSystemReady(os_version)
 
         # Shouldn't see any mention of a TPM or SecureBoot degraded security state
@@ -77,9 +77,9 @@ def TestBaselineInstallNVME(install_image):
         "install.json": "{}"
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.SetDeviceProperty("root", "io.bus=nvme")
 
         vm.WaitSystemReady(os_version, source="/dev/disk/by-id/(usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0|scsi-0QEMU_QEMU_CD-ROM_incus_boot--media)", target="/dev/disk/by-id/nvme-QEMU_NVMe_Ctrl_incus_root")
@@ -103,9 +103,9 @@ def TestBaselineInstallNVMEReadonlyImage(install_image):
         "install.json": "{}"
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image, readonly_install_image="true") as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name, readonly_install_image="true") as vm:
         vm.SetDeviceProperty("root", "io.bus=nvme")
 
         vm.WaitSystemReady(os_version, source="/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0", target="/dev/disk/by-id/nvme-QEMU_NVMe_Ctrl_incus_root")

--- a/incus-osd/tests/incusos_tests/tests_install_swtpm.py
+++ b/incus-osd/tests/incusos_tests/tests_install_swtpm.py
@@ -8,9 +8,9 @@ def TestInstallUseSWTPM(install_image):
         "install.json": """{"security":{"missing_tpm":true}}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.RemoveDevice("vtpm")
 
         vm.WaitSystemReady(os_version)

--- a/incus-osd/tests/incusos_tests/tests_install_system_checks.py
+++ b/incus-osd/tests/incusos_tests/tests_install_system_checks.py
@@ -8,9 +8,9 @@ def TestInstallNoSeed(install_image):
     test_name = "no-seed"
     test_seed = None
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         # Perform IncusOS install.
         vm.StartVM()
         vm.WaitAgentRunning()
@@ -20,9 +20,9 @@ def TestInstallNoSeedReadonlyImage(install_image):
     test_name = "no-seed-readonly-image"
     test_seed = None
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image, readonly_install_image="true") as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name, readonly_install_image="true") as vm:
         # Perform IncusOS install.
         vm.StartVM()
         vm.WaitAgentRunning()
@@ -34,10 +34,10 @@ def TestInstallTooManyTargets(install_image):
         "install.json": "{}"
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img:
-        with IncusTestVM(os_name, test_name, test_image) as vm:
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
             vm.AddDevice("disk1", "disk", "source="+disk_img.name)
 
             # Perform IncusOS install.
@@ -51,9 +51,9 @@ def TestInstallDriveTooSmall(install_image):
         "install.json": "{}"
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image, root_size="10GiB") as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name, root_size="10GiB") as vm:
         # Perform IncusOS install.
         vm.StartVM()
         vm.WaitAgentRunning()
@@ -65,14 +65,14 @@ def TestInstallDriveWithGPT(install_image):
         "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_disk1"}}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img:
         # Truncate the disk image file to 50GiB and setup a single GPT partition.
         disk_img.truncate(50*1024*1024*1024)
         subprocess.run(["/sbin/sgdisk", "-n", "1", disk_img.name], capture_output=True, check=True)
 
-        with IncusTestVM(os_name, test_name, test_image) as vm:
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
             vm.AddDevice("disk1", "disk", "source="+disk_img.name)
 
             # Perform IncusOS install.
@@ -86,9 +86,9 @@ def TestInstallCantDisableSBandTPM(install_image):
         "install.json": """{"security":{"missing_tpm":true,"missing_secure_boot":true}}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         # Perform IncusOS install.
         vm.StartVM()
         vm.WaitAgentRunning()
@@ -100,9 +100,9 @@ def TestInstallNoSWTPMwithTPM(install_image):
         "install.json": """{"security":{"missing_tpm":true}}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         # Perform IncusOS install.
         vm.StartVM()
         vm.WaitAgentRunning()
@@ -114,9 +114,9 @@ def TestInstallNoDisabledSBwithSB(install_image):
         "install.json": """{"security":{"missing_secure_boot":true}}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         # Perform IncusOS install.
         vm.StartVM()
         vm.WaitAgentRunning()
@@ -128,9 +128,9 @@ def TestInstallNoTPMNoSWTPM(install_image):
         "install.json": "{}"
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.RemoveDevice("vtpm")
 
         # Verify we get expected error
@@ -144,10 +144,10 @@ def TestInstallSecureBootDisabledNoFallback(install_image):
         "install.json": "{}"
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
     util._remove_secureboot_keys(test_image)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         # Verify we get expected error
         vm.StartVM()
         vm.WaitAgentRunning()

--- a/incus-osd/tests/incusos_tests/tests_recovery.py
+++ b/incus-osd/tests/incusos_tests/tests_recovery.py
@@ -11,9 +11,9 @@ def TestRecoveryUpdateFromUSB(install_image):
         "network.json": """{"interfaces":[{"name":"enp5s0","hwaddr":"enp5s0","required_for_online":"no"}]}""",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         _installStartChecks(vm, os_name, os_version)
 
         # Apply the updates from a USB stick.
@@ -38,9 +38,9 @@ def TestRecoveryUpdateFromISO(install_image):
         "network.json": """{"interfaces":[{"name":"enp5s0","hwaddr":"enp5s0","required_for_online":"no"}]}""",
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         _installStartChecks(vm, os_name, os_version)
 
         # Apply the updates from an ISO image.
@@ -78,7 +78,7 @@ def _installStartChecks(vm, os_name, os_version):
     vm.WaitExpectedLog("incus-osd", "System is ready version="+os_version)
 
     # Verify that no applications are installed.
-    result = vm.APIRequest("/1.0/applications")
+    result = vm.APIRequest("/1.0/applications", use_unix_socket=True)
     if result["status_code"] != 200:
         raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
@@ -103,7 +103,7 @@ def _recoveryChecks(vm, os_version):
     vm.WaitExpectedLog("incus-osd", "System is ready version="+os_version)
 
     # Verity the incus application is installed.
-    result = vm.APIRequest("/1.0/applications")
+    result = vm.APIRequest("/1.0/applications", use_unix_socket=True)
     if result["status_code"] != 200:
         raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 

--- a/incus-osd/tests/incusos_tests/tests_seed_applications.py
+++ b/incus-osd/tests/incusos_tests/tests_seed_applications.py
@@ -10,9 +10,9 @@ def TestSeedApplictionsEmpty(install_image):
         "applications.json": "{}"
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         # Perform IncusOS install.
         vm.StartVM()
         vm.WaitAgentRunning()
@@ -25,9 +25,9 @@ def TestSeedApplictionsInvalid(install_image):
         "applications.json": """{"applications":[{"name":"foobarbiz"}]}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         # Perform IncusOS install.
         vm.StartVM()
         vm.WaitAgentRunning()
@@ -56,9 +56,9 @@ def TestSeedApplictionsGPUSupport(install_image):
         "applications.json": """{"applications":[{"name":"gpu-support"}]}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version, application="gpu-support")
 
 def TestSeedApplictionsIncus(install_image):
@@ -68,9 +68,9 @@ def TestSeedApplictionsIncus(install_image):
         "applications.json": """{"applications":[{"name":"incus"}]}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version, application="incus")
 
 def TestSeedApplictionsIncusCeph(install_image):
@@ -80,9 +80,9 @@ def TestSeedApplictionsIncusCeph(install_image):
         "applications.json": """{"applications":[{"name":"incus-ceph"}]}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version, application="incus-ceph")
 
         # We should also see Incus pulled in as a dependency
@@ -95,9 +95,9 @@ def TestSeedApplictionsIncusLinstor(install_image):
         "applications.json": """{"applications":[{"name":"incus-linstor"}]}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version, application="incus-linstor")
 
         # We should also see Incus pulled in as a dependency
@@ -110,9 +110,9 @@ def TestSeedApplictionsMigrationManager(install_image):
         "applications.json": """{"applications":[{"name":"migration-manager"}]}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version, application="migration-manager")
 
 def TestSeedApplictionsOperationsCenter(install_image):
@@ -122,16 +122,16 @@ def TestSeedApplictionsOperationsCenter(install_image):
         "applications.json": """{"applications":[{"name":"operations-center"}]}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version, application="operations-center")
 
 def TestExternalSeedApplictionsMigrationManager(install_image):
     test_name = "external-seed-applications-migration-manager"
     test_seed = None
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as seed_img:
         # Create and populate a user-provided ISO with seed files on it
@@ -144,7 +144,7 @@ def TestExternalSeedApplictionsMigrationManager(install_image):
 
             util._create_user_media(seed_img, tmp_dir, "iso", 0, "SEED_DATA")
 
-        with IncusTestVM(os_name, test_name, test_image) as vm:
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
             vm.AttachISO(seed_img.name, "seed")
 
             vm.WaitSystemReady(os_version, application="migration-manager", remove_devices=["seed"])

--- a/incus-osd/tests/incusos_tests/tests_seed_install.py
+++ b/incus-osd/tests/incusos_tests/tests_seed_install.py
@@ -11,9 +11,9 @@ def TestSeedInstallReboot(install_image):
         "install.json": """{"force_reboot":true}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         # Perform IncusOS install.
         vm.StartVM()
         vm.WaitAgentRunning()
@@ -33,10 +33,10 @@ def TestSeedInstallTarget(install_image):
         "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img:
-        with IncusTestVM(os_name, test_name, test_image) as vm:
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
             vm.AddDevice("disk1", "disk", "source="+disk_img.name)
 
             # Perform IncusOS install.
@@ -51,7 +51,7 @@ def TestSeedInstallForce(install_image):
         "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_disk1"},"force_install":true}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img:
         # Truncate the disk image file to 50GiB and setup a single GPT partition.
@@ -60,7 +60,7 @@ def TestSeedInstallForce(install_image):
         disk_img.truncate(50*1024*1024*1024)
         subprocess.run(["/sbin/sgdisk", "-n", "1", disk_img.name], capture_output=True, check=True)
 
-        with IncusTestVM(os_name, test_name, test_image) as vm:
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
             vm.AddDevice("disk1", "disk", "source="+disk_img.name)
 
             # Perform IncusOS install.
@@ -75,9 +75,9 @@ def TestSeedInstallEmpty(install_image):
         "install.json": ""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         # Perform IncusOS install.
         vm.StartVM()
         vm.WaitAgentRunning()
@@ -88,7 +88,7 @@ def TestExternalSeedInstallEmpty(install_image):
     test_name = "external-seed-install-empty"
     test_seed = None
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as seed_img:
         # Create and populate a user-provided ISO image with an empty install seed file on it
@@ -98,7 +98,7 @@ def TestExternalSeedInstallEmpty(install_image):
 
             util._create_user_media(seed_img, tmp_dir, "iso", 0, "SEED_DATA")
 
-        with IncusTestVM(os_name, test_name, test_image) as vm:
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
             vm.AttachISO(seed_img.name, "seed")
 
             # Perform IncusOS install.
@@ -111,7 +111,7 @@ def TestExternalSeedInstallTarget(install_image):
     test_name = "external-seed-install-target"
     test_seed = None
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img:
         with tempfile.NamedTemporaryFile(dir=os.getcwd()) as seed_img:
@@ -122,7 +122,7 @@ def TestExternalSeedInstallTarget(install_image):
 
                 util._create_user_media(seed_img, tmp_dir, "img", 1024*1024*1024, "SEED_DATA")
 
-            with IncusTestVM(os_name, test_name, test_image) as vm:
+            with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
                 vm.AddDevice("disk1", "disk", "source="+disk_img.name)
                 vm.AddDevice("recovery", "disk", "source="+seed_img.name, "io.bus=usb")
 

--- a/incus-osd/tests/incusos_tests/tests_upgrade.py
+++ b/incus-osd/tests/incusos_tests/tests_upgrade.py
@@ -10,9 +10,9 @@ def TestBaselineUpgrade(install_image):
         "install.json": "{}"
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         # Perform IncusOS install.
         vm.StartVM()
         vm.WaitAgentRunning()
@@ -47,9 +47,9 @@ def TestBaselineUpgradeOSOnly(install_image):
         "provider.json": """{"name":"local"}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         # Perform IncusOS install.
         vm.StartVM()
         vm.WaitAgentRunning()
@@ -71,11 +71,11 @@ def TestBaselineUpgradeOSOnly(install_image):
         vm.LogDoesntContain("incus-osd", "Downloading application update")
 
         # Now that we've started up, switch the provider back to the main "images" and check for an OS update.
-        result = vm.APIRequest("/1.0/system/provider", method="PUT", body="""{"config":{"name":"images"}}""")
+        result = vm.APIRequest("/1.0/system/provider", method="PUT", body="""{"config":{"name":"images"}}""", use_unix_socket=True)
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-        result = vm.APIRequest("/1.0/system/update/:check", method="POST", body="""{"os_only":true}""")
+        result = vm.APIRequest("/1.0/system/update/:check", method="POST", body="""{"os_only":true}""", use_unix_socket=True)
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
@@ -95,9 +95,9 @@ def TestBaselineUpgradeApplicationOnly(install_image):
         "provider.json": """{"name":"local"}"""
     }
 
-    test_image, os_name, os_version = util._prepare_test_image(install_image, test_seed)
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
-    with IncusTestVM(os_name, test_name, test_image) as vm:
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         # Perform IncusOS install.
         vm.StartVM()
         vm.WaitAgentRunning()
@@ -120,8 +120,6 @@ def TestBaselineUpgradeApplicationOnly(install_image):
 
                 vm.StartVM()
                 vm.WaitAgentRunning()
-                vm.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
-                vm.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
                 vm.WaitExpectedLog("incus-osd", "Recovery partition detected")
                 vm.WaitExpectedLog("incus-osd", "Update metadata detected, verifying signature")
                 vm.WaitExpectedLog("incus-osd", "Processing validated update metadata version="+os_version)
@@ -129,6 +127,8 @@ def TestBaselineUpgradeApplicationOnly(install_image):
                 vm.WaitExpectedLog("incus-osd", "Skipping missing file: 'x86_64/debug.raw.gz")
                 vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+os_version)
                 vm.WaitExpectedLog("incus-osd", "Recovery actions completed")
+                vm.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
+                vm.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
                 vm.WaitExpectedLog("incus-osd", "Bringing up the network")
                 vm.WaitExpectedLog("incus-osd", "Starting application name=incus version=.+ \\["+os_version+"\\]", regex=True)
                 vm.WaitExpectedLog("incus-osd", "Initializing application name=incus version=.+ \\["+os_version+"\\]", regex=True)


### PR DESCRIPTION
Prevent application factory reset, backup restoration, and update checks from abruptly closing HTTP requests when the underlying primary application is stopped or restarted.

Also updated all existing tests to utilize API requests via HTTPS whenever possible to better mimic actual use and catch any future regressions.