### PR TITLE
incus-osd/providers: Use a custom User-Agent string

### DIFF
--- a/incus-osd/internal/providers/provider_images.go
+++ b/incus-osd/internal/providers/provider_images.go
@@ -296,7 +296,7 @@ func (p *images) load(ctx context.Context) error {
 	p.updateCA = p.state.System.Provider.Config.Config["update_ca"]
 	p.authParam = strings.ToLower(p.state.System.Provider.Config.Config["authentication_by_query_param"]) == "true"
 	p.token = p.state.System.Provider.Config.Config["token"]
-	p.client = http.DefaultClient
+	p.client = &http.Client{}
 
 	// Set default server URL if not configured.
 	if p.serverURL == "" {
@@ -517,7 +517,7 @@ func (a *imagesApplication) Download(ctx context.Context, targetPath string, pro
 		}
 
 		// Download the application.
-		err = downloadAsset(ctx, a.provider.client, fileURL, file.Sha256, filepath.Join(targetPath, targetName), progressFunc)
+		err = downloadAsset(ctx, a.provider.state.OS.Name, a.provider.state.OS.RunningRelease, a.provider.client, fileURL, file.Sha256, filepath.Join(targetPath, targetName), progressFunc)
 		if err != nil {
 			return fmt.Errorf("while downloading %s, got error '%s'", fileURL, err.Error())
 		}
@@ -564,7 +564,7 @@ func (o *imagesOSUpdate) Download(ctx context.Context, targetPath string, progre
 		targetName := strings.TrimSuffix(filepath.Base(file.Filename), ".gz")
 
 		// Download the application.
-		err = downloadAsset(ctx, o.provider.client, fileURL, file.Sha256, filepath.Join(targetPath, targetName), progressFunc)
+		err = downloadAsset(ctx, o.provider.state.OS.Name, o.provider.state.OS.RunningRelease, o.provider.client, fileURL, file.Sha256, filepath.Join(targetPath, targetName), progressFunc)
 		if err != nil {
 			return fmt.Errorf("while downloading %s, got error '%s'", fileURL, err.Error())
 		}
@@ -590,7 +590,7 @@ func (o *imagesOSUpdate) DownloadImage(ctx context.Context, imageType string, ta
 		targetName := strings.TrimSuffix(filepath.Base(file.Filename), ".gz")
 
 		// Download the application.
-		err = downloadAsset(ctx, o.provider.client, fileURL, file.Sha256, filepath.Join(targetPath, targetName), progressFunc)
+		err = downloadAsset(ctx, o.provider.state.OS.Name, o.provider.state.OS.RunningRelease, o.provider.client, fileURL, file.Sha256, filepath.Join(targetPath, targetName), progressFunc)
 
 		return targetName, err
 	}
@@ -633,7 +633,7 @@ func (o *imagesSecureBootCertUpdate) Download(ctx context.Context, targetPath st
 		fileURL := o.provider.serverURL + "/" + o.latestUpdate.Version + "/" + file.Filename
 
 		// Download the application.
-		err = downloadAsset(ctx, o.provider.client, fileURL, file.Sha256, filepath.Join(targetPath, o.GetFilename()), nil)
+		err = downloadAsset(ctx, o.provider.state.OS.Name, o.provider.state.OS.RunningRelease, o.provider.client, fileURL, file.Sha256, filepath.Join(targetPath, o.GetFilename()), nil)
 		if err != nil {
 			return fmt.Errorf("while downloading %s, got error '%s'", fileURL, err.Error())
 		}

--- a/incus-osd/internal/providers/provider_operations_center.go
+++ b/incus-osd/internal/providers/provider_operations_center.go
@@ -631,7 +631,7 @@ func (a *operationsCenterApplication) Download(ctx context.Context, targetPath s
 		}
 
 		// Download the application.
-		err = downloadAsset(ctx, a.provider.client, file.url, file.Sha256, filepath.Join(targetPath, targetName), progressFunc)
+		err = downloadAsset(ctx, a.provider.state.OS.Name, a.provider.state.OS.RunningRelease, a.provider.client, file.url, file.Sha256, filepath.Join(targetPath, targetName), progressFunc)
 		if err != nil {
 			return fmt.Errorf("while downloading %s, got error '%s'", file.url, err.Error())
 		}
@@ -677,7 +677,7 @@ func (o *operationsCenterOSUpdate) Download(ctx context.Context, targetPath stri
 		targetName := strings.TrimSuffix(filepath.Base(file.Filename), ".gz")
 
 		// Download the application.
-		err = downloadAsset(ctx, o.provider.client, file.url, file.Sha256, filepath.Join(targetPath, targetName), progressFunc)
+		err = downloadAsset(ctx, o.provider.state.OS.Name, o.provider.state.OS.RunningRelease, o.provider.client, file.url, file.Sha256, filepath.Join(targetPath, targetName), progressFunc)
 		if err != nil {
 			return fmt.Errorf("while downloading %s, got error '%s'", file.url, err.Error())
 		}
@@ -702,7 +702,7 @@ func (o *operationsCenterOSUpdate) DownloadImage(ctx context.Context, imageType 
 		targetName := strings.TrimSuffix(filepath.Base(file.Filename), ".gz")
 
 		// Download the application.
-		err = downloadAsset(ctx, o.provider.client, file.url, file.Sha256, filepath.Join(targetPath, targetName), progressFunc)
+		err = downloadAsset(ctx, o.provider.state.OS.Name, o.provider.state.OS.RunningRelease, o.provider.client, file.url, file.Sha256, filepath.Join(targetPath, targetName), progressFunc)
 
 		return targetName, err
 	}
@@ -743,7 +743,7 @@ func (o *operationsCenterSecureBootCertUpdate) Download(ctx context.Context, tar
 		}
 
 		// Download the application.
-		err = downloadAsset(ctx, o.provider.client, file.url, file.Sha256, filepath.Join(targetPath, o.GetFilename()), nil)
+		err = downloadAsset(ctx, o.provider.state.OS.Name, o.provider.state.OS.RunningRelease, o.provider.client, file.url, file.Sha256, filepath.Join(targetPath, o.GetFilename()), nil)
 		if err != nil {
 			return fmt.Errorf("while downloading %s, got error '%s'", file.url, err.Error())
 		}

--- a/incus-osd/internal/providers/utils.go
+++ b/incus-osd/internal/providers/utils.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-func downloadAsset(ctx context.Context, client *http.Client, assetURL string, expectedSHA256 string, target string, progressFunc func(float64)) error {
+func downloadAsset(ctx context.Context, osName string, osVersion string, client *http.Client, assetURL string, expectedSHA256 string, target string, progressFunc func(float64)) error {
 	// Remove the target file, if it exists. If we don't, truncating the existing file causes spurious
 	// kernel log messages about verity device-mapper corrupted data blocks for sysext images.
 	err := os.Remove(target)
@@ -26,6 +26,9 @@ func downloadAsset(ctx context.Context, client *http.Client, assetURL string, ex
 	if err != nil {
 		return errors.New("unable to create http request: " + err.Error())
 	}
+
+	// Set a custom User-Agent string.
+	req.Header.Set("User-Agent", osName+"/"+osVersion)
 
 	// Get a reader for the release asset.
 	resp, err := client.Do(req)


### PR DESCRIPTION
This will allow us to get a better idea of what versions of IncusOS are running in the wild. It would also allow for the server to hide updates that would cause known upgrade issues based on the currently running version of IncusOS.