### PR TITLE
Deprecate use of `local` provider

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,27 +78,7 @@ jobs:
 
           make build-iso
 
-          mkdir upload
-
-          ./incus-osd/generate-manifests ./
-
-          mv incus-osd/flasher-tool upload/
-
-          mv mkosi.output/debug.raw upload/
-          mv mkosi.output/gpu-support.raw upload/
-          mv mkosi.output/incus.raw upload/
-          mv mkosi.output/incus-lts-7.0.raw upload/
-          mv mkosi.output/incus-ceph.raw upload/
-          mv mkosi.output/incus-linstor.raw upload/
-          mv mkosi.output/migration-manager.raw upload/
-          mv mkosi.output/operations-center.raw upload/
-
-          OSNAME=$(grep "ImageId=" mkosi.conf | cut -d '=' -f 2)
-
-          mv mkosi.output/${OSNAME}_${{ github.ref_name }}.raw upload/${OSNAME}_${{ github.ref_name }}.img
-          mv mkosi.output/${OSNAME}_${{ github.ref_name }}.iso upload/${OSNAME}_${{ github.ref_name }}.iso
-          mv mkosi.output/${OSNAME}_${{ github.ref_name }}.efi upload/
-          mv mkosi.output/${OSNAME}_${{ github.ref_name }}.usr-*.raw upload/
+          ./scripts/prepare-upload.sh ${{ github.ref_name }}
 
       - name: Compress the files
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,8 +124,14 @@ jobs:
       - name: Start the VM
         run: |
           OSNAME=$(grep "ImageId=" mkosi.conf | cut -d '=' -f 2)
+          RAW_IMAGE=$(ls mkosi.output/${OSNAME}_*.raw | grep -v usr | grep -v esp | sort | tail -1)
 
-          qemu-img convert -f raw -O qcow2 $(ls mkosi.output/${OSNAME}_*.raw | grep -v usr | grep -v esp | sort | tail -1) os-image.qcow2
+          echo '{"applications":[{"name":"incus"},{"name":"debug"}]}' > applications.json
+          echo '{"name":"debug"}' > provider.json
+          tar cf seed.tar applications.json provider.json
+          dd if=seed.tar of=${RAW_IMAGE} seek=4196352 bs=512 conv=notrunc
+
+          qemu-img convert -f raw -O qcow2 ${RAW_IMAGE} os-image.qcow2
           incus image import --alias incus-os test/metadata.tar.xz os-image.qcow2
 
           incus create --quiet --vm incus-os test-incus-os \
@@ -134,7 +140,7 @@ jobs:
             -c limits.memory=2GiB \
             -d root,size=50GiB
           incus config device add test-incus-os vtpm tpm
-          incus config set test-incus-os systemd.credential.fully-enable-incus-agent true
+          incus config set test-incus-os systemd.credential.fully-enable-incus-agent=true
           incus start test-incus-os
 
           incus wait test-incus-os agent --timeout 300
@@ -164,8 +170,8 @@ jobs:
       - name: Test Incus
         run: |
           incus exec test-incus-os -- incus admin init --auto
-          incus exec test-incus-os -- incus launch --quiet images:debian/12 c1
-          incus exec test-incus-os -- incus launch --quiet images:debian/12 v1 --vm
+          incus exec test-incus-os -- incus launch --quiet images:debian/13 c1
+          incus exec test-incus-os -- incus launch --quiet images:debian/13 v1 --vm
 
           incus exec test-incus-os -- sleep 30s
           incus exec test-incus-os -- incus list

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ incus-osd/initrd-utils
 mkosi.packages/initrd-utils*
 mkosi.packages/microcode-metapackage*
 
+scripts/test/local-images-server.pid
+
 *.swp
 
 # Sphinx

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .cache
 debian-tools
 mkosi.output
+local-image-server
 .mkosi-private
 
 mkosi.crt

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ build-iso: build
 	sudo ./scripts/convert-img-to-iso.sh $(shell ls mkosi.output/${OSNAME}_*.raw | grep -v usr | grep -v esp | sort | tail -1)
 
 .PHONY: test
-test: publish-local-update
+test: publish-local-update start-local-image-server
 	# Cleanup
 	incus delete -f test-incus-os || true
 	rm -f mkosi.output/${OSNAME}_boot_media.img
@@ -160,7 +160,7 @@ test: publish-local-update
 	incus start test-incus-os --console
 
 .PHONY: test-iso
-test-iso: publish-local-update
+test-iso: publish-local-update start-local-image-server
 	# Cleanup
 	incus delete -f test-incus-os || true
 	incus storage volume delete default ${OSNAME}_boot_media.iso || true
@@ -208,7 +208,7 @@ test-iso: publish-local-update
 	incus start test-incus-os --console
 
 .PHONY: test-update
-test-update: publish-local-update
+test-update: publish-local-update start-local-image-server
 	incus exec test-incus-os -- curl --unix-socket /run/incus-os/unix.socket http://localhost/1.0/system/update/:check -X POST
 
 .PHONY: publish-local-update
@@ -228,6 +228,12 @@ ifeq (,$(wildcard ./local-image-server/${RELEASE}/))
 
 	rm -rf ./upload/ ${OSNAME}-*-${ARCH}.zip
 endif
+
+.PHONY: start-local-image-server
+start-local-image-server:
+	$(eval SERVER_IP := $(shell incus network list incusbr0 -c 4 -f csv | cut -d '/' -f 1))
+
+	./scripts/test/local-images-server.py ${SERVER_IP} &
 
 .PHONY: test-update-sb-keys
 test-update-sb-keys:

--- a/Makefile
+++ b/Makefile
@@ -189,40 +189,8 @@ test-iso:
 	# Start the installed system
 	incus start test-incus-os --console
 
-.PHONY: test-applications
-test-applications:
-	$(eval RELEASE := $(shell ls mkosi.output/*.efi | sed -e "s/.*_//g" -e "s/.efi//g" | sort -n | tail -1))
-	incus exec test-incus-os -- mkdir -p /root/updates
-	echo ${RELEASE} | incus file push - test-incus-os/root/updates/RELEASE
-
-	incus file push mkosi.output/debug.raw test-incus-os/root/updates/
-	incus file push mkosi.output/gpu-support.raw test-incus-os/root/updates/
-	incus file push mkosi.output/incus.raw test-incus-os/root/updates/
-	incus file push mkosi.output/incus-lts-7.0.raw test-incus-os/root/updates/
-	incus file push mkosi.output/incus-ceph.raw test-incus-os/root/updates/
-	incus file push mkosi.output/incus-linstor.raw test-incus-os/root/updates/
-	incus file push mkosi.output/migration-manager.raw test-incus-os/root/updates/
-	incus file push mkosi.output/operations-center.raw test-incus-os/root/updates/
-
-	incus exec test-incus-os -- curl --unix-socket /run/incus-os/unix.socket http://localhost/1.0/system/update/:check -X POST
-
 .PHONY: test-update
-test-update:
-	$(eval RELEASE := $(shell ls mkosi.output/*.efi | sed -e "s/.*_//g" -e "s/.efi//g" | sort -n | tail -1))
-	incus exec test-incus-os -- mkdir -p /root/updates
-	echo ${RELEASE} | incus file push - test-incus-os/root/updates/RELEASE
-
-	incus file push mkosi.output/${OSNAME}_${RELEASE}.efi test-incus-os/root/updates/
-	incus file push mkosi.output/${OSNAME}_${RELEASE}.usr* test-incus-os/root/updates/
-	incus file push mkosi.output/debug.raw test-incus-os/root/updates/
-	incus file push mkosi.output/gpu-support.raw test-incus-os/root/updates/
-	incus file push mkosi.output/incus.raw test-incus-os/root/updates/
-	incus file push mkosi.output/incus-lts-7.0.raw test-incus-os/root/updates/
-	incus file push mkosi.output/incus-ceph.raw test-incus-os/root/updates/
-	incus file push mkosi.output/incus-linstor.raw test-incus-os/root/updates/
-	incus file push mkosi.output/migration-manager.raw test-incus-os/root/updates/
-	incus file push mkosi.output/operations-center.raw test-incus-os/root/updates/
-
+test-update: publish-local-update
 	incus exec test-incus-os -- curl --unix-socket /run/incus-os/unix.socket http://localhost/1.0/system/update/:check -X POST
 
 .PHONY: publish-local-update

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SPHINXENV=doc/.sphinx/venv/bin/activate
 SPHINXPIPPATH=doc/.sphinx/venv/bin/pip
 
 OSNAME=$(shell grep "ImageId=" mkosi.conf | cut -d '=' -f 2)
+RELEASE=$(shell ls mkosi.output/*.efi | sed -e "s/.*_//g" -e "s/.efi//g" | sort -n | tail -1)
 
 .PHONY: default
 default: build
@@ -26,6 +27,11 @@ flasher-tool:
 generate-manifests:
 	(cd incus-osd && go build ./cmd/generate-manifests)
 	strip incus-osd/generate-manifests
+
+.PHONY: image-publisher
+image-publisher:
+	(cd incus-osd && go build ./cmd/image-publisher)
+	strip incus-osd/image-publisher
 
 .PHONY: initrd-utils
 initrd-utils:
@@ -93,7 +99,7 @@ endif
 	cp incus-osd/certs/files/secureboot-DB-*.crt mkosi.images/base/mkosi.extra/usr/lib/verity.d/
 
 .PHONY: build
-build: inject-system-certs incus-osd flasher-tool generate-manifests initrd-deb-package microcode-metapackage-deb-package
+build: inject-system-certs incus-osd flasher-tool generate-manifests image-publisher initrd-deb-package microcode-metapackage-deb-package
 	cd app-build/ && ./build-applications.py
 
 	sudo rm -Rf mkosi.output/base* mkosi.output/debug* mkosi.output/incus*
@@ -219,9 +225,26 @@ test-update:
 
 	incus exec test-incus-os -- curl --unix-socket /run/incus-os/unix.socket http://localhost/1.0/system/update/:check -X POST
 
+.PHONY: publish-local-update
+publish-local-update:
+	$(eval ARCH := $(shell if [ "$$(uname -m)" = "x86_64" ]; then echo "amd64"; else echo "arm64"; fi))
+
+# Don't perform publish steps if already available locally
+ifeq (,$(wildcard ./local-image-server/${RELEASE}/))
+	rm -rf ./upload/ ${OSNAME}-*-${ARCH}.zip
+	./scripts/prepare-upload.sh ${RELEASE}
+
+	(cd upload && for i in *; do gzip -1 "$${i}"; done)
+
+	zip -j ${OSNAME}-${RELEASE}-${ARCH}.zip upload/*
+
+	SIG_KEY=./certs/cas/root-E1.key SIG_CERTIFICATE=./incus-osd/certs/files/root-E1.crt SIG_CHAIN=./mkosi.crt ./incus-osd/image-publisher sync ./local-image-server/ ./${OSNAME}-${RELEASE}-${ARCH}.zip
+
+	rm -rf ./upload/ ${OSNAME}-*-${ARCH}.zip
+endif
+
 .PHONY: test-update-sb-keys
 test-update-sb-keys:
-	$(eval RELEASE := $(shell ls mkosi.output/*.efi | sed -e "s/.*_//g" -e "s/.efi//g" | sort -n | tail -1))
 	incus exec test-incus-os -- mkdir -p /root/updates
 	echo ${RELEASE} | incus file push - test-incus-os/root/updates/RELEASE
 

--- a/Makefile
+++ b/Makefile
@@ -114,14 +114,23 @@ build-iso: build
 	sudo ./scripts/convert-img-to-iso.sh $(shell ls mkosi.output/${OSNAME}_*.raw | grep -v usr | grep -v esp | sort | tail -1)
 
 .PHONY: test
-test:
+test: publish-local-update
 	# Cleanup
 	incus delete -f test-incus-os || true
 	rm -f mkosi.output/${OSNAME}_boot_media.img
 
+	# Inject a custom provider seed to point the VM to our local images server
+	$(eval SERVER_IP := $(shell incus network list incusbr0 -c 4 -f csv | cut -d '/' -f 1))
+	cp test/seed.install.tar test/seed-test.install.tar
+	echo '{"name":"images","config":{"server_url":"http://${SERVER_IP}:8123/os"}}' > provider.json
+	echo '{"channel":"testing"}' > update.json
+	tar -rf test/seed-test.install.tar provider.json update.json
+	rm provider.json update.json
+
 	# Prepare the install media
 	cp $(shell ls mkosi.output/${OSNAME}_*.raw | grep -v usr | grep -v esp | sort | tail -1) mkosi.output/${OSNAME}_boot_media.img
-	dd if=test/seed.install.tar of=mkosi.output/${OSNAME}_boot_media.img seek=4196352 bs=512 conv=notrunc
+	dd if=test/seed-test.install.tar of=mkosi.output/${OSNAME}_boot_media.img seek=4196352 bs=512 conv=notrunc
+	rm test/seed-test.install.tar
 
 	# Create the VM
 	incus init --empty --vm test-incus-os \
@@ -151,16 +160,25 @@ test:
 	incus start test-incus-os --console
 
 .PHONY: test-iso
-test-iso:
+test-iso: publish-local-update
 	# Cleanup
 	incus delete -f test-incus-os || true
 	incus storage volume delete default ${OSNAME}_boot_media.iso || true
 	rm -f mkosi.output/${OSNAME}_boot_media.iso
 
+	# Inject a custom provider seed to point the VM to our local images server
+	$(eval SERVER_IP := $(shell incus network list incusbr0 -c 4 -f csv | cut -d '/' -f 1))
+	cp test/seed.install.tar test/seed-test.install.tar
+	echo '{"name":"images","config":{"server_url":"http://${SERVER_IP}:8123/os"}}' > provider.json
+	echo '{"channel":"testing"}' > update.json
+	tar -rf test/seed-test.install.tar provider.json update.json
+	rm provider.json update.json
+
 	# Prepare the install media
 	cp $(shell ls mkosi.output/${OSNAME}_*.iso | grep -v usr | grep -v esp | sort | tail -1) mkosi.output/${OSNAME}_boot_media.iso
-	dd if=test/seed.install.tar of=mkosi.output/${OSNAME}_boot_media.iso seek=4196352 bs=512 conv=notrunc
+	dd if=test/seed-test.install.tar of=mkosi.output/${OSNAME}_boot_media.iso seek=4196352 bs=512 conv=notrunc
 	incus storage volume import default mkosi.output/${OSNAME}_boot_media.iso ${OSNAME}_boot_media.iso --type=iso
+	rm test/seed-test.install.tar
 
 	# Create the VM
 	incus init --empty --vm test-incus-os \

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -25,11 +25,6 @@ To test a locally built raw image in an Incus virtual machine, run:
 
     make test
 
-After IncusOS has completed its installation and is running in the virtual machine, to load
-applications run:
-
-    make test-applications
-
 To test the update process, build a new image and update to it with:
 
     make

--- a/doc/reference/system/providers.md
+++ b/doc/reference/system/providers.md
@@ -12,6 +12,6 @@ Configuration fields are defined in the [`SystemProviderConfig` struct](https://
 
 The following configuration options can be set:
 
-* `name`: The name of the provider. One of `images`, `operations-center`, or `local`. `local` is intended for use by developers working on IncusOS.
+* `name`: The name of the provider. One of `images`, `operations-center`, or `debug`. `debug` is intended for use by developers working on IncusOS.
 
 * `config`: A map of provider-specific configuration key-value pairs.

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -647,6 +647,10 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 
 	slog.InfoContext(ctx, "System is starting up", "mode", mode, "version", s.OS.RunningRelease, "machine-id", strings.TrimSuffix(machineID, "\n"))
 
+	if mode != "production" && mode != "dev" {
+		return errors.New("currently unsupported operating mode")
+	}
+
 	// Create this channel early, so we don't block trying to trigger the fallback HTTPS listener.
 	// We can't move the channel processing loop here, because it depends on having a provider (and
 	// therefore potentially a network) properly configured.
@@ -753,18 +757,9 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 	// Get the provider. Must be done after storage pools are loaded, since the operations-center
 	// provider depends on fetching the primary application's client certificate which may be
 	// stored in a local zfs dataset.
-	var provider string
+	defaultProvider := "images"
 
 	var providerConfig map[string]string
-
-	switch mode {
-	case "production":
-		provider = "images"
-	case "dev":
-		provider = "debug"
-	default:
-		return errors.New("currently unsupported operating mode")
-	}
 
 	if s.System.Provider.Config.Name == "" {
 		// Apply the provider seed config (if present).
@@ -776,7 +771,7 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 		if providerSeed != nil {
 			s.System.Provider.Config = providerSeed.SystemProviderConfig
 		} else {
-			s.System.Provider.Config.Name = provider
+			s.System.Provider.Config.Name = defaultProvider
 			s.System.Provider.Config.Config = providerConfig
 		}
 

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -761,7 +761,7 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 	case "production":
 		provider = "images"
 	case "dev":
-		provider = "local"
+		provider = "debug"
 	default:
 		return errors.New("currently unsupported operating mode")
 	}

--- a/incus-osd/internal/providers/load.go
+++ b/incus-osd/internal/providers/load.go
@@ -15,17 +15,17 @@ func Load(ctx context.Context, s *state.State, ignoreSignedJSON bool) (Provider,
 	var p Provider
 
 	switch s.System.Provider.Config.Name {
+	case "debug":
+		// Setup the debug provider.
+		p = &debug{
+			state: s,
+		}
+
 	case "images":
 		// Setup the images provider.
 		p = &images{
 			state:            s,
 			ignoreSignedJSON: ignoreSignedJSON,
-		}
-
-	case "local":
-		// Setup the local provider.
-		p = &local{
-			state: s,
 		}
 
 	case "operations-center":

--- a/incus-osd/internal/providers/provider_debug.go
+++ b/incus-osd/internal/providers/provider_debug.go
@@ -14,11 +14,11 @@ import (
 	"github.com/lxc/incus-os/incus-osd/internal/state"
 )
 
-// LocalPath defines a hard-coded path to where the local provider will look for updates.
-var LocalPath = "/root/updates/"
+// DebugPath defines a hard-coded path to where the debug provider will look for updates.
+var DebugPath = "/root/updates/"
 
-// The Local provider.
-type local struct {
+// The Debug provider.
+type debug struct {
 	state *state.State
 
 	path string
@@ -27,31 +27,31 @@ type local struct {
 	releaseVersion string
 }
 
-func (*local) ClearCache(_ context.Context) error {
-	// No cache for the local provider.
+func (*debug) ClearCache(_ context.Context) error {
+	// No cache for the debug provider.
 	return nil
 }
 
-func (*local) RefreshRegister(_ context.Context, _ ocapi.ServerSelfUpdateCause) error {
-	// No registration with the local provider.
+func (*debug) RefreshRegister(_ context.Context, _ ocapi.ServerSelfUpdateCause) error {
+	// No registration with the debug provider.
 	return ErrRegistrationUnsupported
 }
 
-func (*local) Register(_ context.Context) error {
-	// No registration with the local provider.
+func (*debug) Register(_ context.Context) error {
+	// No registration with the debug provider.
 	return ErrRegistrationUnsupported
 }
 
-func (*local) Deregister(_ context.Context) error {
+func (*debug) Deregister(_ context.Context) error {
 	// Since we can't register, deregister is a no-op.
 	return nil
 }
 
-func (*local) Type() string {
-	return "local"
+func (*debug) Type() string {
+	return "debug"
 }
 
-func (p *local) GetSecureBootCertUpdate(ctx context.Context) (SecureBootCertUpdate, error) {
+func (p *debug) GetSecureBootCertUpdate(ctx context.Context) (SecureBootCertUpdate, error) {
 	// Get latest release.
 	err := p.checkRelease(ctx)
 	if err != nil {
@@ -75,7 +75,7 @@ func (p *local) GetSecureBootCertUpdate(ctx context.Context) (SecureBootCertUpda
 	}
 
 	// Prepare the OS update struct.
-	update := localSecureBootCertUpdate{
+	update := debugSecureBootCertUpdate{
 		provider: p,
 		assets:   p.releaseAssets,
 		version:  p.releaseVersion,
@@ -84,7 +84,7 @@ func (p *local) GetSecureBootCertUpdate(ctx context.Context) (SecureBootCertUpda
 	return &update, nil
 }
 
-func (p *local) GetOSUpdate(ctx context.Context) (OSUpdate, error) {
+func (p *debug) GetOSUpdate(ctx context.Context) (OSUpdate, error) {
 	// Get latest release.
 	err := p.checkRelease(ctx)
 	if err != nil {
@@ -108,7 +108,7 @@ func (p *local) GetOSUpdate(ctx context.Context) (OSUpdate, error) {
 	}
 
 	// Prepare the OS update struct.
-	update := localOSUpdate{
+	update := debugOSUpdate{
 		provider: p,
 		assets:   p.releaseAssets,
 		version:  p.releaseVersion,
@@ -117,7 +117,7 @@ func (p *local) GetOSUpdate(ctx context.Context) (OSUpdate, error) {
 	return &update, nil
 }
 
-func (p *local) GetApplicationUpdate(ctx context.Context, name string) (ApplicationUpdate, error) {
+func (p *debug) GetApplicationUpdate(ctx context.Context, name string) (ApplicationUpdate, error) {
 	// Get latest release.
 	err := p.checkRelease(ctx)
 	if err != nil {
@@ -141,7 +141,7 @@ func (p *local) GetApplicationUpdate(ctx context.Context, name string) (Applicat
 	}
 
 	// Prepare the application struct.
-	app := localApplication{
+	app := debugApplication{
 		provider: p,
 		name:     name,
 		assets:   p.releaseAssets,
@@ -151,14 +151,14 @@ func (p *local) GetApplicationUpdate(ctx context.Context, name string) (Applicat
 	return &app, nil
 }
 
-func (p *local) load(_ context.Context) error {
+func (p *debug) load(_ context.Context) error {
 	// Use a hardcoded path for now.
-	p.path = LocalPath
+	p.path = DebugPath
 
 	return nil
 }
 
-func (p *local) checkRelease(_ context.Context) error {
+func (p *debug) checkRelease(_ context.Context) error {
 	// Deal with missing path.
 	_, err := os.Lstat(p.path)
 	if err != nil {
@@ -194,7 +194,7 @@ func (p *local) checkRelease(_ context.Context) error {
 	return nil
 }
 
-func (p *local) copyAsset(_ context.Context, name string, targetPath string, progressFunc func(float64)) error {
+func (p *debug) copyAsset(_ context.Context, name string, targetPath string, progressFunc func(float64)) error {
 	// Remove the target file, if it exists. If we don't, truncating the existing file causes spurious
 	// kernel log messages about verity device-mapper corrupted data blocks for sysext images.
 	err := os.Remove(filepath.Join(targetPath, name))
@@ -252,28 +252,28 @@ func (p *local) copyAsset(_ context.Context, name string, targetPath string, pro
 	return nil
 }
 
-// An application from the Local provider.
-type localApplication struct {
-	provider *local
+// An application from the Debug provider.
+type debugApplication struct {
+	provider *debug
 
 	assets  []string
 	name    string
 	version string
 }
 
-func (a *localApplication) Name() string {
+func (a *debugApplication) Name() string {
 	return a.name
 }
 
-func (a *localApplication) Version() string {
+func (a *debugApplication) Version() string {
 	return a.version
 }
 
-func (a *localApplication) IsNewerThan(otherVersion string) bool {
+func (a *debugApplication) IsNewerThan(otherVersion string) bool {
 	return DatetimeComparison(a.version, otherVersion)
 }
 
-func (a *localApplication) Download(ctx context.Context, targetPath string, progressFunc func(float64)) error {
+func (a *debugApplication) Download(ctx context.Context, targetPath string, progressFunc func(float64)) error {
 	// Create the target path.
 	err := os.MkdirAll(targetPath, 0o700)
 	if err != nil {
@@ -304,23 +304,23 @@ func (a *localApplication) Download(ctx context.Context, targetPath string, prog
 	return nil
 }
 
-// An update from the Local provider.
-type localOSUpdate struct {
-	provider *local
+// An update from the Debug provider.
+type debugOSUpdate struct {
+	provider *debug
 
 	assets  []string
 	version string
 }
 
-func (o *localOSUpdate) Version() string {
+func (o *debugOSUpdate) Version() string {
 	return o.version
 }
 
-func (o *localOSUpdate) IsNewerThan(otherVersion string) bool {
+func (o *debugOSUpdate) IsNewerThan(otherVersion string) bool {
 	return DatetimeComparison(o.version, otherVersion)
 }
 
-func (o *localOSUpdate) Download(ctx context.Context, targetPath string, progressFunc func(float64)) error {
+func (o *debugOSUpdate) Download(ctx context.Context, targetPath string, progressFunc func(float64)) error {
 	// Clear the path.
 	err := os.RemoveAll(targetPath)
 	if err != nil && !os.IsNotExist(err) {
@@ -360,32 +360,32 @@ func (o *localOSUpdate) Download(ctx context.Context, targetPath string, progres
 	return nil
 }
 
-func (*localOSUpdate) DownloadImage(_ context.Context, _ string, _ string, _ func(float64)) (string, error) {
-	// No reason to support fetching a full install image from the local (development) provider.
-	return "", errors.New("downloading full image not supported by local provider")
+func (*debugOSUpdate) DownloadImage(_ context.Context, _ string, _ string, _ func(float64)) (string, error) {
+	// No reason to support fetching a full install image from the debug (development) provider.
+	return "", errors.New("downloading full image not supported by debug provider")
 }
 
-// Secure Boot key updates from the Local provider.
-type localSecureBootCertUpdate struct {
-	provider *local
+// Secure Boot key updates from the Debug provider.
+type debugSecureBootCertUpdate struct {
+	provider *debug
 
 	assets  []string
 	version string
 }
 
-func (o *localSecureBootCertUpdate) Version() string {
+func (o *debugSecureBootCertUpdate) Version() string {
 	return o.version
 }
 
-func (o *localSecureBootCertUpdate) GetFilename() string {
+func (o *debugSecureBootCertUpdate) GetFilename() string {
 	return "SecureBootKeys_" + o.version + ".tar"
 }
 
-func (o *localSecureBootCertUpdate) IsNewerThan(otherVersion string) bool {
+func (o *debugSecureBootCertUpdate) IsNewerThan(otherVersion string) bool {
 	return DatetimeComparison(o.version, otherVersion)
 }
 
-func (o *localSecureBootCertUpdate) Download(ctx context.Context, targetPath string, _ func(float64)) error {
+func (o *debugSecureBootCertUpdate) Download(ctx context.Context, targetPath string, _ func(float64)) error {
 	for _, asset := range o.assets {
 		// Only select Secure Boot keys for the expected version.
 		if filepath.Base(asset) != o.GetFilename() {

--- a/incus-osd/internal/recovery/recovery.go
+++ b/incus-osd/internal/recovery/recovery.go
@@ -185,14 +185,14 @@ func applyUpdate(ctx context.Context, s *state.State, updateCA string, mountDir 
 
 	slog.InfoContext(ctx, "Processing validated update metadata", "version", updateInfo.Version)
 
-	// Make sure the path used by the local provider exists.
-	err = os.MkdirAll(providers.LocalPath, 0o700)
+	// Make sure the path used by the debug provider exists.
+	err = os.MkdirAll(providers.DebugPath, 0o700)
 	if err != nil {
 		return err
 	}
 
 	// Ensure we cleanup after ourselves.
-	defer os.RemoveAll(providers.LocalPath)
+	defer os.RemoveAll(providers.DebugPath)
 
 	// Get local architecture.
 	archName, err := osarch.ArchitectureGetLocal()
@@ -208,7 +208,7 @@ func applyUpdate(ctx context.Context, s *state.State, updateCA string, mountDir 
 			continue
 		}
 
-		// Verify the SHA256 of each file that exists before making it available to the local provider.
+		// Verify the SHA256 of each file that exists before making it available to the debug provider.
 		err := verifyAndDecompressFile(updateDir, file)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -221,8 +221,8 @@ func applyUpdate(ctx context.Context, s *state.State, updateCA string, mountDir 
 		}
 	}
 
-	// Set the RELEASE version for the local provider.
-	r, err := os.Create(filepath.Join(providers.LocalPath, "RELEASE"))
+	// Set the RELEASE version for the debug provider.
+	r, err := os.Create(filepath.Join(providers.DebugPath, "RELEASE"))
 	if err != nil {
 		return err
 	}
@@ -233,7 +233,7 @@ func applyUpdate(ctx context.Context, s *state.State, updateCA string, mountDir 
 		return err
 	}
 
-	// Stash the current provider state and configuration. We'll be forcing the system to use the local provider,
+	// Stash the current provider state and configuration. We'll be forcing the system to use the debug provider,
 	// and once we're done we want to restore the actual provider configuration.
 	currentProvider := s.System.Provider
 
@@ -241,7 +241,7 @@ func applyUpdate(ctx context.Context, s *state.State, updateCA string, mountDir 
 
 	s.System.Provider = api.SystemProvider{
 		Config: api.SystemProviderConfig{
-			Name: "local",
+			Name: "debug",
 		},
 	}
 
@@ -291,7 +291,7 @@ func verifyAndDecompressFile(updateDir string, file apiupdate.UpdateFile) error 
 
 	// Create the target path.
 	// #nosec G304
-	tfd, err := os.Create(filepath.Join(providers.LocalPath, filepath.Base(strings.TrimSuffix(file.Filename, ".gz"))))
+	tfd, err := os.Create(filepath.Join(providers.DebugPath, filepath.Base(strings.TrimSuffix(file.Filename, ".gz"))))
 	if err != nil {
 		return err
 	}

--- a/incus-osd/internal/rest/api_system_provider.go
+++ b/incus-osd/internal/rest/api_system_provider.go
@@ -95,6 +95,12 @@ func (s *Server) apiSystemProvider(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		if newConfig.Config.Name == "" {
+			_ = response.BadRequest(errors.New("a provider name must be specified")).Render(w)
+
+			return
+		}
+
 		// If switching providers, unregister from the current one.
 		if newConfig.Config.Name != oldConfig.Name {
 			// Load the current provider and deregister it.

--- a/incus-osd/internal/state/state_test.go
+++ b/incus-osd/internal/state/state_test.go
@@ -25,7 +25,7 @@ System.Network.Config.NTP.Timeservers[0]: ntp.example.org
 System.Network.Config.Proxy.HTTPProxy: anonymous-proxy.example.org:1234
 System.Network.Config.Proxy.HTTPSProxy: user:pass@proxy.example.net:8080
 System.Network.Config.Proxy.NoProxy: *.example.org,*.example.net
-System.Provider.Config.Name: local
+System.Provider.Config.Name: debug
 System.Provider.Config.Config[multiline_value]: first\nsecond\nthird
 System.Update.Config.UpdateFrequency: 21600000000000
 `
@@ -44,7 +44,7 @@ System.Network.Config.NTP.Timeservers[0]: ntp.example.org
 System.Network.Config.Proxy.HTTPProxy: anonymous-proxy.example.org:1234
 System.Network.Config.Proxy.HTTPSProxy: user:pass@proxy.example.net:8080
 System.Network.Config.Proxy.NoProxy: *.example.org,*.example.net
-System.Provider.Config.Name: local
+System.Provider.Config.Name: debug
 System.Provider.Config.Config[multiline_value]: first\nsecond\nthird
 System.Security.Config.EncryptionRecoveryKeys[0]: ebbbibiu-ltgjfuhk-gvutdrvu-hijhvfje-gvlrgrfv-ndekdtdh-ghteuklj-ldedfifb
 System.Security.State.EncryptionRecoveryKeysRetrieved: true
@@ -74,7 +74,7 @@ System.Network.Config.Proxy.Servers[proxy_example_net_8080].Auth: basic
 System.Network.Config.Proxy.Servers[proxy_example_net_8080].Host: proxy.example.net:8080
 System.Network.Config.Proxy.Servers[proxy_example_net_8080].Password: pass
 System.Network.Config.Proxy.Servers[proxy_example_net_8080].Username: user
-System.Provider.Config.Name: local
+System.Provider.Config.Name: debug
 System.Provider.Config.Config[multiline_value]: first\nsecond\nthird
 System.Security.Config.EncryptionRecoveryKeys[0]: ebbbibiu-ltgjfuhk-gvutdrvu-hijhvfje-gvlrgrfv-ndekdtdh-ghteuklj-ldedfifb
 System.Security.State.EncryptionRecoveryKeysRetrieved: true
@@ -104,7 +104,7 @@ System.Network.Config.Proxy.Servers[proxy_example_net_8080].Auth: basic
 System.Network.Config.Proxy.Servers[proxy_example_net_8080].Host: proxy.example.net:8080
 System.Network.Config.Proxy.Servers[proxy_example_net_8080].Password: pass
 System.Network.Config.Proxy.Servers[proxy_example_net_8080].Username: user
-System.Provider.Config.Name: local
+System.Provider.Config.Name: debug
 System.Provider.Config.Config[multiline_value]: first\nsecond\nthird
 System.Security.Config.EncryptionRecoveryKeys[0]: ebbbibiu-ltgjfuhk-gvutdrvu-hijhvfje-gvlrgrfv-ndekdtdh-ghteuklj-ldedfifb
 System.Security.State.EncryptionRecoveryKeysRetrieved: true
@@ -134,7 +134,7 @@ System.Network.Config.Proxy.Servers[proxy_example_net_8080].Auth: basic
 System.Network.Config.Proxy.Servers[proxy_example_net_8080].Host: proxy.example.net:8080
 System.Network.Config.Proxy.Servers[proxy_example_net_8080].Password: pass
 System.Network.Config.Proxy.Servers[proxy_example_net_8080].Username: user
-System.Provider.Config.Name: local
+System.Provider.Config.Name: debug
 System.Provider.Config.Config[multiline_value]: first\nsecond\nthird
 System.Security.Config.EncryptionRecoveryKeys[0]: ebbbibiu-ltgjfuhk-gvutdrvu-hijhvfje-gvlrgrfv-ndekdtdh-ghteuklj-ldedfifb
 System.Security.State.EncryptionRecoveryKeysRetrieved: true
@@ -165,7 +165,7 @@ System.Network.Config.Proxy.Servers[proxy_example_net_8080].Auth: basic
 System.Network.Config.Proxy.Servers[proxy_example_net_8080].Host: proxy.example.net:8080
 System.Network.Config.Proxy.Servers[proxy_example_net_8080].Password: pass
 System.Network.Config.Proxy.Servers[proxy_example_net_8080].Username: user
-System.Provider.Config.Name: local
+System.Provider.Config.Name: debug
 System.Provider.Config.Config[multiline_value]: first\nsecond\nthird
 System.Security.Config.EncryptionRecoveryKeys[0]: ebbbibiu-ltgjfuhk-gvutdrvu-hijhvfje-gvlrgrfv-ndekdtdh-ghteuklj-ldedfifb
 System.Security.State.EncryptionRecoveryKeysRetrieved: true
@@ -196,7 +196,7 @@ System.Network.Config.Interfaces[0].Addresses[0]: dhcp4
 System.Network.Config.Interfaces[0].Addresses[1]: slaac
 System.Network.Config.Interfaces[0].Hwaddr: 10:66:6a:7c:8c:b0
 System.Network.Config.Interfaces[0].Name: enp5s0
-System.Provider.Config.Name: local
+System.Provider.Config.Name: debug
 System.Provider.Config.Config[multiline_value]: first\nsecond\nthird
 System.Security.Config.EncryptionRecoveryKeys[0]: ebbbibiu-ltgjfuhk-gvutdrvu-hijhvfje-gvlrgrfv-ndekdtdh-ghteuklj-ldedfifb
 System.Security.State.EncryptionRecoveryKeysRetrieved: true
@@ -227,7 +227,7 @@ System.Network.Config.Interfaces[0].Addresses[0]: dhcp4
 System.Network.Config.Interfaces[0].Addresses[1]: slaac
 System.Network.Config.Interfaces[0].Hwaddr: 10:66:6a:7c:8c:b0
 System.Network.Config.Interfaces[0].Name: enp5s0
-System.Provider.Config.Name: local
+System.Provider.Config.Name: debug
 System.Provider.Config.Config[multiline_value]: first\nsecond\nthird
 System.Security.Config.EncryptionRecoveryKeys[0]: ebbbibiu-ltgjfuhk-gvutdrvu-hijhvfje-gvlrgrfv-ndekdtdh-ghteuklj-ldedfifb
 System.Security.State.EncryptionRecoveryKeysRetrieved: true
@@ -259,7 +259,7 @@ System.Network.Config.Interfaces[0].Addresses[0]: dhcp4
 System.Network.Config.Interfaces[0].Addresses[1]: slaac
 System.Network.Config.Interfaces[0].Hwaddr: 10:66:6a:7c:8c:b0
 System.Network.Config.Interfaces[0].Name: enp5s0
-System.Provider.Config.Name: local
+System.Provider.Config.Name: debug
 System.Provider.Config.Config[multiline_value]: first\nsecond\nthird
 System.Security.Config.EncryptionRecoveryKeys[0]: ebbbibiu-ltgjfuhk-gvutdrvu-hijhvfje-gvlrgrfv-ndekdtdh-ghteuklj-ldedfifb
 System.Security.State.EncryptionRecoveryKeysRetrieved: true

--- a/incus-osd/tests/api-tests.py
+++ b/incus-osd/tests/api-tests.py
@@ -16,8 +16,10 @@ current_release = None
 prior_stable_release = None
 urls = []
 
+IMAGES_SERVER = os.getenv("IMAGES_SERVER", "https://images.linuxcontainers.org")
+
 # Fetch the current and prior stable release information
-with urllib.request.urlopen("https://images.linuxcontainers.org/os/index.json") as url:
+with urllib.request.urlopen(IMAGES_SERVER + "/os/index.json") as url:
     versions = json.loads(url.read().decode())
 
     current_stable_release_version = ""
@@ -39,12 +41,12 @@ with urllib.request.urlopen("https://images.linuxcontainers.org/os/index.json") 
     for file in current_release["files"]:
         if file["architecture"] == "x86_64":
             if file["type"] == "image-raw" or file["type"] == "image-iso":
-                urls.append("https://images." + current_release["origin"] + "/os" + current_release["url"] + "/" + file["filename"])
+                urls.append(IMAGES_SERVER + "/os" + current_release["url"] + "/" + file["filename"])
 
     for file in prior_stable_release["files"]:
         if file["architecture"] == "x86_64":
             if file["type"] == "image-raw":
-                urls.append("https://images." + prior_stable_release["origin"] + "/os" + prior_stable_release["url"] + "/" + file["filename"])
+                urls.append(IMAGES_SERVER + "/os" + prior_stable_release["url"] + "/" + file["filename"])
 
 # Download images if needed
 for url in urls:

--- a/incus-osd/tests/incusos_tests/incus_test_vm/util.py
+++ b/incus-osd/tests/incusos_tests/incus_test_vm/util.py
@@ -90,6 +90,12 @@ def _prepare_test_image(image, seed):
 
     seed["operations-center.json"] = json.dumps(oc_json)
 
+    # Configure the images provider, if needed
+    IMAGES_SERVER = os.getenv("IMAGES_SERVER")
+    if IMAGES_SERVER is not None:
+        if "provider.json" not in seed:
+            seed["provider.json"] = '{"name":"images","config":{"server_url":"' + IMAGES_SERVER + '/os"}}'
+
     # Inject seed data.
     with open(test_image, "rb+") as f:
         f.seek(4196352*512)
@@ -108,10 +114,12 @@ def _prepare_test_image(image, seed):
     return test_image, parts[0], parts[1].replace(ext, ""), client_cert_name
 
 def _manual_download_application(directory, name, version):
+    IMAGES_SERVER = os.getenv("IMAGES_SERVER", "https://images.linuxcontainers.org")
+
     os.mkdir(directory+"/update")
 
-    urllib.request.urlretrieve("https://images.linuxcontainers.org/os/"+version+"/update.json", directory+"/update/update.json")
-    urllib.request.urlretrieve("https://images.linuxcontainers.org/os/"+version+"/update.sjson", directory+"/update/update.sjson")
+    urllib.request.urlretrieve(IMAGES_SERVER + "/os/"+version+"/update.json", directory+"/update/update.json")
+    urllib.request.urlretrieve(IMAGES_SERVER + "/os/"+version+"/update.sjson", directory+"/update/update.sjson")
 
     os.mkdir(directory+"/update/x86_64")
 
@@ -125,7 +133,7 @@ def _manual_download_application(directory, name, version):
             if updateFile["type"] != "application" or updateFile["component"] != name:
                 continue
 
-            urllib.request.urlretrieve("https://images.linuxcontainers.org/os/"+version+"/"+updateFile["filename"], directory+"/update/"+updateFile["filename"])
+            urllib.request.urlretrieve(IMAGES_SERVER + "/os/"+version+"/"+updateFile["filename"], directory+"/update/"+updateFile["filename"])
 
 def _create_user_media(f, d, media_type, media_size, media_label):
     if media_type == "img":

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_applications.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_applications.py
@@ -55,6 +55,8 @@ def TestIncusOSAPIApplicationsIncus(install_image):
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
+        time.sleep(5)
+
         # Verify our test file is no longer present
         result = vm.RunCommand("stat", "/var/lib/incus/test-file", check=False)
         if result.returncode == 0:
@@ -64,6 +66,8 @@ def TestIncusOSAPIApplicationsIncus(install_image):
         result = vm.APIRequest("/1.0/applications/incus/:restore", method="POST", body=backup_archive, content_type="application/x-tar")
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+        time.sleep(5)
 
         # Verify our test file is restored
         vm.RunCommand("stat", "/var/lib/incus/test-file")
@@ -114,6 +118,8 @@ def TestIncusOSAPIApplicationsMigrationManager(install_image):
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
+        time.sleep(5)
+
         # Verify our test file is no longer present
         result = vm.RunCommand("stat", "/var/lib/migration-manager/test-file", check=False)
         if result.returncode == 0:
@@ -123,6 +129,8 @@ def TestIncusOSAPIApplicationsMigrationManager(install_image):
         result = vm.APIRequest("/1.0/applications/migration-manager/:restore", method="POST", body=backup_archive, content_type="application/x-tar")
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+        time.sleep(5)
 
         # Verify our test file is restored
         vm.RunCommand("stat", "/var/lib/migration-manager/test-file")
@@ -173,6 +181,8 @@ def TestIncusOSAPIApplicationsOperationsCenter(install_image):
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
+        time.sleep(30)
+
         # Verify our test file is no longer present
         result = vm.RunCommand("stat", "/var/lib/operations-center/test-file", check=False)
         if result.returncode == 0:
@@ -182,6 +192,8 @@ def TestIncusOSAPIApplicationsOperationsCenter(install_image):
         result = vm.APIRequest("/1.0/applications/operations-center/:restore", method="POST", body=backup_archive, content_type="application/x-tar")
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+        time.sleep(30)
 
         # Verify our test file is restored
         vm.RunCommand("stat", "/var/lib/operations-center/test-file")

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_network.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_network.py
@@ -1,10 +1,13 @@
 import json
+import os
 import time
 
 from .incus_test_vm import IncusTestVM, IncusOSException, util
 
 def _checkNetworkConnectivity(vm):
-    vm.RunCommand("curl", "linuxcontainers.org")
+    IMAGES_SERVER = os.getenv("IMAGES_SERVER", "https://images.linuxcontainers.org")
+
+    vm.RunCommand("curl", IMAGES_SERVER)
 
 def TestIncusOSAPISystemNetworkDefaults(install_image):
     test_name = "incusos-api-system-network-defaults"

--- a/incus-osd/tests/incusos_tests/tests_upgrade.py
+++ b/incus-osd/tests/incusos_tests/tests_upgrade.py
@@ -70,8 +70,10 @@ def TestBaselineUpgradeOSOnly(install_image):
         vm.LogDoesntContain("incus-osd", "Downloading OS update")
         vm.LogDoesntContain("incus-osd", "Downloading application update")
 
+        IMAGES_SERVER = os.getenv("IMAGES_SERVER", "https://images.linuxcontainers.org")
+
         # Now that we've started up, switch the provider back to the main "images" and check for an OS update.
-        result = vm.APIRequest("/1.0/system/provider", method="PUT", body="""{"config":{"name":"images"}}""", use_unix_socket=True)
+        result = vm.APIRequest("/1.0/system/provider", method="PUT", body='{"config":{"name":"images","config":{"server_url":"' + IMAGES_SERVER + '/os"}}}', use_unix_socket=True)
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
@@ -136,8 +138,10 @@ def TestBaselineUpgradeApplicationOnly(install_image):
 
                 vm.LogDoesntContain("incus-osd", "Downloading OS update")
 
+                IMAGES_SERVER = os.getenv("IMAGES_SERVER", "https://images.linuxcontainers.org")
+
                 # Now that we've started up, switch the provider back to the main "images" and check for an application update.
-                result = vm.APIRequest("/1.0/system/provider", method="PUT", body="""{"config":{"name":"images"}}""")
+                result = vm.APIRequest("/1.0/system/provider", method="PUT", body='{"config":{"name":"images","config":{"server_url":"' + IMAGES_SERVER + '/os"}}}')
                 if result["status_code"] != 200:
                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 

--- a/incus-osd/tests/incusos_tests/tests_upgrade.py
+++ b/incus-osd/tests/incusos_tests/tests_upgrade.py
@@ -44,7 +44,7 @@ def TestBaselineUpgradeOSOnly(install_image):
     test_name = "baseline-upgrade-os-only"
     test_seed = {
         "install.json": "{}",
-        "provider.json": """{"name":"local"}"""
+        "provider.json": """{"name":"debug"}"""
     }
 
     test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
@@ -92,7 +92,7 @@ def TestBaselineUpgradeApplicationOnly(install_image):
     test_name = "baseline-upgrade-application-only"
     test_seed = {
         "install.json": "{}",
-        "provider.json": """{"name":"local"}"""
+        "provider.json": """{"name":"debug"}"""
     }
 
     test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)

--- a/scripts/prepare-upload.sh
+++ b/scripts/prepare-upload.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -eu
+
+if [ -z "${1:-}" ]; then
+    echo "Usage: ${0} VERSION"
+    exit 1
+fi
+
+VERSION=${1}
+
+mkdir upload
+
+./incus-osd/generate-manifests ./
+
+cp incus-osd/flasher-tool upload/
+
+cp mkosi.output/debug.raw upload/
+cp mkosi.output/gpu-support.raw upload/
+cp mkosi.output/incus.raw upload/
+cp mkosi.output/incus-lts-7.0.raw upload/
+cp mkosi.output/incus-ceph.raw upload/
+cp mkosi.output/incus-linstor.raw upload/
+cp mkosi.output/migration-manager.raw upload/
+cp mkosi.output/operations-center.raw upload/
+
+OSNAME=$(grep "ImageId=" mkosi.conf | cut -d '=' -f 2)
+
+cp mkosi.output/"${OSNAME}"_"${VERSION}".raw upload/"${OSNAME}"_"${VERSION}".img
+cp mkosi.output/"${OSNAME}"_"${VERSION}".iso upload/"${OSNAME}"_"${VERSION}".iso || true
+cp mkosi.output/"${OSNAME}"_"${VERSION}".efi upload/
+cp mkosi.output/"${OSNAME}"_"${VERSION}".usr-*.raw upload/

--- a/scripts/test/local-images-server.py
+++ b/scripts/test/local-images-server.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python3
+
+import atexit
+import http.server
+import os
+import socketserver
+import sys
+
+class ImagesHandler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        # Only allow access to the local image server contents
+        super().__init__(*args, directory="./local-image-server/", **kwargs)
+
+    def do_GET(self):
+        if not self.path.startswith("/os/"):
+            super().send_error(404, "Not Found")
+        else:
+            self.path = self.path.removeprefix("/os")
+            super().do_GET()
+
+    def log_message(self, format, *args):
+        pass
+
+if len(sys.argv) != 2:
+    print("Usage: " + sys.argv[0] + " <server ip>")
+    exit(1)
+
+script_dir = os.path.dirname(os.path.realpath(__file__))
+pid_file = script_dir + "/local-images-server.pid"
+
+def cleanup_pid():
+    os.remove(pid_file)
+
+# Only allow one instance to run at a time
+if os.path.exists(pid_file):
+    exit(0)
+
+# Record the script's pid
+with open(pid_file, "w") as f:
+    f.write(str(os.getpid()))
+
+# Remove pid file on exit
+atexit.register(cleanup_pid)
+
+with socketserver.TCPServer((sys.argv[1], 8123), ImagesHandler) as httpd:
+    # Run until script is killed
+    httpd.serve_forever()


### PR DESCRIPTION
Rename the `local` provider to `debug` to more accurately reflect its intended use. There are only two remaining uses of this provider:
* The github tests workflow
* Applying recovery updates from a local recovery disk

Also adjust the local development workflow to use a local images server. This mirrors how IncusOS systems operate in real life, which should help us catch any future issues before they hit the pubic images server.