### PR TITLE
Add ability to automatically deploy a Ceph cluster and add it as an Incus storage pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ update-gomod:
 	cd incus-osd && go get -t -v -u ./...
 	cd incus-osd && go get tailscale.com@v1.94.2
 	sed -i "/go-json-experiment/d" incus-osd/go.mod
-	cd incus-osd && go mod tidy --go=1.25.11
+	cd incus-osd && go mod tidy --go=1.25.12
 	cd incus-osd && go get toolchain@none
 
 .PHONY: update-app-versions

--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -125,8 +125,8 @@ symlink
 syslog
 systemd
 systemd's
-Tailscale
 Tailnet
+Tailscale
 TCP
 TDB
 TiB

--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -10,6 +10,7 @@ CAs
 CDN
 CDROM
 Ceph
+Ceph's
 CIDR
 Cisco
 CPUs
@@ -91,6 +92,8 @@ oddlama
 OEM
 OpenFGA
 OpenStack
+OSD
+OSDs
 OVMF
 OVN
 OVS

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -12303,6 +12303,28 @@ paths:
             summary: Update application configuration
             tags:
                 - applications
+    /1.0/applications/{name}/:action:
+        post:
+            description: Triggers the given application to perform a specific task.
+            operationId: applications_post_action
+            parameters:
+                - description: Application name
+                  in: path
+                  name: name
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    $ref: '#/responses/EmptySyncResponse'
+                "404":
+                    $ref: '#/responses/NotFound'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Perform an application-specific action
+            tags:
+                - applications
     /1.0/applications/{name}/:backup:
         post:
             consumes:

--- a/doc/tutorials.md
+++ b/doc/tutorials.md
@@ -3,6 +3,7 @@ The following tutorials demonstrate various ways to configure and use IncusOS.
 
 ```{toctree}
 :maxdepth: 1
+Creating a Ceph cluster </tutorials/storage-create-ceph-cluster>
 Expanding the "local" storage pool </tutorials/storage-expand-local-pool>
 Preparing a storage volume for Incus </tutorials/storage-preparing-volume-incus>
 Import existing Incus instances from an unencrypted pool </tutorials/storage-import-unencrypted-incus-pool>

--- a/doc/tutorials/storage-create-ceph-cluster.md
+++ b/doc/tutorials/storage-create-ceph-cluster.md
@@ -1,0 +1,118 @@
+# Creating a Ceph cluster
+
+IncusOS can automate the process of deploying a Ceph cluster. Utilizing OCI container images, IncusOS can self-host a resilient and fault-tolerant Ceph storage cluster.
+
+## Requirements
+
+* An [IncusOS cluster](./incus-cluster.md) consisting of at least three servers:
+
+   * Each server should have a storage pool named `local` available to store Ceph OCI image(s)
+
+   * An Incus-managed common network accessible to all cluster servers with IPv6 connectivity; ideally this network should only be available to cluster servers
+
+   * Optionally, a dedicated project to use when creating the Ceph OCI images and containers
+
+* Each cluster server that will host a Ceph OSD must have an unused raw block device available for the OSD to use. IncusOS will setup LUKS encryption of the raw device before passing it through to the OSD container.
+
+An IncusOS cluster deployed by Operations Center should meet all of these requirements out of the box.
+
+## Initializing the Ceph control plane
+
+The first step is to create the Ceph control plane. The Ceph OCI image will be downloaded and three Ceph containers will be created, each on a different Incus cluster server. The initialization logic also ensures the `incus-ceph` application is installed on each member of the Incus cluster, and that the Ceph service is properly configured.
+
+```
+incus admin os application action incus -d '{"action":"initialize-ceph-cluster","config":{"control_servers":"server01,server02,server03"}}'
+```
+
+### Configuration parameters
+
+* `control_servers`: A comma-separated list of three Incus servers to use when initially deploying the Ceph control plane. If not specified, defaults to the first three Incus cluster servers as reported via the Incus API.
+* `network`: The Incus network that should be utilized by the Ceph cluster. If not specified, defaults to `meshbr0`.
+
+## Adding storage drives (OSDs)
+
+Ceph requires a minimum of three OSDs, and only one OSD can run at a time on a given physical Incus server to help ensure proper replication.
+
+Each OSD is bound to a specific Incus server, so the `--target` parameter must be specified when creating a new OSD.
+
+```
+incus admin os application action incus-ceph -d '{"action":"add-drive","config":{"device_id":"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_ceph--disk"}}' --target server01
+incus admin os application action incus-ceph -d '{"action":"add-drive","config":{"device_id":"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_ceph--disk"}}' --target server02
+incus admin os application action incus-ceph -d '{"action":"add-drive","config":{"device_id":"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_ceph--disk"}}' --target server03
+```
+
+### Configuration parameters
+
+* `device_id`: The device ID of the raw block device to be used by the OSD.
+
+## Updating deployed Ceph version
+
+Because Ceph is deployed using OCI images, it's easy to update or change the running version of Ceph. By default, IncusOS creates the Ceph containers using a major version tag, such as `v20`. As the upstream tag is changed to track the latest release, refreshing and rebuilding the Ceph containers will then automatically pick up that version. It is also possible to specify an explicit tag such as `v21` to bump Ceph to the next major version, `v20.2` to more specifically track a series of Ceph releases, or `v20.1.1` to pin to a specific version.
+
+```{note}
+IncusOS will not automatically remove old, unused Ceph OCI images; this must be done manually.
+```
+
+### Configuration parameters
+
+* `oci_tag`: If specified, update the Ceph containers to use the specific OCI image tag; otherwise, refresh the currently used OCI image and update the Ceph containers if a newer version is available.
+
+```
+incus admin os application action incus-ceph -d '{"action":"refresh-images"}'
+```
+
+## Removing a storage drive (OSD)
+
+If four or more OSDs are available, an OSD can be removed from the Ceph configuration. Because each OSD is bound to a specific Incus server, the `--target` parameter must be specified:
+
+```{warning}
+Removing an OSD via the IncusOS API is equivalent to pulling the power cord of a physical server. Prior to removal of the OSD container, be sure to properly remove the OSD from Ceph's configuration and allow sufficient time for any necessary data migrations to complete.
+```
+
+```
+incus admin os application action incus-ceph -d '{"action":"remove-drive"}' --target server01
+```
+
+## Ceph cluster configuration and status
+
+After the Ceph cluster is initialized, the IncusOS `ceph` service will report basic status information:
+
+```
+$ incus admin os service show ceph
+WARNING: The IncusOS API and configuration is subject to change
+
+config:
+  clusters:
+    ceph:
+      client_config: null
+      fsid: 7fb7b08a-ec49-4ec0-abb0-cd4e9b7089bb
+      keyrings:
+        admin:
+          key: AQD+6U9qzwiAEhAAriOdhjIAN53Oson6D0c1yg==
+      monitors:
+        - fd42:98b5:52c7:673d:1266:6aff:fefa:2cca
+        - fd42:98b5:52c7:673d:1266:6aff:fe4b:2007
+        - fd42:98b5:52c7:673d:1266:6aff:fe0a:310f
+  enabled: true
+state:
+  election_epoch: 22
+  fsid: 7fb7b08a-ec49-4ec0-abb0-cd4e9b7089bb
+  fsmap:
+    btime: 2026-07-09T19:27:42:293081+0000
+    epoch: 5
+  health:
+    status: HEALTH_OK
+
+[snip]
+
+
+```
+
+A minimal amount of configuration state is stored in Incus cluster-wide project configuration using keys with the `user.ceph.*` prefix. This is used to manage the deployment of OSDs at the Incus cluster level:
+
+```
+$ incus project show internal
+config:
+  user.ceph.fsid: 7fb7b08a-ec49-4ec0-abb0-cd4e9b7089bb
+  user.ceph.network: meshbr0
+```

--- a/incus-osd/api/application.go
+++ b/incus-osd/api/application.go
@@ -23,3 +23,9 @@ type Application struct {
 
 	Config ApplicationConfig `json:"config" yaml:"config"`
 }
+
+// ApplicationAction defines a generic struct that can be used when triggering an application-specific action.
+type ApplicationAction struct {
+	Action string            `json:"action"           yaml:"action"`
+	Config map[string]string `json:"config,omitempty" yaml:"config,omitempty"`
+}

--- a/incus-osd/api/service_ceph.go
+++ b/incus-osd/api/service_ceph.go
@@ -19,8 +19,71 @@ type ServiceCephConfig struct {
 	Clusters map[string]ServiceCephCluster `json:"clusters" yaml:"clusters"`
 }
 
-// ServiceCephState represents state for the Ceph service.
-type ServiceCephState struct{}
+// ServiceCephState represents state for the Ceph service. This largely matches most of the
+// output of running `ceph status --format=json`.
+type ServiceCephState struct {
+	FSID   string `json:"fsid,omitempty" yaml:"fsid,omitempty"`
+	Health *struct {
+		Status string `json:"status" yaml:"status"`
+		Checks map[string]struct {
+			Severity string `json:"severity" yaml:"severity"`
+			Summary  struct {
+				Message string `json:"message" yaml:"message"`
+				Count   int    `json:"count"   yaml:"count"`
+			} `json:"summary" yaml:"summary"`
+			Muted bool `json:"muted" yaml:"muted"`
+		} `json:"checks,omitempty" yaml:"checks,omitempty"`
+	} `json:"health,omitempty"         yaml:"health,omitempty"`
+	ElectionEpoch int      `json:"election_epoch,omitempty" yaml:"election_epoch,omitempty"`
+	Quorum        []int    `json:"quorum,omitempty"         yaml:"quorum,omitempty"`
+	QuorumNames   []string `json:"quorum_names,omitempty"   yaml:"quorum_names,omitempty"`
+	QuorumAge     int      `json:"quorum_age,omitempty"     yaml:"quorum_age,omitempty"`
+	Monmap        *struct {
+		Epoch             int    `json:"epoch"                yaml:"epoch"`
+		MinMonReleaseName string `json:"min_mon_release_name" yaml:"min_mon_release_name"`
+		NumMons           int    `json:"num_mons"             yaml:"num_mons"`
+	} `json:"monmap,omitempty" yaml:"monmap,omitempty"`
+	Osdmap *struct {
+		Epoch          int `json:"epoch"            yaml:"epoch"`
+		NumOsds        int `json:"num_osds"         yaml:"num_osds"`
+		NumUpOsds      int `json:"num_up_osds"      yaml:"num_up_osds"`
+		OsdUpSince     int `json:"osd_up_since"     yaml:"osd_up_since"`
+		NumInOsds      int `json:"num_in_osds"      yaml:"num_in_osds"`
+		OsdInSince     int `json:"osd_in_since"     yaml:"osd_in_since"`
+		NumRemappedPgs int `json:"num_remapped_pgs" yaml:"num_remapped_pgs"`
+	} `json:"osdmap,omitempty" yaml:"osdmap,omitempty"`
+	Pgmap *struct {
+		PgsByState []struct {
+			StateName string `json:"state_name" yaml:"state_name"`
+			Count     int    `json:"count"      yaml:"count"`
+		} `json:"pgs_by_state" yaml:"pgs_by_state"`
+		NumPgs      int `json:"num_pgs"      yaml:"num_pgs"`
+		NumPools    int `json:"num_pools"    yaml:"num_pools"`
+		NumProjects int `json:"num_objects"  yaml:"num_objects"`
+		DataBytes   int `json:"data_bytes"   yaml:"data_bytes"`
+		BytesUsed   int `json:"bytes_used"   yaml:"bytes_used"`
+		BytesAvail  int `json:"bytes_avail"  yaml:"bytes_avail"`
+		BytesTotal  int `json:"bytes_total"  yaml:"bytes_total"`
+	} `json:"pgmap,omitempty" yaml:"pgmap,omitempty"`
+	Fsmap *struct {
+		Epoch int    `json:"epoch" yaml:"epoch"`
+		Btime string `json:"btime" yaml:"btime"`
+	} `json:"fsmap,omitempty" yaml:"fsmap,omitempty"`
+	Mgrmap *struct {
+		Available   bool     `json:"available"    yaml:"available"`
+		NumStandbys int      `json:"num_standbys" yaml:"num_standbys"`
+		Modules     []string `json:"modules"      yaml:"modules"`
+	} `json:"mgrmap,omitempty" yaml:"mgrmap,omitempty"`
+	Servicemap *struct {
+		Epoch    int    `json:"epoch"    yaml:"epoch"`
+		Modified string `json:"modified" yaml:"modified"`
+
+		// The returned daemons are mostly proper structs, but there is a "status" field
+		// that's a regular string. This prevents a clean json umarshaling, so use
+		// `any` to handle this bit of the struct
+		Services map[string]map[string]map[string]any `json:"services" yaml:"services"`
+	} `json:"servicemap,omitempty" yaml:"servicemap,omitempty"`
+}
 
 // ServiceCeph represents the state and configuration of the Ceph service.
 type ServiceCeph struct {

--- a/incus-osd/cli/cli_applications.go
+++ b/incus-osd/cli/cli_applications.go
@@ -16,6 +16,18 @@ func (c *cmdAdminOSApplication) command() *cobra.Command {
 	cmd.Short = "Manage IncusOS applications"
 	cmd.Long = cli.FormatSection("Description", "Manage IncusOS applications")
 
+	// Action.
+	actionCmd := cmdGenericRun{
+		os:          c.os,
+		action:      "action",
+		description: "Perform application-specific action",
+		endpoint:    "applications",
+		entity:      "application",
+		hasData:     true,
+		defaultData: "{}",
+	}
+	cmd.AddCommand(actionCmd.command())
+
 	// Add.
 	addCmd := cmdGenericRun{
 		os:          c.os,

--- a/incus-osd/go.mod
+++ b/incus-osd/go.mod
@@ -1,6 +1,6 @@
 module github.com/lxc/incus-os/incus-osd
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/FuturFusion/migration-manager v0.6.14
@@ -25,6 +25,7 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.6
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
+	gopkg.in/ini.v1 v1.67.3
 	software.sslmate.com/src/go-pkcs12 v0.7.3
 	tailscale.com v1.94.2
 )

--- a/incus-osd/go.sum
+++ b/incus-osd/go.sum
@@ -329,6 +329,8 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/ini.v1 v1.67.3 h1:iM9Lhz5MRSGhHVGGwCuzG9KO8PoirCXj/m/qTmOJJQw=
+gopkg.in/ini.v1 v1.67.3/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/incus-osd/internal/applications/app_common.go
+++ b/incus-osd/internal/applications/app_common.go
@@ -18,6 +18,11 @@ type common struct {
 	appState *api.ApplicationState
 }
 
+// Action runs an application-specific action/task.
+func (*common) Action(_ context.Context, _ api.ApplicationAction) error {
+	return errors.New("not supported")
+}
+
 // AddTrustedCertificate adds a new trusted certificate to the application.
 func (*common) AddTrustedCertificate(_ context.Context, _ string, _ string) error {
 	return errors.New("not supported")

--- a/incus-osd/internal/applications/app_incus.go
+++ b/incus-osd/internal/applications/app_incus.go
@@ -36,10 +36,6 @@ const (
 	incusVersionLTS70  = "incus-lts-7.0"
 )
 
-type incusDebug struct {
-	Action string `json:"action"`
-}
-
 type incus struct {
 	common
 
@@ -110,7 +106,7 @@ func (a *incus) CanBeReplaced(ctx context.Context, otherAppName string) error {
 
 // Debug runs a debug action.
 func (*incus) Debug(ctx context.Context, data any) response.Response {
-	req, ok := data.(*incusDebug)
+	req, ok := data.(*api.ApplicationAction)
 	if !ok {
 		return response.BadRequest(errors.New("invalid request data type"))
 	}
@@ -133,7 +129,7 @@ func (*incus) Debug(ctx context.Context, data any) response.Response {
 
 // DebugStruct returns the struct to fill with debug request data.
 func (*incus) DebugStruct() any {
-	data := &incusDebug{}
+	data := &api.ApplicationAction{}
 
 	return data
 }

--- a/incus-osd/internal/applications/app_incus.go
+++ b/incus-osd/internal/applications/app_incus.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/lxc/incus-os/incus-osd/api"
 	apiseed "github.com/lxc/incus-os/incus-osd/api/seed"
+	"github.com/lxc/incus-os/incus-osd/internal/ceph"
 	"github.com/lxc/incus-os/incus-osd/internal/rest/response"
 	"github.com/lxc/incus-os/incus-osd/internal/seed"
 	"github.com/lxc/incus-os/incus-osd/internal/storage"
@@ -40,6 +41,16 @@ type incus struct {
 	common
 
 	incusVersion string
+}
+
+// Action runs an application-specific action/task.
+func (*incus) Action(ctx context.Context, data api.ApplicationAction) error {
+	switch data.Action {
+	case "initialize-ceph-cluster":
+		return ceph.InitializeCephCluster(ctx, data.Config)
+	default:
+		return errors.New("unsupported action '" + data.Action + "'")
+	}
 }
 
 // AddTrustedCertificate adds a new trusted certificate to the application.

--- a/incus-osd/internal/applications/app_incus_services.go
+++ b/incus-osd/internal/applications/app_incus_services.go
@@ -8,10 +8,25 @@ import (
 	"github.com/lxc/incus/v7/shared/subprocess"
 
 	"github.com/lxc/incus-os/incus-osd/api"
+	"github.com/lxc/incus-os/incus-osd/internal/ceph"
 )
 
 type incusCeph struct {
 	common
+}
+
+// Action runs an application-specific action/task.
+func (*incusCeph) Action(ctx context.Context, data api.ApplicationAction) error {
+	switch data.Action {
+	case "add-drive":
+		return ceph.AddOSD(ctx, data.Config)
+	case "refresh-images":
+		return ceph.RefreshCephOCIImages(ctx, data.Config)
+	case "remove-drive":
+		return ceph.RemoveOSD(ctx)
+	default:
+		return errors.New("unsupported action '" + data.Action + "'")
+	}
 }
 
 func (i *incusCeph) Get(_ context.Context) (any, error) {

--- a/incus-osd/internal/applications/struct.go
+++ b/incus-osd/internal/applications/struct.go
@@ -5,11 +5,13 @@ import (
 	"crypto/tls"
 	"io"
 
+	"github.com/lxc/incus-os/incus-osd/api"
 	"github.com/lxc/incus-os/incus-osd/internal/rest/response"
 )
 
 // Application represents an installed application.
 type Application interface { //nolint:interfacebloat
+	Action(ctx context.Context, data api.ApplicationAction) error
 	AddTrustedCertificate(ctx context.Context, name string, cert string) error
 	AvailableVersions() []string
 	CanBeReplaced(ctx context.Context, otherAppName string) error

--- a/incus-osd/internal/ceph/ceph-additional.sh
+++ b/incus-osd/internal/ceph/ceph-additional.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# shellcheck disable=SC1083
+
+# Setup the keyrings
+ceph mon getmap > /tmp/monmap
+
+# Setup the monitor
+mkdir -p /var/lib/ceph/mon/ceph-{{.INST_NAME}}
+ceph-mon --mkfs -i {{.INST_NAME}} --monmap /tmp/monmap --keyring /tmp/ceph.mon.keyring
+chown -R ceph:ceph /var/lib/ceph/mon/ceph-{{.INST_NAME}}
+systemctl enable --now ceph-mon@{{.INST_NAME}}.service
+
+# Setup the manager
+mkdir -p /var/lib/ceph/mgr/ceph-{{.INST_NAME}}
+ceph auth get-or-create mgr.{{.INST_NAME}} mon 'allow profile mgr' osd 'allow *' mds 'allow *' > /var/lib/ceph/mgr/ceph-{{.INST_NAME}}/keyring
+chown -R ceph:ceph /var/lib/ceph/mgr/ceph-{{.INST_NAME}}
+systemctl enable --now ceph-mgr@{{.INST_NAME}}.service
+
+# Setup the metadata service
+mkdir -p /var/lib/ceph/mds/ceph-{{.INST_NAME}}
+ceph auth get-or-create mds.{{.INST_NAME}} mon 'profile mds' mgr 'profile mds' mds 'allow *' osd 'allow *' > /var/lib/ceph/mds/ceph-{{.INST_NAME}}/keyring
+chown -R ceph:ceph /var/lib/ceph/mds/ceph-{{.INST_NAME}}
+systemctl enable --now ceph-mds@{{.INST_NAME}}.service
+
+# Setup the block device mirroring service
+ceph auth get-or-create client.rbd-mirror.{{.INST_NAME}} mon 'profile rbd-mirror' osd 'profile rbd' > /etc/ceph/ceph.client.rbd-mirror.{{.INST_NAME}}.keyring
+chown ceph:ceph /etc/ceph/ceph.client.rbd-mirror.{{.INST_NAME}}.keyring
+systemctl enable --now ceph-rbd-mirror@rbd-mirror.{{.INST_NAME}}.service

--- a/incus-osd/internal/ceph/ceph-initial.sh
+++ b/incus-osd/internal/ceph/ceph-initial.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# shellcheck disable=SC1083
+
+# Create ceph.conf
+(
+cat << EOG
+[global]
+fsid = {{.FSID}}
+mon_initial_members = {{.INST_NAME}}
+mon_host = [{{.INST_IPV6}}]
+ms_bind_ipv4 = false
+ms_bind_ipv6 = true
+public_network = {{.NET_IPV6}}
+EOG
+) > /etc/ceph/ceph.conf
+
+# Create the initial keyrings and map
+ceph-authtool --create-keyring /tmp/ceph.mon.keyring --gen-key -n mon. --cap mon 'allow *'
+ceph-authtool --create-keyring /etc/ceph/ceph.client.admin.keyring --gen-key -n client.admin --cap mon 'allow *' --cap osd 'allow *'  --cap mds 'allow *' --cap mgr 'allow *'
+ceph-authtool /tmp/ceph.mon.keyring --import-keyring /etc/ceph/ceph.client.admin.keyring
+chown ceph:ceph /tmp/ceph.mon.keyring
+monmaptool --create --add {{.INST_NAME}} [{{.INST_IPV6}}] --fsid {{.FSID}} /tmp/monmap
+
+# Setup the initial monitor
+mkdir -p /var/lib/ceph/mon/ceph-{{.INST_NAME}}
+ceph-mon --mkfs -i {{.INST_NAME}} --monmap /tmp/monmap --keyring /tmp/ceph.mon.keyring
+chown -R ceph:ceph /var/lib/ceph/mon/ceph-{{.INST_NAME}}
+systemctl enable --now ceph-mon@{{.INST_NAME}}.service
+
+# Apply some initial configuration
+ceph mon enable-msgr2
+ceph config set global auth_allow_insecure_global_id_reclaim false
+ceph config set global mon_allow_pool_delete true
+
+# Setup the initial manager
+mkdir -p /var/lib/ceph/mgr/ceph-{{.INST_NAME}}
+ceph auth get-or-create mgr.{{.INST_NAME}} mon 'allow profile mgr' osd 'allow *' mds 'allow *' > /var/lib/ceph/mgr/ceph-{{.INST_NAME}}/keyring
+chown -R ceph:ceph /var/lib/ceph/mgr/ceph-{{.INST_NAME}}
+systemctl enable --now ceph-mgr@{{.INST_NAME}}.service
+
+# Setup the initial metadata service
+mkdir -p /var/lib/ceph/mds/ceph-{{.INST_NAME}}
+ceph auth get-or-create mds.{{.INST_NAME}} mon 'profile mds' mgr 'profile mds' mds 'allow *' osd 'allow *' > /var/lib/ceph/mds/ceph-{{.INST_NAME}}/keyring
+chown -R ceph:ceph /var/lib/ceph/mds/ceph-{{.INST_NAME}}
+systemctl enable --now ceph-mds@{{.INST_NAME}}.service
+
+# Setup the initial block device mirroring service
+ceph auth get-or-create client.rbd-mirror.{{.INST_NAME}} mon 'profile rbd-mirror' osd 'profile rbd' > /etc/ceph/ceph.client.rbd-mirror.{{.INST_NAME}}.keyring
+chown ceph:ceph /etc/ceph/ceph.client.rbd-mirror.{{.INST_NAME}}.keyring
+systemctl enable --now ceph-rbd-mirror@rbd-mirror.{{.INST_NAME}}.service

--- a/incus-osd/internal/ceph/ceph-osd.sh
+++ b/incus-osd/internal/ceph/ceph-osd.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# shellcheck disable=SC1083
+
+# Wipe the disk
+wipefs -af /dev/ceph-1
+
+# Get a new OSD ID
+ID=$(ceph osd create)
+
+# Create filesystem structure
+mkdir -p "/var/lib/ceph/osd/ceph-${ID}"
+ln -s /dev/ceph-1 "/var/lib/ceph/osd/ceph-${ID}/block"
+uuidgen > "/var/lib/ceph/osd/ceph-${ID}/fsid"
+echo bluestore > "/var/lib/ceph/osd/ceph-${ID}/type"
+
+# Keyring generation
+ceph auth add "osd.${ID}" mgr 'allow profile osd' mon 'allow profile osd' osd 'allow *'
+ceph auth export "osd.${ID}" > "/var/lib/ceph/osd/ceph-${ID}/keyring"
+
+# Initialize the OSD
+ceph-osd --mkfs --no-mon-config -i "${ID}"
+
+# Fix permissions
+chown -R ceph:ceph /var/lib/ceph/osd/
+
+# Start the OSD
+systemctl enable --now "ceph-osd@${ID}"
+
+# Set device type
+sleep 5s
+ceph osd crush rm-device-class "${ID}"
+ceph osd crush set-device-class {{.DEVICE_CLASS}} "${ID}"

--- a/incus-osd/internal/ceph/ceph.go
+++ b/incus-osd/internal/ceph/ceph.go
@@ -1,0 +1,1164 @@
+package ceph
+
+import (
+	"bytes"
+	"context"
+	"embed"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"slices"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/google/uuid"
+	incus "github.com/lxc/incus/v7/client"
+	incusapi "github.com/lxc/incus/v7/shared/api"
+	"gopkg.in/ini.v1"
+
+	"github.com/lxc/incus-os/incus-osd/api"
+)
+
+//go:embed *.sh
+var embeddedScripts embed.FS
+
+var cephDockerHost = "quay.io"
+
+var cephDockerImage = "ceph/ceph:v20"
+
+var cephControlContainerNames = []string{"ceph-central01", "ceph-central02", "ceph-central03"}
+
+var projectName = "internal"
+
+type shTemplate struct {
+	DEVICE_CLASS string //nolint:revive
+	FSID         string //nolint:revive
+	INST_IPV6    string //nolint:revive
+	NET_IPV6     string //nolint:revive
+	INST_NAME    string //nolint:revive
+}
+
+type clusterConfigFiles struct {
+	Conf         []byte
+	AdminKeyring []byte
+	MonKeyring   []byte
+}
+
+type osdCreationInfo struct {
+	Host        string `json:"host"`
+	DeviceID    string `json:"device_id"`
+	DeviceClass string `json:"device_class"`
+}
+
+// InitializeCephCluster creates an initial Ceph cluster consisting of three control plane
+// servers. OSDs must be added separately. It also ensures the "incus-ceph" application is
+// installed on each member of the Incus cluster, and that the Ceph service is properly configured.
+//
+// Configuration fields:
+//
+//	control_servers -- A comma-separated list of three Incus servers to use for hosting the Ceph control plane.
+//	                   If not specified, the first three reported cluster members will be used.
+//	network -- The Incus network for the Ceph cluster to use. If not specified, defaults to "meshbr0".
+func InitializeCephCluster(ctx context.Context, config map[string]string) error {
+	incusClient, err := incus.ConnectIncusUnixWithContext(ctx, "", nil)
+	if err != nil {
+		return err
+	}
+
+	//
+	// Start by checking the provided configuration.
+	//
+
+	if config == nil {
+		config = make(map[string]string)
+	}
+
+	// If no network was provided, supply a default.
+	if config["network"] == "" {
+		config["network"] = "meshbr0"
+	}
+
+	// Ensure the specified network exists.
+	_, _, err = incusClient.GetNetwork(config["network"])
+	if err != nil {
+		return errors.New("the Incus network '" + config["network"] + "' doesn't exist")
+	}
+
+	// Ensure the 'internal' project exists.
+	project, projectEtag, err := incusClient.GetProject(projectName)
+	if err != nil {
+		return errors.New("the Incus project '" + projectName + "' doesn't exist")
+	}
+
+	// Ensure we're running in an Incus cluster.
+	if !incusClient.IsClustered() {
+		return errors.New("can only deploy Ceph in an Incus cluster")
+	}
+
+	clusterMembers, err := incusClient.GetClusterMembers()
+	if err != nil {
+		return err
+	}
+
+	// Ensure the cluster consists of at least three members.
+	if len(clusterMembers) < 3 {
+		return errors.New("the Incus cluster must consist of at least three servers")
+	}
+
+	// Ensure that each cluster member is online and doesn't have a Ceph service already configured.
+	for _, member := range clusterMembers {
+		if member.Status != "Online" {
+			return errors.New("Incus server '" + member.ServerName + "' state isn't Online: " + member.Status)
+		}
+
+		// Get the current ceph service configuration, if any.
+		cephService := api.ServiceCeph{}
+
+		resp, _, err := incusClient.RawQuery("GET", "/os/1.0/services/ceph?target="+member.ServerName, nil, "")
+		if err == nil {
+			err := json.Unmarshal(resp.Metadata, &cephService)
+			if err != nil {
+				return err
+			}
+
+			_, exists := cephService.Config.Clusters["ceph"]
+			if exists {
+				return errors.New("the Ceph service is already configured for cluster 'ceph' on Incus Server '" + member.ServerName + "'")
+			}
+		}
+	}
+
+	controlServers := []string{}
+
+	if config["control_servers"] != "" {
+		controlServers = strings.Split(config["control_servers"], ",")
+	}
+
+	// Ensure valid members were specified for hosting the Ceph control plane.
+	switch len(controlServers) {
+	case 0:
+		// If no specific Incus servers were specified, arbitrarily pick the first three
+		// reported cluster members.
+		for i := range 3 {
+			controlServers = append(controlServers, clusterMembers[i].ServerName)
+		}
+	case 3:
+		// If three specific Incus servers were specified, make sure they exist.
+		for i := range 3 {
+			if !slices.ContainsFunc(clusterMembers, func(m incusapi.ClusterMember) bool {
+				return m.ServerName == controlServers[i]
+			}) {
+				return errors.New("specified Incus server '" + controlServers[i] + "' isn't a member of the cluster")
+			}
+		}
+	default:
+		return errors.New("exactly zero or three Incus servers must be defined for hosting the Ceph data plane")
+	}
+
+	incusClient = incusClient.UseProject(projectName)
+
+	// Check if any of the Ceph control plane containers currently exist.
+	for _, srv := range cephControlContainerNames {
+		_, _, err := incusClient.GetInstance(srv)
+		if err == nil {
+			return errors.New("a Ceph container '" + srv + "' currently exists; refusing to attempt to initialize a new Ceph cluster")
+		}
+	}
+
+	//
+	// Ensure the "incus-ceph" application is installed on each cluster member.
+	//
+
+	type applicationPost struct {
+		Name string `json:"name"`
+	}
+
+	for _, member := range clusterMembers {
+		resp, _, err := incusClient.RawQuery("POST", "/os/1.0/applications?target="+member.ServerName, applicationPost{Name: "incus-ceph"}, "")
+		if err != nil && err.Error() != "already exists" {
+			return err
+		} else if resp.StatusCode != http.StatusOK && resp.Error != "already exists" {
+			return errors.New("bad response: " + resp.Error)
+		}
+	}
+
+	//
+	// Save cluster-wide Ceph configuration.
+	//
+
+	project.Config["user.ceph.fsid"] = uuid.NewString()
+	project.Config["user.ceph.network"] = config["network"]
+
+	err = incusClient.UpdateProject(projectName, project.ProjectPut, projectEtag)
+	if err != nil {
+		return err
+	}
+
+	//
+	// Deploy the Ceph control plane.
+	//
+
+	// Deploy the initial Ceph control plane server.
+	err = deployCephContainer(ctx, controlServers[0], cephControlContainerNames[0], "ceph-initial.sh", nil)
+	if err != nil {
+		return err
+	}
+
+	// Deploy the other two Ceph control plane servers.
+	for i, srv := range cephControlContainerNames[1:] {
+		err := deployCephContainer(ctx, controlServers[i+1], srv, "ceph-additional.sh", nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	//
+	// Configure the IncusOS Ceph service on each cluster member.
+	//
+
+	cephConfigFiles, err := getCephClusterConfigFiles(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Extract the client key.
+	parsedConfig, err := ini.Load(cephConfigFiles.AdminKeyring)
+	if err != nil {
+		return err
+	}
+
+	clientKey, err := parsedConfig.Section("client.admin").Key("key").String(), nil
+	if err != nil {
+		return err
+	}
+
+	monAddrs := []string{}
+
+	// Get the IP of each Ceph monitor.
+	for _, cephServerName := range cephControlContainerNames {
+		ipv6Addr, err := getInstanceIPv6Addr(ctx, cephServerName)
+		if err != nil {
+			return err
+		}
+
+		monAddrs = append(monAddrs, ipv6Addr)
+	}
+
+	// For each member of the cluster, ensure the incus-ceph service is properly configured.
+	// Using incusClient.UseTarget(host.IncusServerName) to properly switch targets
+	// doesn't work with raw queries.
+	for _, member := range clusterMembers {
+		// Get the current ceph service configuration.
+		cephService := api.ServiceCeph{}
+
+		resp, _, err := incusClient.RawQuery("GET", "/os/1.0/services/ceph?target="+member.ServerName, nil, "")
+		if err != nil {
+			return err
+		} else if resp.StatusCode != http.StatusOK {
+			return errors.New("bad response: " + resp.Error)
+		}
+
+		err = json.Unmarshal(resp.Metadata, &cephService)
+		if err != nil {
+			return err
+		}
+
+		// Ensure the service is enabled.
+		cephService.Config.Enabled = true
+
+		if cephService.Config.Clusters == nil {
+			cephService.Config.Clusters = make(map[string]api.ServiceCephCluster)
+		}
+
+		// Inform the service about our Ceph cluster.
+		cephService.Config.Clusters["ceph"] = api.ServiceCephCluster{
+			FSID:     project.Config["user.ceph.fsid"],
+			Monitors: monAddrs,
+			Keyrings: map[string]api.ServiceCephKeyring{
+				"admin": {
+					Key: clientKey,
+				},
+			},
+		}
+
+		// Update the ceph service configuration.
+		resp, _, err = incusClient.RawQuery("PUT", "/os/1.0/services/ceph?target="+member.ServerName, cephService, "")
+		if err != nil {
+			return err
+		} else if resp.StatusCode != http.StatusOK {
+			return errors.New("bad response: " + resp.Error)
+		}
+	}
+
+	return nil
+}
+
+// AddOSD adds a Ceph OSD with storage backing from the local server.
+//
+// Configuration fields:
+//
+//	device_id -- The ID of the raw device that should be used by the OSD. Will be LUKS
+//	             encrypted if not already encrypted prior to use.
+func AddOSD(ctx context.Context, config map[string]string) error {
+	incusClient, err := incus.ConnectIncusUnixWithContext(ctx, "", nil)
+	if err != nil {
+		return err
+	}
+
+	server, _, err := incusClient.GetServer()
+	if err != nil {
+		return err
+	}
+
+	//
+	// Check that there's not already an OSD on this host.
+	//
+
+	osdHosts, err := getOSDHosts(ctx)
+	if err != nil {
+		return err
+	}
+
+	if slices.Contains(osdHosts, server.Environment.ServerName) {
+		return errors.New("a Ceph OSD instance already exists on Incus server " + server.Environment.ServerName)
+	}
+
+	//
+	// Ensure the local raw device is encrypted.
+	//
+
+	encryptedDeviceID, deviceClass, err := ensureDeviceIsEncrypted(ctx, config["device_id"])
+	if err != nil {
+		return err
+	}
+
+	//
+	// Create the new OSD instance.
+	//
+
+	err = deployCephContainer(ctx, server.Environment.ServerName, "ceph-osd-"+server.Environment.ServerName, "ceph-osd.sh", &osdCreationInfo{
+		Host:        server.Environment.ServerName,
+		DeviceID:    encryptedDeviceID,
+		DeviceClass: deviceClass,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RefreshCephOCIImages refreshes the OCI image used by the Ceph containers.
+//
+// Configuration fields:
+//
+//	oci_tag -- Optional; if specified, set the Ceph OCI image tag to the provided value.
+//	           This is useful for performing major version updates, such as from v19 to
+//	           v20, or pinning to an exact version.
+func RefreshCephOCIImages(ctx context.Context, config map[string]string) error {
+	incusClient, err := incus.ConnectIncusUnixWithContext(ctx, "", nil)
+	if err != nil {
+		return err
+	}
+
+	incusClient = incusClient.UseProject(projectName)
+
+	cephContainers := cephControlContainerNames
+
+	// Add any existing OSDs to the list of containers to refresh.
+	osdHosts, err := getOSDHosts(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, host := range osdHosts {
+		cephContainers = append(cephContainers, "ceph-osd-"+host)
+	}
+
+	for _, containerName := range cephContainers {
+		var imageAlias string
+
+		if config["oci_tag"] != "" {
+			imageAlias = "ceph/ceph:" + config["oci_tag"]
+		} else {
+			instance, _, err := incusClient.GetInstance(containerName)
+			if err != nil {
+				return err
+			}
+
+			imageAlias = instance.Config["image.id"]
+		}
+
+		err := refreshCephOCIImage(ctx, containerName, imageAlias)
+		if err != nil {
+			return err
+		}
+
+		// Sleep a few seconds to allow Ceph to stabilize its state.
+		time.Sleep(10 * time.Second)
+	}
+
+	return nil
+}
+
+// RemoveOSD removes a Ceph OSD from the local server. Because Ceph requires a minimum of
+// three OSDs, removal won't be allowed if there are currently three or fewer OSDs.
+//
+// WARNING -- This will forcefully remove the OSD from the Ceph cluster. Prior to removal,
+// you should remove the OSD via Ceph's API and wait for data migration to complete.
+func RemoveOSD(ctx context.Context) error {
+	incusClient, err := incus.ConnectIncusUnixWithContext(ctx, "", nil)
+	if err != nil {
+		return err
+	}
+
+	server, _, err := incusClient.GetServer()
+	if err != nil {
+		return err
+	}
+
+	incusClient = incusClient.UseProject(projectName)
+
+	//
+	// Check if it's possible to remove the OSD.
+	//
+
+	osdHosts, err := getOSDHosts(ctx)
+	if err != nil {
+		return err
+	}
+
+	if !slices.Contains(osdHosts, server.Environment.ServerName) {
+		return errors.New("no Ceph OSD instance exists on Incus server " + server.Environment.ServerName)
+	}
+
+	if len(osdHosts) <= 3 {
+		return errors.New("a minimum of three OSDs are required by Ceph; refusing to remove OSD from Incus server " + server.Environment.ServerName)
+	}
+
+	//
+	// Delete the OSD.
+	//
+
+	op, err := incusClient.UpdateInstanceState("ceph-osd-"+server.Environment.ServerName, incusapi.InstanceStatePut{
+		Action:  "stop",
+		Timeout: -1,
+	}, "")
+	if err != nil {
+		return err
+	}
+
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+
+	op, err = incusClient.DeleteInstance("ceph-osd-" + server.Environment.ServerName)
+	if err != nil {
+		return err
+	}
+
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deployCephContainer(ctx context.Context, incusTarget string, cephContainerName string, configScript string, osd *osdCreationInfo) error {
+	incusClient, err := incus.ConnectIncusUnixWithContext(ctx, "", nil)
+	if err != nil {
+		return err
+	}
+
+	incusClient = incusClient.UseProject(projectName)
+	incusClient = incusClient.UseTarget(incusTarget)
+
+	project, _, err := incusClient.GetProject(projectName)
+	if err != nil {
+		return err
+	}
+
+	// Create a storage volume for /etc/ceph/ and /var/lib/ceph/.
+	err = incusClient.CreateStoragePoolVolume("local", incusapi.StorageVolumesPost{
+		Name: cephContainerName + "-data",
+		Type: "custom",
+	})
+	if err != nil {
+		return err
+	}
+
+	// Download the OCI image.
+	err = fetchOCIImage(ctx, cephDockerImage)
+	if err != nil {
+		return err
+	}
+
+	// Prepare the container's configuration and devices.
+	config := map[string]string{
+		"oci.entrypoint":   "/sbin/init",
+		"cluster.evacuate": "stop",
+	}
+
+	devices := map[string]map[string]string{
+		"eth0": {
+			"type":    "nic",
+			"network": project.Config["user.ceph.network"],
+		},
+		"etc": {
+			"type":      "disk",
+			"pool":      "local",
+			"source":    cephContainerName + "-data/etc",
+			"path":      "/etc/ceph/",
+			"dependent": "true",
+		},
+		"var": {
+			"type":      "disk",
+			"pool":      "local",
+			"source":    cephContainerName + "-data/var",
+			"path":      "/var/lib/ceph/",
+			"dependent": "true",
+		},
+	}
+
+	if configScript == "ceph-osd.sh" {
+		devices["ceph-1"] = map[string]string{
+			"type":   "unix-block",
+			"source": osd.DeviceID,
+			"path":   "/dev/ceph-1",
+			"uid":    "167",
+			"gid":    "167",
+		}
+	}
+
+	// Create and start the Ceph server.
+	op, err := incusClient.CreateInstance(incusapi.InstancesPost{
+		Name: cephContainerName,
+		InstancePut: incusapi.InstancePut{
+			Config:  config,
+			Devices: devices,
+		},
+		Source: incusapi.InstanceSource{
+			Type:  "image",
+			Alias: cephDockerHost + "/" + cephDockerImage,
+		},
+		Type:  "container",
+		Start: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+
+	// Allow the container to start up.
+	time.Sleep(5 * time.Second)
+
+	var buf bytes.Buffer
+
+	var templateVars shTemplate
+
+	switch configScript {
+	case "ceph-initial.sh":
+		// Get the IPv6 network that Ceph will be using.
+		network, _, err := incusClient.GetNetwork(project.Config["user.ceph.network"])
+		if err != nil {
+			return err
+		}
+
+		ipv6Net := network.Config["ipv6.address"]
+
+		// Get the IPv6 address of the new Ceph container.
+		ipv6Addr, err := getInstanceIPv6Addr(ctx, cephContainerName)
+		if err != nil {
+			return err
+		}
+
+		templateVars = shTemplate{
+			FSID:      project.Config["user.ceph.fsid"],
+			INST_IPV6: ipv6Addr,
+			NET_IPV6:  ipv6Net,
+			INST_NAME: cephContainerName,
+		}
+	case "ceph-additional.sh":
+		templateVars = shTemplate{
+			INST_NAME: cephContainerName,
+		}
+
+		cephConfigFiles, err := getCephClusterConfigFiles(ctx)
+		if err != nil {
+			return err
+		}
+
+		sftpConn, err := incusClient.GetInstanceFileSFTP(cephContainerName)
+		if err != nil {
+			return err
+		}
+
+		defer sftpConn.Close()
+
+		// Push configuration files.
+		file, err := sftpConn.OpenFile("/etc/ceph/ceph.conf", os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
+		if err != nil {
+			return err
+		}
+
+		_, err = file.Write(cephConfigFiles.Conf)
+		if err != nil {
+			return err
+		}
+
+		_ = file.Close()
+
+		file, err = sftpConn.OpenFile("/etc/ceph/ceph.client.admin.keyring", os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
+		if err != nil {
+			return err
+		}
+
+		_, err = file.Write(cephConfigFiles.AdminKeyring)
+		if err != nil {
+			return err
+		}
+
+		_ = file.Close()
+
+		file, err = sftpConn.OpenFile("/tmp/ceph.mon.keyring", os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
+		if err != nil {
+			return err
+		}
+
+		_, err = file.Write(cephConfigFiles.MonKeyring)
+		if err != nil {
+			return err
+		}
+
+		_ = file.Close()
+	case "ceph-osd.sh":
+		templateVars = shTemplate{
+			DEVICE_CLASS: osd.DeviceClass,
+		}
+
+		cephConfigFiles, err := getCephClusterConfigFiles(ctx)
+		if err != nil {
+			return err
+		}
+
+		sftpConn, err := incusClient.GetInstanceFileSFTP(cephContainerName)
+		if err != nil {
+			return err
+		}
+
+		defer sftpConn.Close()
+
+		// Push configuration files.
+		file, err := sftpConn.OpenFile("/etc/ceph/ceph.conf", os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
+		if err != nil {
+			return err
+		}
+
+		_, err = file.Write(cephConfigFiles.Conf)
+		if err != nil {
+			return err
+		}
+
+		_ = file.Close()
+
+		file, err = sftpConn.OpenFile("/etc/ceph/ceph.client.admin.keyring", os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
+		if err != nil {
+			return err
+		}
+
+		_, err = file.Write(cephConfigFiles.AdminKeyring)
+		if err != nil {
+			return err
+		}
+
+		_ = file.Close()
+	default:
+		return errors.New("unrecognized configuration script: " + configScript)
+	}
+
+	// Parse and render the script template.
+	t, err := template.ParseFS(embeddedScripts, configScript)
+	if err != nil {
+		return err
+	}
+
+	err = t.Execute(&buf, templateVars)
+	if err != nil {
+		return err
+	}
+
+	// Execute the configuration script.
+	op, err = incusClient.ExecInstance(cephContainerName, incusapi.InstanceExecPost{
+		Command:     []string{"sh", "-eux"},
+		WaitForWS:   true,
+		Interactive: false,
+	}, &incus.InstanceExecArgs{
+		Stdin:  &buf,
+		Stdout: nil,
+		Stderr: nil,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ensureDeviceIsEncrypted(ctx context.Context, deviceID string) (string, string, error) {
+	incusClient, err := incus.ConnectIncusUnixWithContext(ctx, "", nil)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Note: Every interaction with Incus in this function is calling an IncusOS API
+	//       endpoint on the local host, so there's no need to set a project or target.
+
+	resp, _, err := incusClient.RawQuery("GET", "/os/1.0/system/storage", nil, "")
+	if err != nil {
+		return "", "", err
+	} else if resp.StatusCode != http.StatusOK {
+		return "", "", errors.New("bad response: " + resp.Error)
+	}
+
+	storageInfo := api.SystemStorage{}
+
+	err = json.Unmarshal(resp.Metadata, &storageInfo)
+	if err != nil {
+		return "", "", err
+	}
+
+	i := slices.IndexFunc(storageInfo.State.Drives, func(drive api.SystemStorageDrive) bool {
+		return drive.ID == deviceID
+	})
+
+	if i < 0 {
+		return "", "", errors.New("specified raw device '" + deviceID + "' doesn't exist")
+	}
+
+	// Determine the Ceph device class.
+	var deviceClass string
+
+	switch storageInfo.State.Drives[i].Bus {
+	case "nvme":
+		deviceClass = "nvme"
+	case "scsi":
+		deviceClass = "sdd"
+	default:
+		deviceClass = "hdd"
+	}
+
+	// If the drive is currently encrypted, return its encrypted device ID and class
+	// as there's nothing else we need to do.
+	if storageInfo.State.Drives[i].Encrypted {
+		return storageInfo.State.Drives[i].EncryptedID, deviceClass, nil
+	}
+
+	// Encrypt the storage device.
+	resp, _, err = incusClient.RawQuery("POST", "/os/1.0/system/storage/:encrypt-drive", api.SystemStorageEncrypt{ID: deviceID}, "")
+	if err != nil {
+		return "", "", err
+	} else if resp.StatusCode != http.StatusOK {
+		return "", "", errors.New("bad response: " + resp.Error)
+	}
+
+	// Get updated storage state and record the device's encrypted ID.
+	resp, _, err = incusClient.RawQuery("GET", "/os/1.0/system/storage", nil, "")
+	if err != nil {
+		return "", "", err
+	} else if resp.StatusCode != http.StatusOK {
+		return "", "", errors.New("bad response: " + resp.Error)
+	}
+
+	storageInfo = api.SystemStorage{}
+
+	err = json.Unmarshal(resp.Metadata, &storageInfo)
+	if err != nil {
+		return "", "", err
+	}
+
+	i = slices.IndexFunc(storageInfo.State.Drives, func(drive api.SystemStorageDrive) bool {
+		return drive.ID == deviceID
+	})
+
+	return storageInfo.State.Drives[i].EncryptedID, deviceClass, nil
+}
+
+func fetchOCIImage(ctx context.Context, imageAlias string) error {
+	incusClient, err := incus.ConnectIncusUnixWithContext(ctx, "", nil)
+	if err != nil {
+		return err
+	}
+
+	incusClient = incusClient.UseProject(projectName)
+
+	// Check if this OCI image is already present locally.
+	_, _, err = incusClient.GetImageAlias(cephDockerHost + "/" + imageAlias)
+	if err == nil {
+		// If the OCI image already exists, there's nothing to do.
+		return nil
+	}
+
+	op, err := incusClient.CreateImage(incusapi.ImagesPost{
+		Source: &incusapi.ImagesPostSource{
+			Type: "image",
+			ImageSource: incusapi.ImageSource{
+				Alias:    imageAlias,
+				Server:   "https://" + cephDockerHost,
+				Protocol: "oci",
+			},
+		},
+		Aliases: []incusapi.ImageAlias{
+			{Name: cephDockerHost + "/" + imageAlias},
+		},
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getCephClusterConfigFiles(ctx context.Context) (*clusterConfigFiles, error) {
+	incusClient, err := incus.ConnectIncusUnixWithContext(ctx, "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	incusClient = incusClient.UseProject(projectName)
+
+	sftpConn, err := incusClient.GetInstanceFileSFTP(cephControlContainerNames[0])
+	if err != nil {
+		return nil, err
+	}
+
+	defer sftpConn.Close()
+
+	// Grab required configuration files from the initial Ceph server.
+	ret := &clusterConfigFiles{}
+
+	reader, err := sftpConn.Open("/etc/ceph/ceph.conf")
+	if err != nil {
+		return nil, err
+	}
+
+	ret.Conf, err = io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	_ = reader.Close()
+
+	reader, err = sftpConn.Open("/etc/ceph/ceph.client.admin.keyring")
+	if err != nil {
+		return nil, err
+	}
+
+	ret.AdminKeyring, err = io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	_ = reader.Close()
+
+	reader, err = sftpConn.Open("/var/lib/ceph/mon/ceph-" + cephControlContainerNames[0] + "/keyring")
+	if err != nil {
+		return nil, err
+	}
+
+	ret.MonKeyring, err = io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	_ = reader.Close()
+
+	return ret, nil
+}
+
+func getInstanceIPv6Addr(ctx context.Context, instanceName string) (string, error) {
+	incusClient, err := incus.ConnectIncusUnixWithContext(ctx, "", nil)
+	if err != nil {
+		return "", err
+	}
+
+	incusClient = incusClient.UseProject(projectName)
+
+	ret := ""
+
+	instanceState, _, err := incusClient.GetInstanceState(instanceName)
+	if err != nil {
+		return "", err
+	}
+
+	for _, network := range instanceState.Network {
+		for _, addr := range network.Addresses {
+			if addr.Family == "inet6" && !strings.HasPrefix(addr.Address, "fe80::") && addr.Address != "::1" {
+				ret = addr.Address
+
+				break
+			}
+		}
+
+		if ret != "" {
+			break
+		}
+	}
+
+	if ret == "" {
+		return "", errors.New("unable to determine IPv6 address for " + instanceName)
+	}
+
+	return ret, nil
+}
+
+func refreshCephOCIImage(ctx context.Context, containerName string, imageAlias string) error {
+	// Temporarily add /opt/incus/bin to $PATH so the skopeo binary bundled with Incus
+	// can be found. We don't just add /opt/incus/bin to the incus-osd service definition
+	// because of conflicts with various tpm2_* commands.
+	originalPath := os.Getenv("PATH")
+
+	err := os.Setenv("PATH", originalPath+":/opt/incus/bin")
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = os.Setenv("PATH", originalPath)
+	}()
+
+	incusClient, err := incus.ConnectIncusUnixWithContext(ctx, "", nil)
+	if err != nil {
+		return err
+	}
+
+	incusClient = incusClient.UseProject(projectName)
+
+	var existingImageFingerprint string
+
+	// Determine if the OCI image currently exists locally.
+	images, err := incusClient.GetImages()
+	if err != nil {
+		return err
+	}
+
+	i := slices.IndexFunc(images, func(image incusapi.Image) bool {
+		return slices.ContainsFunc(image.Aliases, func(alias incusapi.ImageAlias) bool {
+			return alias.Name == cephDockerHost+"/"+imageAlias
+		})
+	})
+
+	if i >= 0 {
+		existingImageFingerprint = images[i].Fingerprint
+	}
+
+	// Get the fingerprint of the remote OCI image.
+	ociRemote, err := incus.ConnectOCI("https://"+cephDockerHost, nil)
+	if err != nil {
+		return err
+	}
+
+	alias, _, err := ociRemote.GetImageAlias(imageAlias)
+	if err != nil {
+		if strings.Contains(err.Error(), "manifest unknown") {
+			return errors.New("OCI image '" + cephDockerHost + "/" + imageAlias + "' doesn't exist")
+		}
+
+		return err
+	}
+
+	remoteImageFingerprint := alias.Target
+
+	// If the new OCI image fingerprint is different than it was previously, the container
+	// will need to be refreshed.
+	containerNeedsRefresh := existingImageFingerprint != remoteImageFingerprint
+
+	// Check if the new OCI alias no longer matches the container's, for example a major version bump.
+	if !containerNeedsRefresh {
+		instance, _, err := incusClient.GetInstance(containerName)
+		if err != nil {
+			return err
+		}
+
+		containerNeedsRefresh = instance.Config["image.id"] != imageAlias
+	}
+
+	// Return early if the container is running the latest version of the OCI image.
+	if !containerNeedsRefresh {
+		return nil
+	}
+
+	// Fetch the remote OCI image if not present locally.
+	if existingImageFingerprint != remoteImageFingerprint {
+		// If we currently have an older version of the OCI image, delete it
+		// before downloading the latest version.
+		if existingImageFingerprint != "" {
+			op, err := incusClient.DeleteImage(existingImageFingerprint)
+			if err != nil {
+				return err
+			}
+
+			err = op.Wait()
+			if err != nil {
+				return err
+			}
+		}
+
+		// Download the remote OCI image.
+		err = fetchOCIImage(ctx, imageAlias)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Stop the container.
+	op, err := incusClient.UpdateInstanceState(containerName, incusapi.InstanceStatePut{
+		Action:  "stop",
+		Timeout: -1,
+	}, "")
+	if err != nil {
+		return err
+	}
+
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+
+	// Rebuild the container's rootfs.
+	op, err = incusClient.RebuildInstance(containerName, incusapi.InstanceRebuildPost{
+		Source: incusapi.InstanceSource{
+			Type:  "image",
+			Alias: cephDockerHost + "/" + imageAlias,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+
+	// Update the container's image.id property.
+	instance, etag, err := incusClient.GetInstance(containerName)
+	if err != nil {
+		return err
+	}
+
+	instance.Config["image.id"] = imageAlias
+
+	op, err = incusClient.UpdateInstance(containerName, instance.InstancePut, etag)
+	if err != nil {
+		return err
+	}
+
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+
+	// Start the container.
+	op, err = incusClient.UpdateInstanceState(containerName, incusapi.InstanceStatePut{
+		Action:  "start",
+		Timeout: -1,
+	}, "")
+	if err != nil {
+		return err
+	}
+
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+
+	// Allow the container to start up.
+	time.Sleep(5 * time.Second)
+
+	// Re-enable the various systemd services.
+	if !strings.HasPrefix(containerName, "ceph-osd-") {
+		for _, serviceName := range []string{"ceph-mon@" + containerName + ".service", "ceph-mgr@" + containerName + ".service", "ceph-mds@" + containerName + ".service", "ceph-rbd-mirror@rbd-mirror." + containerName + ".service"} {
+			op, err := incusClient.ExecInstance(containerName, incusapi.InstanceExecPost{
+				Command:     []string{"systemctl", "enable", "--now", serviceName},
+				WaitForWS:   true,
+				Interactive: false,
+			}, &incus.InstanceExecArgs{
+				Stdin:  nil,
+				Stdout: nil,
+				Stderr: nil,
+			})
+			if err != nil {
+				return err
+			}
+
+			err = op.Wait()
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		op, err := incusClient.ExecInstance(containerName, incusapi.InstanceExecPost{
+			Command:     []string{"sh", "-ceux", `systemctl enable --now "ceph-osd@$(ls /var/lib/ceph/osd/ | cut -d '-' -f 2)"`},
+			WaitForWS:   true,
+			Interactive: false,
+		}, &incus.InstanceExecArgs{
+			Stdin:  nil,
+			Stdout: nil,
+			Stderr: nil,
+		})
+		if err != nil {
+			return err
+		}
+
+		err = op.Wait()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Return a list of Incus servers that currently host an OSD.
+func getOSDHosts(ctx context.Context) ([]string, error) {
+	incusClient, err := incus.ConnectIncusUnixWithContext(ctx, "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	incusClient = incusClient.UseProject(projectName)
+
+	instances, err := incusClient.GetInstances("container")
+	if err != nil {
+		return nil, err
+	}
+
+	ret := []string{}
+
+	for _, i := range instances {
+		if strings.HasPrefix(i.Name, "ceph-osd-") {
+			ret = append(ret, i.Location)
+		}
+	}
+
+	return ret, nil
+}

--- a/incus-osd/internal/ceph/doc.go
+++ b/incus-osd/internal/ceph/doc.go
@@ -1,0 +1,2 @@
+// Package ceph contains methods to initialize and configure a Ceph cluster hosted in an IncusOS cluster.
+package ceph

--- a/incus-osd/internal/rest/api_applications.go
+++ b/incus-osd/internal/rest/api_applications.go
@@ -389,6 +389,74 @@ func (s *Server) apiApplicationsEndpoint(w http.ResponseWriter, r *http.Request)
 	}
 }
 
+// swagger:operation POST /1.0/applications/{name}/:action applications applications_post_action
+//
+//	Perform an application-specific action
+//
+//	Triggers the given application to perform a specific task.
+//
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: path
+//	    name: name
+//	    description: Application name
+//	    required: true
+//	    type: string
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
+func (s *Server) apiApplicationsAction(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method != http.MethodPost {
+		_ = response.NotImplemented(nil).Render(w)
+
+		return
+	}
+
+	name := r.PathValue("name")
+
+	// Load the application.
+	app, err := applications.Load(r.Context(), s.state, name)
+	if err != nil {
+		_ = response.NotFound(nil).Render(w)
+
+		return
+	}
+
+	if !app.IsInstalled() {
+		_ = response.NotFound(nil).Render(w)
+
+		return
+	}
+
+	// Trigger the specific action.
+	data := api.ApplicationAction{}
+	decoder := json.NewDecoder(r.Body)
+
+	err = decoder.Decode(&data)
+	if err != nil {
+		_ = response.InternalError(err).Render(w)
+
+		return
+	}
+
+	err = app.Action(r.Context(), data)
+	if err != nil {
+		_ = response.InternalError(err).Render(w)
+
+		return
+	}
+
+	_ = response.EmptySyncResponse.Render(w)
+}
+
 // swagger:operation POST /1.0/applications/{name}/:debug applications applications_post_debug
 //
 //	Perform debug actions or retrieve debug data for an application

--- a/incus-osd/internal/rest/server.go
+++ b/incus-osd/internal/rest/server.go
@@ -43,6 +43,7 @@ func (s *Server) Serve() error {
 	router.HandleFunc("/1.0", s.apiRoot10)
 	router.HandleFunc("/1.0/applications", s.apiApplications)
 	router.HandleFunc("/1.0/applications/{name}", s.apiApplicationsEndpoint)
+	router.HandleFunc("/1.0/applications/{name}/:action", s.apiApplicationsAction)
 	router.HandleFunc("/1.0/applications/{name}/:backup", s.apiApplicationsBackup)
 	router.HandleFunc("/1.0/applications/{name}/:check-update", s.apiApplicationsCheckUpdate)
 	router.HandleFunc("/1.0/applications/{name}/:debug", s.apiApplicationsDebug)

--- a/incus-osd/internal/services/service_ceph.go
+++ b/incus-osd/internal/services/service_ceph.go
@@ -2,11 +2,15 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
+
+	"github.com/lxc/incus/v7/shared/subprocess"
 
 	"github.com/lxc/incus-os/incus-osd/api"
 	"github.com/lxc/incus-os/incus-osd/internal/state"
@@ -20,10 +24,27 @@ type Ceph struct {
 }
 
 // Get returns the current service state.
-func (n *Ceph) Get(_ context.Context) (any, error) {
+func (n *Ceph) Get(ctx context.Context) (any, error) {
 	// Initialize target list if missing.
 	if n.state.Services.Ceph.Config.Clusters == nil {
 		n.state.Services.Ceph.Config.Clusters = map[string]api.ServiceCephCluster{}
+	}
+
+	// Get current Ceph cluster status, if the service is enabled.
+	if n.state.Services.Ceph.Config.Enabled {
+		n.state.Services.Ceph.State = api.ServiceCephState{}
+
+		// Setup a timeout context, as `ceph status` hangs if the Ceph cluster is unavailable.
+		cancelCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		output, err := subprocess.RunCommandContext(cancelCtx, "ceph", "status", "--format=json")
+		if err == nil {
+			err = json.Unmarshal([]byte(output), &n.state.Services.Ceph.State)
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	return n.state.Services.Ceph, nil


### PR DESCRIPTION
This adds the capability for IncusOS to automatically deploy a Ceph cluster running from self-hosted OCI application images. Each ODS instance utilizes a LUKS-encrypted raw storage device from the IncusOS server on which it is running.

The logic assumes all Incus cluster members are running on top of IncusOS.

Partially addresses #497