### PR TITLE
Show update channel in log messages

### DIFF
--- a/incus-osd/internal/update/update.go
+++ b/incus-osd/internal/update/update.go
@@ -379,7 +379,7 @@ func CheckAndDownloadUpdate(ctx context.Context, s *state.State, t *tui.TUI, p p
 
 	if err != nil {
 		if errors.Is(err, providers.ErrNoUpdateAvailable) {
-			slog.DebugContext(ctx, ut.String()+" update provider doesn't currently have any update")
+			slog.DebugContext(ctx, ut.String()+" update provider doesn't currently have any update", "channel", s.System.Update.Config.Channel)
 
 			return "", nil
 		}
@@ -430,9 +430,9 @@ func CheckAndDownloadUpdate(ctx context.Context, s *state.State, t *tui.TUI, p p
 		return applyUpdate(ctx, s, t, update, appName, isStartupCheck)
 	} else if isStartupCheck {
 		if ut == TypeApplication {
-			slog.DebugContext(ctx, "System is already running latest application version", "application", appName, "version", update.Version())
+			slog.DebugContext(ctx, "System is already running latest application version", "application", appName, "channel", s.System.Update.Config.Channel, "version", update.Version())
 		} else {
-			slog.DebugContext(ctx, "System is already running latest "+ut.String()+" version", "version", update.Version())
+			slog.DebugContext(ctx, "System is already running latest "+ut.String()+" version", "channel", s.System.Update.Config.Channel, "version", update.Version())
 		}
 	}
 
@@ -452,18 +452,18 @@ func applyUpdate(ctx context.Context, s *state.State, t *tui.TUI, update provide
 	case providers.SecureBootCertUpdate:
 		targetPath = "/tmp/"
 
-		slog.InfoContext(ctx, "Downloading SecureBoot update", "version", update.Version())
-		updateModal.Update("Downloading SecureBoot update " + update.Version())
+		slog.InfoContext(ctx, "Downloading SecureBoot update", "channel", s.System.Update.Config.Channel, "version", update.Version())
+		updateModal.Update("Downloading SecureBoot update " + update.Version() + " from channel " + s.System.Update.Config.Channel)
 	case providers.OSUpdate:
 		targetPath = systemd.SystemUpdatesPath
 
-		slog.InfoContext(ctx, "Downloading OS update", "version", update.Version())
-		updateModal.Update("Downloading OS update " + update.Version())
+		slog.InfoContext(ctx, "Downloading OS update", "channel", s.System.Update.Config.Channel, "version", update.Version())
+		updateModal.Update("Downloading OS update " + update.Version() + " from channel " + s.System.Update.Config.Channel)
 	case providers.ApplicationUpdate:
 		targetPath = filepath.Join(systemd.LocalExtensionsPath, update.Version())
 
-		slog.InfoContext(ctx, "Downloading application update", "application", appName, "version", update.Version())
-		updateModal.Update("Downloading application update " + appName + " version " + update.Version())
+		slog.InfoContext(ctx, "Downloading application update", "application", appName, "channel", s.System.Update.Config.Channel, "version", update.Version())
+		updateModal.Update("Downloading application update " + appName + " version " + update.Version() + " from channel " + s.System.Update.Config.Channel)
 	default:
 		// An invalid update type has been handled previously in checkDownloadUpdate().
 	}

--- a/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
+++ b/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
@@ -116,7 +116,7 @@ class IncusTestVM:
         self.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
         if not secureboot_disabled:
             self.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
-        self.WaitExpectedLog("incus-osd", "Downloading application update application="+application+" version="+os_version)
+        self.WaitExpectedLog("incus-osd", "Downloading application update application="+application+" channel=stable version="+os_version)
         self.WaitExpectedLog("incus-osd", "System is ready version="+os_version)
 
     def WaitAgentRunning(self, timeout=420):

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_applications.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_applications.py
@@ -276,7 +276,7 @@ def TestIncusOSAPIApplicationsIncusLinstor(install_image):
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus-linstor version="+os_version)
+        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus-linstor channel=stable version="+os_version)
         vm.WaitExpectedLog("incus-osd", "Initializing application name=incus-linstor version=.+ \\["+os_version+"\\]", regex=True)
 
         result = vm.APIRequest("/1.0/applications")

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_reset.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_reset.py
@@ -27,7 +27,7 @@ def TestIncusOSAPISystemReset(install_image):
         vm.WaitAgentRunning()
         vm.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
         vm.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
-        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+os_version)
+        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus channel=stable version="+os_version)
         vm.WaitExpectedLog("incus-osd", "System is ready version="+os_version)
 
         # Shouldn't see any mention of a TPM or SecureBoot degraded security state
@@ -69,7 +69,7 @@ def TestIncusOSAPISystemResetSWTPM(install_image):
         vm.WaitAgentRunning()
         vm.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
         vm.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
-        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+os_version)
+        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus channel=stable version="+os_version)
         vm.WaitExpectedLog("incus-osd", "System is ready version="+os_version)
 
         # Should see a log message about swtpm
@@ -108,7 +108,7 @@ def TestIncusOSAPISystemResetSWTPMToTPM(install_image):
         vm.WaitAgentRunning()
         vm.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
         vm.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
-        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+os_version)
+        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus channel=stable version="+os_version)
         vm.WaitExpectedLog("incus-osd", "System is ready version="+os_version)
 
         # Shouldn't see any mention of a TPM or SecureBoot degraded security state
@@ -140,7 +140,7 @@ def TestIncusOSAPISystemResetSecureBootDisabled(install_image):
         # Wait for the system to come back up.
         vm.WaitAgentRunning()
         vm.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
-        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+os_version)
+        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus channel=stable version="+os_version)
         vm.WaitExpectedLog("incus-osd", "System is ready version="+os_version)
 
         # Should see a log message about SecureBoot being disabled
@@ -183,7 +183,7 @@ def TestIncusOSAPISystemResetSecureBootDisabledToSB(install_image):
             vm.WaitAgentRunning()
             vm.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
             vm.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
-            vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+os_version)
+            vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus channel=stable version="+os_version)
             vm.WaitExpectedLog("incus-osd", "System is ready version="+os_version)
 
             # Shouldn't see any mention of a TPM or SecureBoot degraded security state

--- a/incus-osd/tests/incusos_tests/tests_incusos_live.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_live.py
@@ -22,7 +22,7 @@ def TestIncusOSLive(install_image):
         vm.WaitAgentRunning()
         vm.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
         vm.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
-        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+os_version)
+        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus channel=stable version="+os_version)
         vm.WaitExpectedLog("incus-osd", "System is ready version="+os_version)
 
         # Shouldn't see any mention of a TPM or SecureBoot degraded security state
@@ -67,7 +67,7 @@ def TestIncusOSLiveSWTPM(install_image):
         vm.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
         vm.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
         vm.WaitExpectedLog("incus-osd", "Degraded security state: no physical TPM found, using swtpm")
-        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+os_version)
+        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus channel=stable version="+os_version)
         vm.WaitExpectedLog("incus-osd", "System is ready version="+os_version)
 
         # Check some PCR values: expect PCR0 to be empty with swtpm, while PCR7, PCR11, and PCR15 should have non-zero values
@@ -116,7 +116,7 @@ def TestIncusOSLiveNoSecureBoot(install_image):
         vm.WaitAgentRunning()
         vm.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
         vm.WaitExpectedLog("incus-osd", "Degraded security state: Secure Boot is disabled")
-        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+os_version)
+        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus channel=stable version="+os_version)
         vm.WaitExpectedLog("incus-osd", "System is ready version="+os_version)
 
         # Verify that LUKS encryption is bound to PCRs 4+7+11+15

--- a/incus-osd/tests/incusos_tests/tests_recovery.py
+++ b/incus-osd/tests/incusos_tests/tests_recovery.py
@@ -94,7 +94,7 @@ def _recoveryChecks(vm, os_version):
     vm.WaitExpectedLog("incus-osd", "Processing validated update metadata version="+os_version)
     vm.WaitExpectedLog("incus-osd", "Decompressing and verifying each update file")
     vm.WaitExpectedLog("incus-osd", "Skipping missing file: 'x86_64/debug.raw.gz")
-    vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+os_version)
+    vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus channel=stable version="+os_version)
     vm.WaitExpectedLog("incus-osd", "Recovery actions completed")
     vm.WaitExpectedLog("incus-osd", "Bringing up the network")
     vm.WaitExpectedLog("incus-osd", "systemd-timesyncd failed to perform NTP synchronization, system time may be incorrect")

--- a/incus-osd/tests/incusos_tests/tests_seed_applications.py
+++ b/incus-osd/tests/incusos_tests/tests_seed_applications.py
@@ -86,7 +86,7 @@ def TestSeedApplictionsIncusCeph(install_image):
         vm.WaitSystemReady(os_version, application="incus-ceph")
 
         # We should also see Incus pulled in as a dependency
-        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+os_version)
+        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus channel=stable version="+os_version)
 
 def TestSeedApplictionsIncusLinstor(install_image):
     test_name = "seed-applications-incus-linstor"
@@ -101,7 +101,7 @@ def TestSeedApplictionsIncusLinstor(install_image):
         vm.WaitSystemReady(os_version, application="incus-linstor")
 
         # We should also see Incus pulled in as a dependency
-        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+os_version)
+        vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus channel=stable version="+os_version)
 
 def TestSeedApplictionsMigrationManager(install_image):
     test_name = "seed-applications-migration-manager"

--- a/incus-osd/tests/incusos_tests/tests_upgrade.py
+++ b/incus-osd/tests/incusos_tests/tests_upgrade.py
@@ -127,7 +127,7 @@ def TestBaselineUpgradeApplicationOnly(install_image):
                 vm.WaitExpectedLog("incus-osd", "Processing validated update metadata version="+os_version)
                 vm.WaitExpectedLog("incus-osd", "Decompressing and verifying each update file")
                 vm.WaitExpectedLog("incus-osd", "Skipping missing file: 'x86_64/debug.raw.gz")
-                vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version="+os_version)
+                vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus channel=stable version="+os_version)
                 vm.WaitExpectedLog("incus-osd", "Recovery actions completed")
                 vm.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
                 vm.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
@@ -149,7 +149,7 @@ def TestBaselineUpgradeApplicationOnly(install_image):
                 if result["status_code"] != 200:
                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                match = vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus version=((?!" + os_version + ")\\d+)", regex=True)
+                match = vm.WaitExpectedLog("incus-osd", "Downloading application update application=incus channel=stable version=((?!" + os_version + ")\\d+)", regex=True)
                 new_version = match.group(1)
                 vm.WaitExpectedLog("incus-osd", "Reloading application name=incus version="+new_version)
 


### PR DESCRIPTION
Should help diagnose future issues downloading updates if the log messages include what channel the update(s) is/are coming from.