### PR TITLE
incus-osd/systemd: Fix handling of broken NIC drivers

### DIFF
--- a/incus-osd/internal/systemd/networkd.go
+++ b/incus-osd/internal/systemd/networkd.go
@@ -784,10 +784,6 @@ func getInterfaceState(ctx context.Context, ifaceType string, iface string, hwad
 		// #nosec G304
 		contents, err := os.ReadFile("/sys/class/net/" + underlyingDevice + "/speed")
 		if err != nil {
-			if !errors.Is(err, os.ErrNotExist) {
-				return api.SystemNetworkInterfaceState{}, err
-			}
-
 			speed = "unknown"
 		} else {
 			speed = strings.TrimSuffix(string(contents), "\n")


### PR DESCRIPTION
Some NIC drivers expose a /speed file that can't be read instead of just hiding it...

Closes #1162