### PR TITLE
Fixes

### DIFF
--- a/incus-osd/cli/cli_applications.go
+++ b/incus-osd/cli/cli_applications.go
@@ -61,6 +61,10 @@ func (c *cmdAdminOSApplication) command() *cobra.Command {
 	}
 	cmd.AddCommand(debugCmd.command())
 
+	// Edit.
+	editCmd := cmdGenericEdit{os: c.os, entity: "application", entityShort: "application", endpoint: "applications"}
+	cmd.AddCommand(editCmd.command())
+
 	// Factory reset.
 	factoryResetCmd := cmdGenericRun{
 		os:          c.os,

--- a/incus-osd/tests/api-tests.py
+++ b/incus-osd/tests/api-tests.py
@@ -17,6 +17,9 @@ current_release = None
 prior_stable_release = None
 urls = []
 
+# Expand PATH to include /usr/sbin/
+os.environ["PATH"] = os.environ["PATH"] + ":/usr/sbin"
+
 # Check that expected commands are available before running any tests
 for cmd in ["curl", "gdisk", "go", "mkfs.vfat", "mcopy", "mdeltree", "mkisofs", "openssl", "truncate"]:
     try:


### PR DESCRIPTION
* incus-osd/tests: Ensure /usr/sbin is in path for running commands
* cli: Add an `application edit` command