### PR TITLE
Improve reporting of the system's security state

### DIFF
--- a/incus-osd/api/system_security.go
+++ b/incus-osd/api/system_security.go
@@ -1,5 +1,15 @@
 package api
 
+// TPMStatus defines a custom type for reporting the system's TPM status.
+type TPMStatus string
+
+// Define constants used to report the state of the system's TPM.
+const (
+	TPMStatusOK          TPMStatus = "ok"
+	TPMStatusPCRMismatch TPMStatus = "pcr mismatch"
+	TPMStatusSWTPM       TPMStatus = "swtpm"
+)
+
 // SystemSecurityState holds information about the current security state.
 type SystemSecurityState struct {
 	EncryptedVolumes                []SystemSecurityEncryptedVolume       `incusos:"-"                               json:"encrypted_volumes"                  yaml:"encrypted_volumes"`
@@ -9,7 +19,7 @@ type SystemSecurityState struct {
 	SecureBootCertificates          []SystemSecuritySecureBootCertificate `incusos:"-"                               json:"secure_boot_certificates"           yaml:"secure_boot_certificates"`
 	SecureBootEnabled               bool                                  `incusos:"-"                               json:"secure_boot_enabled"                yaml:"secure_boot_enabled"`
 	SystemStateIsTrusted            bool                                  `incusos:"-"                               json:"system_state_is_trusted"            yaml:"system_state_is_trusted"`
-	TPMStatus                       string                                `incusos:"-"                               json:"tpm_status"                         yaml:"tpm_status"`
+	TPMStatus                       TPMStatus                             `incusos:"-"                               json:"tpm_status"                         yaml:"tpm_status"`
 	TPMPublicKey                    string                                `incusos:"-"                               json:"tpm_public_key,omitempty"           yaml:"tpm_public_key,omitempty"`
 }
 

--- a/incus-osd/api/system_security.go
+++ b/incus-osd/api/system_security.go
@@ -19,6 +19,7 @@ type SystemSecurityState struct {
 	SecureBootCertificates          []SystemSecuritySecureBootCertificate `incusos:"-"                               json:"secure_boot_certificates"           yaml:"secure_boot_certificates"`
 	SecureBootEnabled               bool                                  `incusos:"-"                               json:"secure_boot_enabled"                yaml:"secure_boot_enabled"`
 	SystemStateIsTrusted            bool                                  `incusos:"-"                               json:"system_state_is_trusted"            yaml:"system_state_is_trusted"`
+	SystemStateStatus               string                                `incusos:"-"                               json:"system_state_status"                yaml:"system_state_status"`
 	TPMStatus                       TPMStatus                             `incusos:"-"                               json:"tpm_status"                         yaml:"tpm_status"`
 	TPMPublicKey                    string                                `incusos:"-"                               json:"tpm_public_key,omitempty"           yaml:"tpm_public_key,omitempty"`
 }

--- a/incus-osd/internal/backup/backup.go
+++ b/incus-osd/internal/backup/backup.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/lxc/incus/v7/shared/revert"
 
+	"github.com/lxc/incus-os/incus-osd/api"
 	"github.com/lxc/incus-os/incus-osd/internal/applications"
 	"github.com/lxc/incus-os/incus-osd/internal/secureboot"
 	"github.com/lxc/incus-os/incus-osd/internal/state"
@@ -251,9 +252,13 @@ func processNewState(ctx context.Context, s *state.State, skipOptions []string) 
 	// 1. Need to be able to use TPM to change encryption recovery passphrase(s).
 	// 2. At least one recovery passphrase provided.
 	// 3. At least one primary application must be installed.
-	tpmStatus := secureboot.TPMStatus()
-	if tpmStatus != "ok" {
-		return errors.New("TPM status isn't OK: " + tpmStatus)
+	tpmStatus, err := secureboot.TPMStatus()
+	if err != nil {
+		return err
+	}
+
+	if tpmStatus != api.TPMStatusOK {
+		return errors.New("TPM status isn't OK: " + string(tpmStatus))
 	}
 
 	if len(newState.System.Security.Config.EncryptionRecoveryKeys) == 0 {

--- a/incus-osd/internal/rest/api_system_security.go
+++ b/incus-osd/internal/rest/api_system_security.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"slices"
+	"strings"
 
 	"github.com/lxc/incus-os/incus-osd/api"
 	"github.com/lxc/incus-os/incus-osd/internal/auth"
@@ -137,6 +138,31 @@ func (s *Server) apiSystemSecurity(w http.ResponseWriter, r *http.Request) {
 		}
 
 		s.state.System.Security.State.SystemStateIsTrusted = !secureboot.IsTrustedFuseBlown()
+
+		// If the system state is untrusted, report details about why.
+		if !s.state.System.Security.State.SystemStateIsTrusted {
+			issues := []string{}
+
+			if s.state.UsingSWTPM {
+				issues = append(issues, "using swtpm")
+			}
+
+			if s.state.SecureBootDisabled {
+				issues = append(issues, "Secure Boot is disabled")
+			}
+
+			if s.state.FullAgentEnabled {
+				issues = append(issues, "incus-agent is/was fully enabled")
+			}
+
+			s.state.System.Security.State.SystemStateStatus = strings.Join(issues, ", ")
+
+			if s.state.System.Security.State.SystemStateStatus == "" {
+				s.state.System.Security.State.SystemStateStatus = "no current issues, but system was previously in an untrusted state"
+			}
+		} else {
+			s.state.System.Security.State.SystemStateStatus = "system state is fully trusted"
+		}
 
 		// Get TPM public key, if it exists.
 		contents, err := os.ReadFile(auth.PEMPath)

--- a/incus-osd/internal/rest/api_system_security.go
+++ b/incus-osd/internal/rest/api_system_security.go
@@ -113,7 +113,12 @@ func (s *Server) apiSystemSecurity(w http.ResponseWriter, r *http.Request) {
 		s.state.System.Security.State.SecureBootCertificates = secureboot.ListCertificates()
 
 		// Get TPM status.
-		s.state.System.Security.State.TPMStatus = secureboot.TPMStatus()
+		s.state.System.Security.State.TPMStatus, err = secureboot.TPMStatus()
+		if err != nil {
+			_ = response.InternalError(err).Render(w)
+
+			return
+		}
 
 		// Get drive encryption keys.
 		s.state.System.Security.State.DriveRecoveryKeys, err = storage.GetDriveKeys()

--- a/incus-osd/internal/secureboot/doc.go
+++ b/incus-osd/internal/secureboot/doc.go
@@ -3,6 +3,3 @@
 //
 // NOTE -- It's assumed that PCR7 is the only one we care about in this code.
 package secureboot
-
-// TPMPCRMismatch holds the string returned by TPMStatus() if there's a PCR mismatch between the TPM and our computed value.
-var TPMPCRMismatch = "pending PCR7 update"

--- a/incus-osd/internal/secureboot/tpm.go
+++ b/incus-osd/internal/secureboot/tpm.go
@@ -9,36 +9,39 @@ import (
 
 	"github.com/google/go-eventlog/register"
 	"github.com/google/go-eventlog/tcg"
+
+	"github.com/lxc/incus-os/incus-osd/api"
 )
 
 // TPMStatus returns basic information about the status of the TPM.
-func TPMStatus() string {
+func TPMStatus() (api.TPMStatus, error) {
 	eventLog, err := GetValidatedTPMEventLog()
 	if err != nil {
-		return err.Error()
+		return "", err
 	}
 
 	computedPCR, err := computeNewPCR7Value(eventLog)
 	if err != nil {
-		return err.Error()
+		return "", err
 	}
 
 	actualPCR, err := ReadPCR("7")
 	if err != nil {
-		return err.Error()
+		return "", err
 	}
 
 	if !bytes.Equal(computedPCR, actualPCR) {
-		return TPMPCRMismatch
+		// TPM reports a PCR7 mismatch.
+		return api.TPMStatusPCRMismatch, nil
 	}
 
 	if GetSWTPMInUse() {
 		// We have a swtpm TPM in a good state.
-		return "swtpm"
+		return api.TPMStatusSWTPM, nil
 	}
 
 	// We have a physical TPM in a good state.
-	return "ok"
+	return api.TPMStatusOK, nil
 }
 
 // GetSWTPMInUse returns a boolean indicating if a swtpm-backed TPM is running.

--- a/incus-osd/internal/systemd/cryptenroll.go
+++ b/incus-osd/internal/systemd/cryptenroll.go
@@ -231,8 +231,13 @@ func ListEncryptedVolumes(ctx context.Context) ([]api.SystemSecurityEncryptedVol
 
 		// Second, test if we can auto-unlock with the current TPM state.
 		if !tpmStateIsGood {
+			tpmStatus, err := secureboot.TPMStatus()
+			if err != nil {
+				return ret, err
+			}
+
 			// Do we have a PCR mismatch on the TPM? If so, assume we can unlock with the TPM upon reboot.
-			if secureboot.TPMStatus() == secureboot.TPMPCRMismatch {
+			if tpmStatus == api.TPMStatusPCRMismatch {
 				ret = append(ret, api.SystemSecurityEncryptedVolume{
 					Volume: volumeName,
 					State:  "unlocked (TPM; PCR update pending)",


### PR DESCRIPTION
Define constants to use when reporting the TPM state, and add a new `SystemStateStatus` field to the `SystemSecurityState` struct that will be populated if the system is in an untrusted state.

I did change the value of `TPMStatusPCRMismatch`, but no code in Migration Manger or Operations Center currently have any reference to the constant or actual value, so it should be a safe breaking change.

@breml after this is included in IncusOS, Operations Center can be updated to report better information about a server's trusted status in its UI.

Closes #1121