### PR TITLE
Add support for configuring zram-backed swap

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -149,3 +149,4 @@ Xeon
 YAML
 Zabbly
 ZFS
+zram

--- a/doc/reference/system/kernel.md
+++ b/doc/reference/system/kernel.md
@@ -10,8 +10,9 @@ The following configuration options can be set:
 
 * `blacklist_modules`: A list of one or more kernel modules to blacklist. Typically useful when passing through PCI devices to virtual machines.
 
-* `memory`: Change `sysctl` values that impact the system's memory configuration
+* `memory`: Change `sysctl` values or other settings that impact the system's memory configuration
    * `persistent_hugepages`: Optional; number of persistent hugepages to allocate.
+   * `zram_swap_size`: Optional; a human-readable string such as "4GiB" that defines the size of the zram-backed swap device to create. A value of "0" will disable any existing zram-backed swap that may exist. IncusOS will attempt to immediately apply this change without requiring a reboot.
 
 * `network`: Change `sysctl` values that impact the system's network configuration.
    * `buffer_size`: Optional; configure the maximum buffer size used when setting the `net.ipv4.tcp_rmem`, `net.ipv4.tcp_wmem`, `net.core.rmem_max`, and `net.core.wmem_max` `sysctl` fields.

--- a/incus-osd/api/system_kernel.go
+++ b/incus-osd/api/system_kernel.go
@@ -17,7 +17,8 @@ type SystemKernelConfigConsole struct {
 
 // SystemKernelConfigMemory holds memory-specific kernel configuration.
 type SystemKernelConfigMemory struct {
-	PersistentHugepages int `json:"persistent_hugepages" yaml:"persistent_hugepages"`
+	PersistentHugepages int    `json:"persistent_hugepages" yaml:"persistent_hugepages"`
+	ZramSwapSize        string `json:"zram_swap_size"       yaml:"zram_swap_size"`
 }
 
 // SystemKernelConfigNetwork holds network-specific kernel configuration.

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/lxc/incus-os/incus-osd/certs"
 	"github.com/lxc/incus-os/incus-osd/internal/applications"
 	"github.com/lxc/incus-os/incus-osd/internal/install"
+	"github.com/lxc/incus-os/incus-osd/internal/kernel"
 	"github.com/lxc/incus-os/incus-osd/internal/keyring"
 	"github.com/lxc/incus-os/incus-osd/internal/nftables"
 	"github.com/lxc/incus-os/incus-osd/internal/providers"
@@ -546,6 +547,14 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 					slog.WarnContext(ctx, "Unable to activate encrypted swap partition")
 				}
 			}
+		}
+	}
+
+	// Enable zram-backed swap, if configured.
+	if s.System.Kernel.Config.Memory != nil {
+		err = kernel.EnableZramSwap(ctx, s.System.Kernel.Config.Memory.ZramSwapSize)
+		if err != nil {
+			slog.WarnContext(ctx, "Unable to activate zram-backed sawp: "+err.Error())
 		}
 	}
 

--- a/incus-osd/internal/kernel/kernel.go
+++ b/incus-osd/internal/kernel/kernel.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/lxc/incus/v7/shared/subprocess"
+	"github.com/lxc/incus/v7/shared/units"
 
 	"github.com/lxc/incus-os/incus-osd/api"
 	"github.com/lxc/incus-os/incus-osd/internal/systemd"
@@ -39,6 +43,103 @@ func ApplyKernelConfiguration(ctx context.Context, config api.SystemKernelConfig
 	}
 
 	return nil
+}
+
+// EnableZramSwap enables zram-backed swap if the provided swapSize is greater than
+// zero bytes. Out of the box, IncusOS only supports the zstd compression algorithm.
+func EnableZramSwap(ctx context.Context, swapSize string) error {
+	if swapSize == "" {
+		return nil
+	}
+
+	// Convert the requested size to an integer number of bytes.
+	capacity, err := units.ParseByteSizeString(swapSize)
+	if err != nil {
+		return err
+	}
+
+	// Ensure the kernel module is loaded.
+	_, err = subprocess.RunCommandContext(ctx, "modprobe", "zram")
+	if err != nil {
+		return err
+	}
+
+	// Remove any existing zram device.
+	_, err = os.Stat("/dev/zram0")
+	if err == nil {
+		// Check if swap is currently enabled for the zram device; if so, first turn it off.
+		fd, err := os.Open("/proc/swaps")
+		if err != nil {
+			return err
+		}
+		defer fd.Close()
+
+		contents, err := io.ReadAll(fd)
+		if err != nil {
+			return err
+		}
+
+		if strings.Contains(string(contents), "/dev/zram0") {
+			_, err := subprocess.RunCommandContext(ctx, "swapoff", "/dev/zram0")
+			if err != nil {
+				return err
+			}
+		}
+
+		err = runZramCmd(ctx, "--reset", "/dev/zram0")
+		if err != nil {
+			return err
+		}
+	}
+
+	// If the requested capacity is zero, nothing to do after the zram device was removed.
+	if capacity == 0 {
+		return nil
+	}
+
+	// Create the zram device.
+	err = runZramCmd(ctx, "--find")
+	if err != nil {
+		return err
+	}
+
+	// Configure the zram device.
+	err = runZramCmd(ctx, "/dev/zram0", "--algorithm", "zstd", "--size", strconv.FormatInt(capacity, 10))
+	if err != nil {
+		return err
+	}
+
+	// Format zram as swap.
+	_, err = subprocess.RunCommandContext(ctx, "mkswap", "/dev/zram0")
+	if err != nil {
+		return err
+	}
+
+	// Enable the zram-backed swap.
+	_, err = subprocess.RunCommandContext(ctx, "swapon", "--priority", "100", "/dev/zram0")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// The zramctl command is a bit too flaky and frequently returns "Device or resource busy"
+// errors. To handle this, try each command up to ten times with brief sleeps in between
+// before fully failing.
+func runZramCmd(ctx context.Context, args ...string) error {
+	var err error
+
+	for range 10 {
+		_, err = subprocess.RunCommandContext(ctx, "zramctl", args...)
+		if err == nil {
+			break
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return err
 }
 
 func updateBlacklistModules(modules []string) error {

--- a/incus-osd/internal/kernel/kernel.go
+++ b/incus-osd/internal/kernel/kernel.go
@@ -42,6 +42,14 @@ func ApplyKernelConfiguration(ctx context.Context, config api.SystemKernelConfig
 		}
 	}
 
+	// Enable zram swap, if configured.
+	if config.Memory != nil {
+		err := EnableZramSwap(ctx, config.Memory.ZramSwapSize)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Add a new kernel memory configuration option `zram_swap_size` that enables configuring zram-backed swap of the specified size. A value > 0 will (re)create the zram swap device, while a value of 0 will remove it. The configuration is persisted in the IncusOS state, and will automatically apply when `incus-osd` starts up.

The compression algorithm is fixed to zstd, which is the only one supported out-of-the-box in the IncusOS kernel. I think that's fine for now; if there's really a pressing need we can look at enabling additional kernel modules at a later point.

Closes #1157