### PR TITLE
Revert "incus-osd/applications/incus: Load br_netfilter"

### DIFF
--- a/incus-osd/internal/applications/app_incus.go
+++ b/incus-osd/internal/applications/app_incus.go
@@ -321,12 +321,6 @@ func (*incus) Start(ctx context.Context) error {
 		return err
 	}
 
-	// Make sure br_netfilter is loaded (for proxy and forwards).
-	_, err = subprocess.RunCommandContext(ctx, "modprobe", "br_netfilter")
-	if err != nil {
-		return err
-	}
-
 	// Start the units.
 	return systemd.StartUnit(ctx, "incus.socket", "incus-lxcfs.service", "incus-startup.service", "incus.service")
 }


### PR DESCRIPTION
This reverts commit 2ce7916e4e6470ea342c53f81f8ec458ea710a7f.

br_netfilter interacts VERY badly with the IncusOS bridge setup and causes traffic to just get completely dropped.