### PR TITLE
mkosi.packages/initrd-utils: Run fsck on the root partition immediately after cryptsetup completes

### DIFF
--- a/mkosi.packages/initrd-utils/debian/initrd-utils.install
+++ b/mkosi.packages/initrd-utils/debian/initrd-utils.install
@@ -2,6 +2,7 @@ initrd-utils                  usr/bin/
 initrd-boot-message.sh        usr/bin/
 initrd-debug-info.sh          usr/bin/
 initrd-finalize-luks-state.sh usr/bin/
+initrd-fsck-root.sh           usr/bin/
 initrd-multipath.sh           usr/bin/
 initrd-multipath-partition.sh usr/bin/
 initrd-startup-checks.sh      usr/bin/

--- a/mkosi.packages/initrd-utils/initrd-fsck-root.sh
+++ b/mkosi.packages/initrd-utils/initrd-fsck-root.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Ideally systemd-fsck-root.service would check the root partition automatically, but because of
+# how we are relying on swtpm storing state in /boot/, the unencrypted root device won't be available.
+# Attempting to add additional service ordering dependencies results in a dependency cycle, so we mimic
+# what that service does immediately following the successful unlocking of the root device.
+
+/usr/sbin/fsck.ext4 -p /dev/mapper/root
+ret=$?
+
+# Perform a couple actions based on the exit code of fsck. If it failed to repair the file system, don't
+# cause this script to exit with a failure. Hopefully the file system can still be mounted, otherwise
+# sysroot.mount will likely fail.
+if [ $ret = 0 ] || [ $ret = 1 ]; then
+    # No errors or errors were corrected
+    mkdir -p /run/initramfs/
+    touch /run/initramfs/fsck-root
+elif [ $ret = 2 ]; then
+    # A system reboot is required
+    systemctl reboot
+fi

--- a/mkosi.packages/initrd-utils/systemd-cryptsetup.conf
+++ b/mkosi.packages/initrd-utils/systemd-cryptsetup.conf
@@ -1,3 +1,8 @@
+[Unit]
+Before=sysroot.mount
+Wants=sysroot.mount
+
 [Service]
 ExecStart=
 ExecStart=/usr/bin/systemd-cryptsetup attach 'root' '/dev/gpt-auto-root-luks' '' 'tpm2-device=auto,tpm2-measure-pcr=yes,tries=0'
+ExecStartPost=/usr/bin/initrd-fsck-root.sh


### PR DESCRIPTION
Ideally we would let systemd-fsck-root.service to do this for us, but because we rely on swtpm storing state in /boot/, dependency ordering prevents that service from running after the root partition is unlocked but before it is mounted. Instead, immediately run fsck ourselves from the cryptsetup service.

Closes #1101