### PR TITLE
mkosi.packages/initrd-utils: Improve detection of failed TPM unlocking

### DIFF
--- a/mkosi.packages/initrd-utils/initrd-finalize-luks-state.sh
+++ b/mkosi.packages/initrd-utils/initrd-finalize-luks-state.sh
@@ -8,7 +8,7 @@ if systemctl status systemd-cryptsetup@root.service > /dev/null 2>&1; then
         rm /sys/firmware/efi/efivars/IncusOSTPMState-12f075e0-2d07-493d-811a-00920a72c04c
     fi
 
-    if journalctl -b -g "TPM2 operation failed, falling back to traditional unlocking" -u systemd-cryptsetup@root.service > /dev/null 2>&1; then
+    if journalctl -b -g "falling back to traditional unlocking" -u systemd-cryptsetup@root.service > /dev/null 2>&1; then
         # A recovery password was used to unlock the volume
         printf "\07\00\00\00\00\00\00\01" > /sys/firmware/efi/efivars/IncusOSTPMState-12f075e0-2d07-493d-811a-00920a72c04c
     else


### PR DESCRIPTION
At least two different error messages can be returned if the TPM fails to automatically unlock the root LUKS volume during boot. Relax the string we search for to be the common substring of the error, regardless of actual cause.