### PR TITLE
Add a `security` seed

### DIFF
--- a/doc/reference/seed.md
+++ b/doc/reference/seed.md
@@ -107,6 +107,20 @@ to fetch IncusOS updates and applications.
 
 The structure used is the [provider API struct](https://github.com/lxc/incus-os/blob/main/incus-osd/api/system_provider.go).
 
+### `security.{json,yml,yaml}`
+This file provides security configuration for the system.
+
+The structure used is the [security API struct](https://github.com/lxc/incus-os/blob/main/incus-osd/api/system_security.go):
+
+- `custom_ca_certs`: An array of PEM-encoded CA certificates that should be
+  added to the IncusOS trust store.
+
+```{note}
+It is not possible to set encryption recovery key(s) via the security seed. This is
+because the seed must be stored in plain text, which would allow trivial access to
+anyone trying to compromise the encrypted IncusOS root partition.
+```
+
 ### `update.{json,yml,yaml}`
 This file provides update configuration for the system.
 

--- a/incus-osd/api/seed/security.go
+++ b/incus-osd/api/seed/security.go
@@ -1,0 +1,12 @@
+package seed
+
+import (
+	"github.com/lxc/incus-os/incus-osd/api"
+)
+
+// Security represents the security seed.
+type Security struct {
+	api.SystemSecurityConfig `yaml:",inline"`
+
+	Version string `json:"version" yaml:"version"`
+}

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -94,15 +94,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Ensure custom CA certificates are set, if any.
-	if len(s.System.Security.Config.CustomCACerts) > 0 {
-		err := util.UpdateSystemCustomCACerts(s.System.Security.Config.CustomCACerts)
-		if err != nil {
-			tui.EarlyError("unable to configure custom CA certificates: "+err.Error(), osName)
-			os.Exit(1)
-		}
-	}
-
 	// Record the OS name and version in the state.
 	s.OS.Name = osName
 	s.OS.RunningRelease = osRelease
@@ -157,7 +148,7 @@ func main() {
 
 	// Perform first-boot actions, if needed.
 	if !s.OS.SuccessfulBoot && !s.ShouldPerformInstall && s.System.Network.Config == nil {
-		err := firstBootActions(ctx)
+		err := firstBootActions(ctx, s)
 		if err != nil {
 			tui.EarlyError("unable to perform first boot actions: "+err.Error(), s.OS.Name)
 			os.Exit(1)
@@ -204,11 +195,45 @@ func main() {
 	}
 }
 
-func firstBootActions(ctx context.Context) error {
+func firstBootActions(ctx context.Context, s *state.State) error {
 	// Clear the "IncusOSInstallComplete" UEFI variable, if it exists.
 	err := secureboot.ClearIncusOSInstallComplete(ctx)
 	if err != nil {
 		return err
+	}
+
+	// Apply any custom CA certificates from the security seed. Because it's not
+	// possible to reload cached CA root certificates, if custom CAs are set we
+	// will write them and the updated state to disk, then cleanly exit and allow
+	// the systemd service to restart the incus-osd daemon. On the second "first
+	// boot" the custom CAs will exist in the state, so we'll skip the logic to
+	// extract them from the security seed again.
+	if len(s.System.Security.Config.CustomCACerts) == 0 {
+		// Get any custom CAs from the security seed.
+		securitySeed, err := seed.GetSecurity(ctx)
+		if err != nil && !seed.IsMissing(err) {
+			return errors.New("unable to parse security seed: " + err.Error())
+		}
+
+		if securitySeed != nil && len(securitySeed.CustomCACerts) > 0 {
+			s.System.Security.Config.CustomCACerts = securitySeed.CustomCACerts
+
+			err := s.Save()
+			if err != nil {
+				return err
+			}
+
+			err = util.UpdateSystemCustomCACerts(s.System.Security.Config.CustomCACerts)
+			if err != nil {
+				return errors.New("unable to configure custom CA certificates: " + err.Error())
+			}
+
+			// Use a fmt.Print() here, since at this point the logger isn't configured, but we
+			// still would like a journal entry to appear explaining why the process restarted.
+			_, _ = fmt.Print("Custom CAs configured from security seed, restarting incus-osd daemon") //nolint:forbidigo
+
+			os.Exit(0) //nolint:revive
+		}
 	}
 
 	// Ensure the system timezone is set properly.

--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -59,6 +59,12 @@ func CheckSystemRequirements(ctx context.Context) error { //nolint:revive
 		return errors.New("cannot run if Secure Boot is disabled and no physical TPM is present")
 	}
 
+	// Ensure the security seed, if present, isn't attempting to set any encryption recovery keys.
+	_, err = seed.GetSecurity(ctx)
+	if err != nil && !seed.IsMissing(err) {
+		return err
+	}
+
 	// Get the install seed, if it exists.
 	installSeed, err := seed.GetInstall()
 	if err != nil && !seed.IsMissing(err) && !errors.Is(err, io.EOF) {

--- a/incus-osd/internal/rest/api_system_security.go
+++ b/incus-osd/internal/rest/api_system_security.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"os"
 	"slices"
@@ -224,6 +225,8 @@ func (s *Server) apiSystemSecurity(w http.ResponseWriter, r *http.Request) {
 
 			return
 		}
+
+		slog.InfoContext(r.Context(), "Custom CA certificates updated, but may not fully take effect until the system is rebooted")
 
 		_ = response.EmptySyncResponse.Render(w)
 	default:

--- a/incus-osd/internal/seed/security.go
+++ b/incus-osd/internal/seed/security.go
@@ -1,0 +1,25 @@
+package seed
+
+import (
+	"context"
+	"errors"
+
+	apiseed "github.com/lxc/incus-os/incus-osd/api/seed"
+)
+
+// GetSecurity extracts the security configuration from the seed data.
+func GetSecurity(_ context.Context) (*apiseed.Security, error) {
+	// Get the security configuration.
+	var config apiseed.Security
+
+	err := parseFileContents(getSeedPath(), "security", &config)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(config.EncryptionRecoveryKeys) != 0 {
+		return nil, errors.New("it is not possible to set encryption recovery key(s) via the security seed")
+	}
+
+	return &config, nil
+}

--- a/mkosi.images/base/mkosi.extra/usr/lib/systemd/system/incus-osd.service
+++ b/mkosi.images/base/mkosi.extra/usr/lib/systemd/system/incus-osd.service
@@ -13,7 +13,7 @@ Environment=TERM=xterm-256color
 KillMode=process
 TimeoutStartSec=30s
 TimeoutStopSec=30s
-Restart=on-failure
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/mkosi.images/base/mkosi.extra/usr/lib/tmpfiles.d/04-java.conf
+++ b/mkosi.images/base/mkosi.extra/usr/lib/tmpfiles.d/04-java.conf
@@ -1,1 +1,1 @@
-L /etc/java-21-openjdk/ - - - - /usr/share/java-21-openjdk/
+L /etc/java-25-openjdk/ - - - - /usr/share/java-25-openjdk/

--- a/mkosi.images/incus-linstor/install.sh
+++ b/mkosi.images/incus-linstor/install.sh
@@ -18,12 +18,12 @@ rm \
 
 ARCH="$(dpkg --print-architecture)"
 
-ln -s "/usr/lib/jvm/java-21-openjdk-${ARCH}/lib/jexec" "/buildroot/usr/bin/jexec"
-ln -s "/usr/lib/jvm/java-21-openjdk-${ARCH}/bin/java" "/buildroot/usr/bin/java"
-ln -s "/usr/lib/jvm/java-21-openjdk-${ARCH}/bin/jpackage" "/buildroot/usr/bin/jpackage"
-ln -s "/usr/lib/jvm/java-21-openjdk-${ARCH}/bin/keytool" "/buildroot/usr/bin/keytool"
-ln -s "/usr/lib/jvm/java-21-openjdk-${ARCH}/bin/rmiregistry" "/buildroot/usr/bin/rmiregistry"
+ln -s "/usr/lib/jvm/java-25-openjdk-${ARCH}/lib/jexec" "/buildroot/usr/bin/jexec"
+ln -s "/usr/lib/jvm/java-25-openjdk-${ARCH}/bin/java" "/buildroot/usr/bin/java"
+ln -s "/usr/lib/jvm/java-25-openjdk-${ARCH}/bin/jpackage" "/buildroot/usr/bin/jpackage"
+ln -s "/usr/lib/jvm/java-25-openjdk-${ARCH}/bin/keytool" "/buildroot/usr/bin/keytool"
+ln -s "/usr/lib/jvm/java-25-openjdk-${ARCH}/bin/rmiregistry" "/buildroot/usr/bin/rmiregistry"
 
-mv /buildroot/etc/java-21-openjdk/ /buildroot/usr/share/java-21-openjdk/
+mv /buildroot/etc/java-25-openjdk/ /buildroot/usr/share/java-25-openjdk/
 
 exit 0


### PR DESCRIPTION
Add a new `security` seed to allow configuration of custom CAs during first boot.

Also updated expected Java paths for the new version of Linstor which bumped to Java 25.