### PR TITLE
Add more system tests

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -102,6 +102,6 @@ ogp_image = "https://linuxcontainers.org/static/img/containers.png"
 
 # Links to ignore when checking links
 
-linkcheck_ignore = ["https://web.libera.chat/#lxc", r"https://uefi.org/.*", r"https://ceph.io/", r"https://usbip.sourceforge.net/", r"https://www.freedesktop.org/"]
+linkcheck_ignore = ["https://web.libera.chat/#lxc", r"https://uefi.org/.*", r"https://ceph.io/", r"https://usbip.sourceforge.net/", r"https://www.freedesktop.org/", r"https://techcommunity.microsoft.com/blog/windows-itpro-blog/updating-microsoft-secure-boot-keys/4055324"]
 
 linkcheck_anchors_ignore_for_url = [r"https://github\.com/.*"]

--- a/doc/reference/seed.md
+++ b/doc/reference/seed.md
@@ -34,6 +34,12 @@ The structure is defined in [`api/seed/install.go`](https://github.com/lxc/incus
 - `force_install`: If true, will install to target device even if partitions
   already exist. WARNING: THIS CAN CAUSE DATA LOSS!
 
+- `force_install_confirmation`: An optional value used when `force_install` is true
+  and IncusOS is already installed on the target device. To guard against accidental
+  data loss, the first six characters of the currently installed IncusOS system must
+  be provided. (The installer will provide this as part of its error message if this
+  field is unset in the install seed.)
+
 - `force_reboot`: If true, reboot after install without waiting for removal of
   install media.
 
@@ -56,8 +62,10 @@ running.
 
 The structure is defined in [`api/seed/applications.go`](https://github.com/lxc/incus-os/blob/main/incus-osd/api/seed/applications.go):
 
-- `applications`: Holds an array of applications to install. Currently the
-  only supported application are `incus`, `migration-manager`, and `operations-center`.
+- `applications`: Holds an array of applications to install. Currently supported applications
+  can be viewed [here](./applications.md). At most one primary application can be specified,
+  and if no primary application is specified the `incus` application will be automatically appended
+  to any other provided applications.
 
 ### `incus.{json,yml,yaml}`
 This file provides preseed information for Incus.
@@ -87,25 +95,62 @@ This file defines what network configuration should be applied when IncusOS
 boots. If not specified, IncusOS will attempt automatic {abbr}`DHCP (Dynamic Host Configuration Protocol)`/{abbr}`SLAAC (Stateless Address Configuration)`
 configuration on each network interface.
 
-The structure used is the [network API struct](https://github.com/lxc/incus-os/blob/main/incus-osd/api/system_network.go).
+The structure used is the [network API struct](https://github.com/lxc/incus-os/blob/main/incus-osd/api/system_network.go):
+
+- `dns`: Optional, configure specific DNS servers as well as the system's
+  host name and domain name.
+
+- `time`: Optional, configure specific NTP servers and the server's timezone.
+
+- `proxy`: Optional, configure the system-wide proxy.
+
+- `interfaces`, `bonds`, `vlans`, and `wireguard`: Define one ore more interfaces,
+  bonds, VLANS or WireGuard tunnels for use by IncusOS.
 
 ### `migration-manager.{json,yml,yaml}`
 This file provides preseed information for Migration Manager.
 
 The structure is defined in [`api/seed/migration_manager.go`](https://github.com/lxc/incus-os/blob/main/incus-osd/api/seed/migration_manager.go)
-and references Migration Manager's [`system` API](https://github.com/FuturFusion/migration-manager/blob/main/shared/api/system.go).
+and references Migration Manager's [`system` API](https://github.com/FuturFusion/migration-manager/blob/main/shared/api/system.go):
+
+- `apply_defaults`: If true, automatically apply a set of reasonable defaults
+  when installing Migration Manager.
+
+- `trusted_client_certificates`: A list of one or more PEM-encoded client TLS
+  certificates that should be trusted by Migration Manger.
+
+- `preseed`: Additional preseed information to be passed to Migration Manager during
+  install.
 
 ### `operations-center.{json,yml,yaml}`
 This file provides preseed information for Operations Center.
 
 The structure is defined in [`api/seed/operations_center.go`](https://github.com/lxc/incus-os/blob/main/incus-osd/api/seed/operations_center.go)
-and references Operations Center's [`system` API](https://github.com/FuturFusion/operations-center/blob/main/shared/api/system/system.go).
+and references Operations Center's [`system` API](https://github.com/FuturFusion/operations-center/blob/main/shared/api/system/system.go):
+
+- `apply_defaults`: If true, automatically apply a set of reasonable defaults
+  when installing Operations Center.
+
+- `trusted_client_certificates`: A list of one or more PEM-encoded client TLS
+  certificates that should be trusted by Operations Center.
+
+- `preseed`: Additional preseed information to be passed to Operations Center during
+  install.
 
 ### `provider.{json,yml,yaml}`
 This file provides preseed information to configure a given provider, which is used
 to fetch IncusOS updates and applications.
 
-The structure used is the [provider API struct](https://github.com/lxc/incus-os/blob/main/incus-osd/api/system_provider.go).
+The structure used is the [provider API struct](https://github.com/lxc/incus-os/blob/main/incus-osd/api/system_provider.go):
+
+- `name`: The provider name; must be one of "images", "operations-center", or "debug".
+
+- `config`: A map that defines provider-specific configuration.
+
+```{note}
+The "debug" provider is not intended for general use, and should only be used to
+support work developing IncusOS.
+```
 
 ### `security.{json,yml,yaml}`
 This file provides security configuration for the system.
@@ -124,4 +169,16 @@ anyone trying to compromise the encrypted IncusOS root partition.
 ### `update.{json,yml,yaml}`
 This file provides update configuration for the system.
 
-The structure used is the [update API struct](https://github.com/lxc/incus-os/blob/main/incus-osd/api/system_update.go).
+The structure used is the [update API struct](https://github.com/lxc/incus-os/blob/main/incus-osd/api/system_update.go):
+
+- `auto_reboot`: If true, automatically reboot the system after applying an OS update.
+
+- `channel`: The channel to use when checking for updates. Defaults to "stable"; depending
+  on the provider other values such as "testing" may be valid.
+
+- `check_frequency`: How often IncusOS should check for updates. Defaults to six hours, and
+  accepts values like "6h", "1d", "3h 30m"; the special value "never" disables automatic
+  update checks.
+
+- `maintenance_windows`: Optional, defining one or more maintenance windows will limit when
+  IncusOS will check for and apply updates.

--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -225,12 +225,12 @@ func CheckSystemRequirements(ctx context.Context) error { //nolint:revive
 				return err
 			}
 
-			configmationValue := string(machineID[:6])
+			confirmationValue := string(machineID[:6])
 
 			switch installSeed.ForceInstallConfirmation {
 			case "":
-				return fmt.Errorf("%s is already installed on this system; to confirm overwriting, add `ForceInstallConfirmation=%s` to the install seed and reboot", osName, configmationValue)
-			case configmationValue:
+				return fmt.Errorf("%s is already installed on this system; to confirm overwriting, add `ForceInstallConfirmation=%s` to the install seed and reboot", osName, confirmationValue)
+			case confirmationValue:
 				// Get the device that IncusOS is currently installed on.
 				output, err := subprocess.RunCommandContext(ctx, "dmsetup", "deps", "-o", "blkdevname", "/dev/mapper/root")
 				if err != nil {
@@ -261,7 +261,7 @@ func CheckSystemRequirements(ctx context.Context) error { //nolint:revive
 				// Sleep until the system reboots so we don't attempt to proceed with the install.
 				time.Sleep(10 * time.Second)
 			default:
-				return fmt.Errorf("%s is already installed on this system; the value of `ForceInstallConfirmation` '%s' != '%s', refusing to continue", osName, installSeed.ForceInstallConfirmation, configmationValue)
+				return fmt.Errorf("%s is already installed on this system; the value of `ForceInstallConfirmation` '%s' != '%s', refusing to continue", osName, installSeed.ForceInstallConfirmation, confirmationValue)
 			}
 		}
 

--- a/incus-osd/tests/incusos_tests/__init__.py
+++ b/incus-osd/tests/incusos_tests/__init__.py
@@ -4,9 +4,9 @@ from . import tests_flasher_tool, tests_incusos_api, tests_incusos_api_applicati
     tests_incusos_api_network, tests_incusos_api_services, tests_incusos_api_system, tests_incusos_api_system_backup, \
     tests_incusos_api_system_logging, tests_incusos_api_system_provider, tests_incusos_api_system_reset, \
     tests_incusos_api_system_resources, tests_incusos_api_system_security, tests_incusos_api_system_storage, \
-    tests_incusos_api_system_storage_local_pool, tests_incusos_live, tests_install_secureboot_disabled, \
-    tests_install_multipath, tests_install_smoke, tests_install_swtpm, tests_install_system_checks, tests_recovery, \
-    tests_upgrade
+    tests_incusos_api_system_storage_local_pool, tests_incusos_live, tests_recovery, tests_upgrade
+
+from .install import tests_secureboot_disabled, tests_multipath, tests_smoke, tests_swtpm, tests_system_checks
 
 from .seed import test_external_seed, test_applications, test_install, test_kernel, test_network, test_provider, \
     test_security, test_update
@@ -22,25 +22,10 @@ class IncusOSTests:
         upgrade_tests = [tests_upgrade]
 
         # Tests that rely on the ISO install image
-        iso_install_tests = [tests_install_smoke]
+        iso_install_tests = [tests_smoke]
 
         # The bulk of the tests for IncusOS
         core_tests = [
-            # Basic system pre-install checks
-            tests_install_system_checks,
-
-            # Baseline install smoke tests
-            tests_install_smoke,
-
-            # Test use of swtpm
-            tests_install_swtpm,
-
-            # Test disabling Secure Boot
-            tests_install_secureboot_disabled,
-
-            # Test installing on multipath
-            tests_install_multipath,
-
             # Test running IncusOS live from a large enough drive
             tests_incusos_live,
 
@@ -67,6 +52,24 @@ class IncusOSTests:
         # Test the flasher-tool utility
         flasher_tool_tests = [tests_flasher_tool]
 
+        # Tests specifically related to installation
+        install_tests = [
+            # Basic system pre-install checks
+            tests_system_checks,
+
+            # Baseline install smoke tests
+            tests_smoke,
+
+            # Test use of swtpm
+            tests_swtpm,
+
+            # Test disabling Secure Boot
+            tests_secureboot_disabled,
+
+            # Test installing on multipath
+            tests_multipath,
+        ]
+
         # Tests exercising the various seeds supported by IncusOS; application-specific seeds
         # are pretty well tested when the trusted client TLS certificate is injected into each
         # VM, so they aren't specifically tested here.
@@ -83,6 +86,7 @@ class IncusOSTests:
 
         ret = []
 
+        ret.extend(self._get_tests(install_tests, self.current_image_img))
         ret.extend(self._get_tests(core_tests, self.current_image_img))
         ret.extend(self._get_tests(seed_tests, self.current_image_img))
         ret.extend(self._get_tests(upgrade_tests, self.prior_image_img))

--- a/incus-osd/tests/incusos_tests/__init__.py
+++ b/incus-osd/tests/incusos_tests/__init__.py
@@ -6,7 +6,10 @@ from . import tests_flasher_tool, tests_incusos_api, tests_incusos_api_applicati
     tests_incusos_api_system_resources, tests_incusos_api_system_security, tests_incusos_api_system_storage, \
     tests_incusos_api_system_storage_local_pool, tests_incusos_live, tests_install_secureboot_disabled, \
     tests_install_multipath, tests_install_smoke, tests_install_swtpm, tests_install_system_checks, tests_recovery, \
-    tests_seed_applications, tests_seed_install, tests_upgrade
+    tests_upgrade
+
+from .seed import test_external_seed, test_applications, test_install, test_kernel, test_network, test_provider, \
+    test_security, test_update
 
 class IncusOSTests:
     def __init__(self, prior_image_img, current_image_img, current_image_iso):
@@ -38,12 +41,6 @@ class IncusOSTests:
             # Test installing on multipath
             tests_install_multipath,
 
-            # Basic application seed tests
-            tests_seed_applications,
-
-            # Basic install seed tests
-            tests_seed_install,
-
             # Test running IncusOS live from a large enough drive
             tests_incusos_live,
 
@@ -70,9 +67,24 @@ class IncusOSTests:
         # Test the flasher-tool utility
         flasher_tool_tests = [tests_flasher_tool]
 
+        # Tests exercising the various seeds supported by IncusOS; application-specific seeds
+        # are pretty well tested when the trusted client TLS certificate is injected into each
+        # VM, so they aren't specifically tested here.
+        seed_tests = [
+            test_external_seed,
+            test_applications,
+            test_install,
+            test_kernel,
+            test_network,
+            test_provider,
+            test_security,
+            test_update,
+        ]
+
         ret = []
 
         ret.extend(self._get_tests(core_tests, self.current_image_img))
+        ret.extend(self._get_tests(seed_tests, self.current_image_img))
         ret.extend(self._get_tests(upgrade_tests, self.prior_image_img))
         ret.extend(self._get_tests(iso_install_tests, self.current_image_iso))
         ret.extend(self._get_tests(flasher_tool_tests, ""))

--- a/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
+++ b/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
@@ -154,7 +154,7 @@ class IncusTestVM:
         if log in str(result.stdout):
             raise IncusOSException(f"wasn't expecting log entry '{log}' to appear")
 
-    def APIRequest(self, path, method="GET", body=None, content_type=None, return_raw_content=False, use_unix_socket=False):
+    def APIRequest(self, path, method="GET", body=None, content_type=None, return_raw_content=False, use_unix_socket=False, use_os_proxy=True):
         """Perform a HTTP REST API call, and return the result."""
         args = []
         cmd_input = None
@@ -170,7 +170,10 @@ class IncusTestVM:
 
                 self.vm_ip = match.group(1)
 
-            args = ["curl", "-k", "https://" + self.vm_ip + ":8443/os" + path, "-H", "X-IncusOS-Proxy: /"]
+            if use_os_proxy:
+                args = ["curl", "-k", "https://" + self.vm_ip + ":8443/os" + path, "-H", "X-IncusOS-Proxy: /"]
+            else:
+                args = ["curl", "-k", "https://" + self.vm_ip + ":8443" + path]
 
             if self.client_cert_file != "":
                 args.append("--cert")

--- a/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
+++ b/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
@@ -94,7 +94,7 @@ class IncusTestVM:
         else:
             subprocess.run(["incus", "stop", self.vm_name], capture_output=True, check=True, timeout=timeout)
 
-    def WaitSystemReady(self, os_version, source="/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0", target="/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root", application="incus", remove_devices=[], agent_timeout=300, secureboot_disabled=False):
+    def WaitSystemReady(self, os_version, source="/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0", target="/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root", application="incus", remove_devices=[], agent_timeout=300, secureboot_disabled=False, channel="stable"):
         """Wait for the system install to complete, the given application to be configured and the system become ready for use."""
 
         # Perform IncusOS install.
@@ -116,7 +116,7 @@ class IncusTestVM:
         self.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
         if not secureboot_disabled:
             self.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
-        self.WaitExpectedLog("incus-osd", "Downloading application update application="+application+" channel=stable version="+os_version)
+        self.WaitExpectedLog("incus-osd", "Downloading application update application="+application+" channel="+channel+" version="+os_version)
         self.WaitExpectedLog("incus-osd", "System is ready version="+os_version)
 
     def WaitAgentRunning(self, timeout=420):

--- a/incus-osd/tests/incusos_tests/install/tests_multipath.py
+++ b/incus-osd/tests/incusos_tests/install/tests_multipath.py
@@ -2,7 +2,7 @@ import os
 import re
 import tempfile
 
-from .incus_test_vm import IncusTestVM, IncusOSException, util
+from ..incus_test_vm import IncusTestVM, IncusOSException, util
 
 def TestInstallMultipath(install_image):
     test_name = "multipath"

--- a/incus-osd/tests/incusos_tests/install/tests_secureboot_disabled.py
+++ b/incus-osd/tests/incusos_tests/install/tests_secureboot_disabled.py
@@ -1,6 +1,6 @@
 import json
 
-from .incus_test_vm import IncusTestVM, IncusOSException, util
+from ..incus_test_vm import IncusTestVM, IncusOSException, util
 
 def TestInstallSecureBootDisabled(install_image):
     test_name = "secureboot-disabled"

--- a/incus-osd/tests/incusos_tests/install/tests_smoke.py
+++ b/incus-osd/tests/incusos_tests/install/tests_smoke.py
@@ -1,4 +1,4 @@
-from .incus_test_vm import IncusTestVM, util
+from ..incus_test_vm import IncusTestVM, util
 
 def TestInstallDontRemoveInstallMedia(install_image):
     test_name = "dont-remove-install-media"

--- a/incus-osd/tests/incusos_tests/install/tests_swtpm.py
+++ b/incus-osd/tests/incusos_tests/install/tests_swtpm.py
@@ -1,6 +1,6 @@
 import json
 
-from .incus_test_vm import IncusTestVM, IncusOSException, util
+from ..incus_test_vm import IncusTestVM, IncusOSException, util
 
 def TestInstallUseSWTPM(install_image):
     test_name = "use-swtpm"

--- a/incus-osd/tests/incusos_tests/install/tests_system_checks.py
+++ b/incus-osd/tests/incusos_tests/install/tests_system_checks.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import tempfile
 
-from .incus_test_vm import IncusTestVM, util
+from ..incus_test_vm import IncusTestVM, util
 
 def TestInstallNoSeed(install_image):
     test_name = "no-seed"

--- a/incus-osd/tests/incusos_tests/seed/test_applications.py
+++ b/incus-osd/tests/incusos_tests/seed/test_applications.py
@@ -1,7 +1,4 @@
-import os
-import tempfile
-
-from .incus_test_vm import IncusTestVM, util
+from ..incus_test_vm import IncusTestVM, util
 
 def TestSeedApplictionsEmpty(install_image):
     test_name = "seed-applications-empty"
@@ -49,6 +46,18 @@ def TestSeedApplictionsInvalid(install_image):
         # We shouldn't see anything about loading an invalid application.
         vm.LogDoesntContain("incus-osd", "Downloading application update application=foobarbiz")
 
+def TestSeedApplictionsDebug(install_image):
+    test_name = "seed-applications-debug"
+    test_seed = {
+        "install.json": "{}",
+        "applications.json": """{"applications":[{"name":"debug"}]}"""
+    }
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+        vm.WaitSystemReady(os_version, application="debug")
+
 def TestSeedApplictionsGPUSupport(install_image):
     test_name = "seed-applications-gpu-support"
     test_seed = {
@@ -72,6 +81,18 @@ def TestSeedApplictionsIncus(install_image):
 
     with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version, application="incus")
+
+def TestSeedApplictionsIncusLTS70(install_image):
+    test_name = "seed-applications-incus-lts-70"
+    test_seed = {
+        "install.json": "{}",
+        "applications.json": """{"applications":[{"name":"incus-lts-7.0"}]}"""
+    }
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+        vm.WaitSystemReady(os_version, application="incus-lts-7.0")
 
 def TestSeedApplictionsIncusCeph(install_image):
     test_name = "seed-applications-incus-ceph"
@@ -115,6 +136,18 @@ def TestSeedApplictionsMigrationManager(install_image):
     with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version, application="migration-manager")
 
+def TestSeedApplictionsOpenFGA(install_image):
+    test_name = "seed-applications-openfga"
+    test_seed = {
+        "install.json": "{}",
+        "applications.json": """{"applications":[{"name":"openfga"}]}"""
+    }
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+        vm.WaitSystemReady(os_version, application="openfga")
+
 def TestSeedApplictionsOperationsCenter(install_image):
     test_name = "seed-applications-operations-center"
     test_seed = {
@@ -126,25 +159,3 @@ def TestSeedApplictionsOperationsCenter(install_image):
 
     with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version, application="operations-center")
-
-def TestExternalSeedApplictionsMigrationManager(install_image):
-    test_name = "external-seed-applications-migration-manager"
-    test_seed = None
-
-    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
-
-    with tempfile.NamedTemporaryFile(dir=os.getcwd()) as seed_img:
-        # Create and populate a user-provided ISO with seed files on it
-        with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmp_dir:
-            with open(os.path.join(tmp_dir, "install.json"), "w") as seed:
-                seed.write("{}")
-
-            with open(os.path.join(tmp_dir, "applications.json"), "w") as seed:
-                seed.write("""{"applications":[{"name":"migration-manager"}]}""")
-
-            util._create_user_media(seed_img, tmp_dir, "iso", 0, "SEED_DATA")
-
-        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
-            vm.AttachISO(seed_img.name, "seed")
-
-            vm.WaitSystemReady(os_version, application="migration-manager", remove_devices=["seed"])

--- a/incus-osd/tests/incusos_tests/seed/test_external_seed.py
+++ b/incus-osd/tests/incusos_tests/seed/test_external_seed.py
@@ -1,0 +1,74 @@
+import os
+import tempfile
+
+from ..incus_test_vm import IncusTestVM, util
+
+def TestExternalSeedApplictionsMigrationManager(install_image):
+    test_name = "external-seed-applications-migration-manager"
+    test_seed = None
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with tempfile.NamedTemporaryFile(dir=os.getcwd()) as seed_img:
+        # Create and populate a user-provided ISO with seed files on it
+        with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmp_dir:
+            with open(os.path.join(tmp_dir, "install.json"), "w") as seed:
+                seed.write("{}")
+
+            with open(os.path.join(tmp_dir, "applications.json"), "w") as seed:
+                seed.write("""{"applications":[{"name":"migration-manager"}]}""")
+
+            util._create_user_media(seed_img, tmp_dir, "iso", 0, "SEED_DATA")
+
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+            vm.AttachISO(seed_img.name, "seed")
+
+            vm.WaitSystemReady(os_version, application="migration-manager", remove_devices=["seed"])
+
+def TestExternalSeedInstallEmpty(install_image):
+    test_name = "external-seed-install-empty"
+    test_seed = None
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with tempfile.NamedTemporaryFile(dir=os.getcwd()) as seed_img:
+        # Create and populate a user-provided ISO image with an empty install seed file on it
+        with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmp_dir:
+            with open(os.path.join(tmp_dir, "install.yaml"), "w") as seed:
+                seed.write("")
+
+            util._create_user_media(seed_img, tmp_dir, "iso", 0, "SEED_DATA")
+
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+            vm.AttachISO(seed_img.name, "seed")
+
+            # Perform IncusOS install.
+            vm.StartVM()
+            vm.WaitAgentRunning()
+            vm.WaitExpectedLog("incus-osd", "Installing " + os_name + " source=/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0 target=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root")
+            vm.WaitExpectedLog("incus-osd", os_name + " was successfully installed")
+
+def TestExternalSeedInstallTarget(install_image):
+    test_name = "external-seed-install-target"
+    test_seed = None
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img:
+        with tempfile.NamedTemporaryFile(dir=os.getcwd()) as seed_img:
+            # Create and populate a user-provided USB stick with a seed file on it
+            with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmp_dir:
+                with open(os.path.join(tmp_dir, "install.json"), "w") as seed:
+                    seed.write("""{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}""")
+
+                util._create_user_media(seed_img, tmp_dir, "img", 1024*1024*1024, "SEED_DATA")
+
+            with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+                vm.AddDevice("disk1", "disk", "source="+disk_img.name)
+                vm.AddDevice("recovery", "disk", "source="+seed_img.name, "io.bus=usb")
+
+                # Perform IncusOS install.
+                vm.StartVM()
+                vm.WaitAgentRunning()
+                vm.WaitExpectedLog("incus-osd", "Installing " + os_name + " source=/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0 target=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root")
+                vm.WaitExpectedLog("incus-osd", os_name + " was successfully installed")

--- a/incus-osd/tests/incusos_tests/seed/test_install.py
+++ b/incus-osd/tests/incusos_tests/seed/test_install.py
@@ -3,7 +3,7 @@ import subprocess
 import tempfile
 import time
 
-from .incus_test_vm import IncusTestVM, util
+from ..incus_test_vm import IncusTestVM, util
 
 def TestSeedInstallReboot(install_image):
     test_name = "seed-install-reboot"
@@ -69,6 +69,60 @@ def TestSeedInstallForce(install_image):
             vm.WaitExpectedLog("incus-osd", "Installing " + os_name + " source=/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0 target=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1")
             vm.WaitExpectedLog("incus-osd", os_name + " was successfully installed")
 
+def TestSeedInstallForceConfirmation(install_image):
+    test_name = "seed-install-force-confirmation"
+    test_seed = {
+        "install.yaml": "",
+    }
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+        # Wait for a normal install to complete
+        vm.WaitSystemReady(os_version)
+
+        # Get the machine ID
+        output = vm.RunCommand("cat", "/etc/machine-id")
+        confirmationValue = output.stdout.decode("utf-8")[:6]
+
+        # Re-attach the install media and update the install seed
+        vm.AddDevice("boot-media", "disk", "source="+test_image, "io.bus=usb", "boot.priority=10", "readonly=false")
+
+        # Allow time for the device to appear
+        time.sleep(5)
+
+        vm.RunCommand("mkdir", "/tmp/seed/")
+        vm.RunCommand("tar", "xf", "/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0-part2", "-C", "/tmp/seed/")
+        vm.RunCommand("sh", "-c", "echo 'force_install: true' >> /tmp/seed/install.yaml")
+        vm.RunCommand("tar", "cf", "/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0-part2", "-C", "/tmp/seed/", ".")
+
+        # Restart the VM and check that we get an error about ForceInstallConfirmation.
+        vm.StopVM()
+        vm.StartVM()
+        time.sleep(5)
+        vm.WaitAgentRunning()
+
+        vm.WaitExpectedLog("incus-osd", os_name + " is already installed on this system; to confirm overwriting, add `ForceInstallConfirmation=" + confirmationValue + "` to the install seed and reboot")
+
+        vm.RunCommand("mkdir", "/tmp/seed/")
+        vm.RunCommand("tar", "xf", "/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0-part2", "-C", "/tmp/seed/")
+        vm.RunCommand("sh", "-c", "echo 'force_install_confirmation: " + confirmationValue + "' >> /tmp/seed/install.yaml")
+        vm.RunCommand("tar", "cf", "/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0-part2", "-C", "/tmp/seed/", ".")
+
+        # Restart the VM and check that we then properly wipe the existing install.
+        vm.StopVM()
+        vm.StartVM()
+        time.sleep(5)
+        vm.WaitAgentRunning()
+
+        vm.WaitExpectedLog("incus-osd", "Wiping existing version of " + os_name + ", then rebooting in five seconds to run actual installation")
+
+        # Wait for the VM to auto-reboot and begin the installation once again
+        time.sleep(10)
+        vm.WaitAgentRunning()
+
+        vm.WaitExpectedLog("incus-osd", "Installing " + os_name + " source=")
+
 def TestSeedInstallEmpty(install_image):
     test_name = "seed-install-empty"
     test_seed = {
@@ -83,51 +137,3 @@ def TestSeedInstallEmpty(install_image):
         vm.WaitAgentRunning()
         vm.WaitExpectedLog("incus-osd", "Installing " + os_name + " source=/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0 target=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root")
         vm.WaitExpectedLog("incus-osd", os_name + " was successfully installed")
-
-def TestExternalSeedInstallEmpty(install_image):
-    test_name = "external-seed-install-empty"
-    test_seed = None
-
-    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
-
-    with tempfile.NamedTemporaryFile(dir=os.getcwd()) as seed_img:
-        # Create and populate a user-provided ISO image with an empty install seed file on it
-        with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmp_dir:
-            with open(os.path.join(tmp_dir, "install.yaml"), "w") as seed:
-                seed.write("")
-
-            util._create_user_media(seed_img, tmp_dir, "iso", 0, "SEED_DATA")
-
-        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
-            vm.AttachISO(seed_img.name, "seed")
-
-            # Perform IncusOS install.
-            vm.StartVM()
-            vm.WaitAgentRunning()
-            vm.WaitExpectedLog("incus-osd", "Installing " + os_name + " source=/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0 target=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root")
-            vm.WaitExpectedLog("incus-osd", os_name + " was successfully installed")
-
-def TestExternalSeedInstallTarget(install_image):
-    test_name = "external-seed-install-target"
-    test_seed = None
-
-    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
-
-    with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img:
-        with tempfile.NamedTemporaryFile(dir=os.getcwd()) as seed_img:
-            # Create and populate a user-provided USB stick with a seed file on it
-            with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmp_dir:
-                with open(os.path.join(tmp_dir, "install.json"), "w") as seed:
-                    seed.write("""{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}""")
-
-                util._create_user_media(seed_img, tmp_dir, "img", 1024*1024*1024, "SEED_DATA")
-
-            with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
-                vm.AddDevice("disk1", "disk", "source="+disk_img.name)
-                vm.AddDevice("recovery", "disk", "source="+seed_img.name, "io.bus=usb")
-
-                # Perform IncusOS install.
-                vm.StartVM()
-                vm.WaitAgentRunning()
-                vm.WaitExpectedLog("incus-osd", "Installing " + os_name + " source=/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0 target=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root")
-                vm.WaitExpectedLog("incus-osd", os_name + " was successfully installed")

--- a/incus-osd/tests/incusos_tests/seed/test_kernel.py
+++ b/incus-osd/tests/incusos_tests/seed/test_kernel.py
@@ -1,0 +1,19 @@
+from ..incus_test_vm import IncusTestVM, IncusOSException, util
+
+def TestSeedKernel(install_image):
+    test_name = "seed-kernel"
+    test_seed = {
+        "install.json": "{}",
+        "kernel.json": """{"console":[{"device":"/dev/ttyS0","baud_rate":115200}]}"""
+    }
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+        vm.WaitSystemReady(os_version)
+
+        # Verify the baud rate has been updated from the default of 9600
+        output = vm.RunCommand("/usr/bin/stty", "-F", "/dev/ttyS0", "speed")
+
+        if output.stdout.decode("utf-8").strip() != "115200":
+            raise IncusOSException("baud rate for /dev/ttyS0 != 115200")

--- a/incus-osd/tests/incusos_tests/seed/test_network.py
+++ b/incus-osd/tests/incusos_tests/seed/test_network.py
@@ -1,0 +1,31 @@
+from ..incus_test_vm import IncusTestVM, IncusOSException, util
+
+def TestSeedNetwork(install_image):
+    test_name = "seed-network"
+    test_seed = {
+        "install.json": "{}",
+        "network.json": """{"dns":{"domain":"example.org","hostname":"myserver"},"time":{"timezone":"America/Denver"},"interfaces":[{"addresses":["dhcp4","slaac"],"name":"enp5s0","hwaddr":"enp5s0"}]}"""
+    }
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+        vm.WaitSystemReady(os_version)
+
+        # Check that we get back the expected network configuration.
+        result = vm.APIRequest("/1.0/system/network")
+        if result["status_code"] != 200:
+            raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+        if len(result["metadata"]["state"]["interfaces"]) != 1:
+            raise IncusOSException("expected a single network interface to exist")
+
+        output = vm.RunCommand("timedatectl", "show")
+
+        if "Timezone=America/Denver" not in output.stdout.decode("utf-8"):
+            raise IncusOSException("system timezone doesn't match seed configuration")
+
+        output = vm.RunCommand("hostnamectl", "hostname")
+
+        if output.stdout.decode("utf-8").strip() != "myserver.example.org":
+            raise IncusOSException("system hostname doesn't match seed configuration")

--- a/incus-osd/tests/incusos_tests/seed/test_provider.py
+++ b/incus-osd/tests/incusos_tests/seed/test_provider.py
@@ -1,0 +1,69 @@
+from ..incus_test_vm import IncusTestVM, IncusOSException, util
+
+def TestSeedProvider(install_image):
+    test_name = "seed-provider"
+    test_seed = {
+        "install.json": "{}",
+        "provider.json": """{"name":"debug","config":{"myKey":"testing"}}"""
+    }
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+        # Perform IncusOS install.
+        vm.StartVM()
+        vm.WaitAgentRunning()
+        vm.WaitExpectedLog("incus-osd", "Installing " + os_name + " source=/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0 target=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root")
+        vm.WaitExpectedLog("incus-osd", os_name + " was successfully installed")
+
+        # Stop the VM post-install and remove install media.
+        vm.StopVM()
+        vm.RemoveDevice("boot-media")
+
+        # Start freshly installed IncusOS and verify the provider seed was properly applied.
+        vm.StartVM()
+        vm.WaitAgentRunning()
+        vm.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
+        vm.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
+        vm.WaitExpectedLog("incus-osd", "System is ready version="+os_version)
+
+        # We shouldn't see anything about loading an application from the debug provider.
+        vm.LogDoesntContain("incus-osd", "Downloading application update application=")
+
+        # Check that we get back the expected provider configuration.
+        result = vm.APIRequest("/1.0/system/provider", use_unix_socket=True)
+        if result["status_code"] != 200:
+            raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+        if result["metadata"]["config"]["name"] != "debug":
+            raise IncusOSException("expected provider name to be 'debug'")
+
+        if result["metadata"]["config"]["config"]["myKey"] != "testing":
+            raise IncusOSException("expected provider configuration key 'myKey' to be 'testing'")
+
+def TestSeedProviderInvalid(install_image):
+    test_name = "seed-provider-invalid"
+    test_seed = {
+        "install.json": "{}",
+        "provider.json": """{"name":"bizbaz"}"""
+    }
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+        # Perform IncusOS install.
+        vm.StartVM()
+        vm.WaitAgentRunning()
+        vm.WaitExpectedLog("incus-osd", "Installing " + os_name + " source=/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0 target=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root")
+        vm.WaitExpectedLog("incus-osd", os_name + " was successfully installed")
+
+        # Stop the VM post-install and remove install media.
+        vm.StopVM()
+        vm.RemoveDevice("boot-media")
+
+        # Start freshly installed IncusOS and check for the expected error loading the provider.
+        vm.StartVM()
+        vm.WaitAgentRunning()
+        vm.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
+        vm.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
+        vm.WaitExpectedLog("incus-osd", "unknown provider \"bizbaz\"")

--- a/incus-osd/tests/incusos_tests/seed/test_security.py
+++ b/incus-osd/tests/incusos_tests/seed/test_security.py
@@ -1,0 +1,44 @@
+from ..incus_test_vm import IncusTestVM, IncusOSException, util
+
+def TestSeedSecurity(install_image):
+    test_name = "seed-security"
+    test_seed = {
+        "install.json": "{}",
+        "security.json": """{"custom_ca_certs":["-----BEGIN CERTIFICATE-----\\nMIIBrTCCAVOgAwIBAgIUSzoVuJh5V+uJMeJxYh6K+YoCBXMwCgYIKoZIzj0EAwMw\\nLDEZMBcGA1UEAwwQVGVzdE9TIC0gUm9vdCBFMTEPMA0GA1UECgwGVGVzdE9TMB4X\\nDTI2MDYyMzE0MjkzN1oXDTM2MDYyMDE0MjkzN1owLDEZMBcGA1UEAwwQVGVzdE9T\\nIC0gUm9vdCBFMTEPMA0GA1UECgwGVGVzdE9TMFkwEwYHKoZIzj0CAQYIKoZIzj0D\\nAQcDQgAEnCNObq07+z6WBwEIfMPKGrNHD0GTeDiSm371JfwQUz2P2YmZrDXBIgkg\\nAsFcF2fMNie5x+CVtpOR6ybkrxCvq6NTMFEwHQYDVR0OBBYEFDXTcCO5mk85DELG\\nx0iAmpivf2ErMB8GA1UdIwQYMBaAFDXTcCO5mk85DELGx0iAmpivf2ErMA8GA1Ud\\nEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwMDSAAwRQIgT+n1+wuRCfFb8ZSJDTwGPYZA\\ng87AdIeLEcQ3x/uZpgoCIQD2Wjk/L4HdWJn0OlipAsLww6mTWq4EndK/2NQQRlam\\nCw==\\n-----END CERTIFICATE-----\\n"]}"""
+    }
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+        vm.WaitSystemReady(os_version)
+
+        # Verify IncusOS found and applied the custom CA certificate.
+        vm.WaitExpectedLog("incus-osd", "Custom CAs configured from security seed, restarting incus-osd daemon")
+
+        # Check that we get back the expected security configuration.
+        result = vm.APIRequest("/1.0/system/security")
+        if result["status_code"] != 200:
+            raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+        if len(result["metadata"]["config"]["custom_ca_certs"]) != 1:
+            raise IncusOSException("expected exactly one custom CA certificate")
+
+        # Verify the custom CA certificate is present in the system store.
+        vm.RunCommand("grep", "AQcDQgAEnCNObq07+z6WBwEIfMPKGrNHD0GTeDiSm371JfwQUz2P2YmZrDXBIgkg", "/etc/ssl/certs/ca-certificates.crt")
+
+def TestSeedSecurityInvalid(install_image):
+    test_name = "seed-security-invalid"
+    test_seed = {
+        "install.json": "{}",
+        "security.json": """{"encryption_recovery_keys":["my-password"]}"""
+    }
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+        # Perform IncusOS install.
+        vm.StartVM()
+        vm.WaitAgentRunning()
+
+        # Verify attempting to set encryption recovery keys via the seed is rejected.
+        vm.WaitExpectedLog("incus-osd", "it is not possible to set encryption recovery key(s) via the security seed")

--- a/incus-osd/tests/incusos_tests/seed/test_update.py
+++ b/incus-osd/tests/incusos_tests/seed/test_update.py
@@ -1,0 +1,42 @@
+from ..incus_test_vm import IncusTestVM, IncusOSException, util
+
+def TestSeedUpdate(install_image):
+    test_name = "seed-update"
+    test_seed = {
+        "install.json": "{}",
+        "update.json": """{"auto_reboot":true,"channel":"testing","check_frequency":"1h","maintenance_windows":[{"start_hour":6,"start_minute":15,"end_hour":16,"end_minute":30}]}"""
+    }
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+        vm.WaitSystemReady(os_version, channel="testing")
+
+        # Check that we get back the expected update configuration.
+        result = vm.APIRequest("/1.0/system/update")
+        if result["status_code"] != 200:
+            raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+        if not result["metadata"]["config"]["auto_reboot"]:
+            raise IncusOSException("expected auto_reboot to be true")
+
+        if result["metadata"]["config"]["channel"] != "testing":
+            raise IncusOSException("expected channel to be 'testing'")
+
+        if result["metadata"]["config"]["check_frequency"] != "1h":
+            raise IncusOSException("expected check_frequency to be '1h'")
+
+        if len(result["metadata"]["config"]["maintenance_windows"]) != 1:
+            raise IncusOSException("expected a single maintenance window to be defined")
+
+        if result["metadata"]["config"]["maintenance_windows"][0]["start_hour"] != 6:
+            raise IncusOSException("expected start_hour to be 6")
+
+        if result["metadata"]["config"]["maintenance_windows"][0]["start_minute"] != 15:
+            raise IncusOSException("expected start_minute to be 15")
+
+        if result["metadata"]["config"]["maintenance_windows"][0]["end_hour"] != 16:
+            raise IncusOSException("expected end_hour to be 16")
+
+        if result["metadata"]["config"]["maintenance_windows"][0]["end_minute"] != 30:
+            raise IncusOSException("expected end_minute to be 30")

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_applications.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_applications.py
@@ -57,6 +57,8 @@ def TestIncusOSAPIApplicationsIncus(install_image):
 
         time.sleep(5)
 
+        vm.LogDoesntContain("incus-osd", "Failed to perform factory reset of application 'incus'")
+
         # Verify our test file is no longer present
         result = vm.RunCommand("stat", "/var/lib/incus/test-file", check=False)
         if result.returncode == 0:
@@ -120,6 +122,8 @@ def TestIncusOSAPIApplicationsMigrationManager(install_image):
 
         time.sleep(5)
 
+        vm.LogDoesntContain("incus-osd", "Failed to perform factory reset of application 'migration-manager'")
+
         # Verify our test file is no longer present
         result = vm.RunCommand("stat", "/var/lib/migration-manager/test-file", check=False)
         if result.returncode == 0:
@@ -181,7 +185,11 @@ def TestIncusOSAPIApplicationsOperationsCenter(install_image):
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-        time.sleep(30)
+        # We need a really long sleep here. Operations Center takes a while to shutdown, although the factory reset
+        # API call returns immediately. In local testing it took about 70 seconds for the reset process to complete.
+        time.sleep(120)
+
+        vm.LogDoesntContain("incus-osd", "Failed to perform factory reset of application 'operations-center'")
 
         # Verify our test file is no longer present
         result = vm.RunCommand("stat", "/var/lib/operations-center/test-file", check=False)

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_provider.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_provider.py
@@ -1,3 +1,6 @@
+import os
+import time
+
 from .incus_test_vm import IncusTestVM, IncusOSException, util
 
 def TestIncusOSAPISystemProviderImages(install_image):
@@ -29,10 +32,23 @@ def TestIncusOSAPISystemProviderOperationsCenter(install_image):
         "applications.json": """{"applications":[{"name":"operations-center"}]}"""
     }
 
+    # If the default images server has been overridden, assume we're testing against a local build of IncusOS
+    # and grab the local root CA certificate so Operations Center can properly verify the signed json metadata.
+    IMAGES_SERVER = os.getenv("IMAGES_SERVER")
+    if IMAGES_SERVER is not None:
+        with open("incus-osd/certs/files/root-E1.crt") as f:
+            contents = f.read().replace("\n", "\\n")
+
+            # Configure the Operations Center seed to point to the local images server
+            test_seed["operations-center.json"] = '{"preseed":{"system_updates":{"source":"' + IMAGES_SERVER + '/os","signature_verification_root_ca":"' + contents + '"}}}'
+
     test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
 
     with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
         vm.WaitSystemReady(os_version, application="operations-center")
+
+        vm.WaitExpectedLog("incus-osd", "Server successfully deregistered from the 'images' provider")
+        vm.WaitExpectedLog("incus-osd", "Server successfully registered with the 'operations-center' provider")
 
         # Get current provider configuration.
         result = vm.APIRequest("/1.0/system/provider")
@@ -60,3 +76,30 @@ def TestIncusOSAPISystemProviderOperationsCenter(install_image):
 
         if not result["metadata"]["state"]["registered"]:
             raise IncusOSException("provider 'operations-center' should be registered")
+
+        # Trigger a provisioning update refresh, and wait until it finishes.
+        result = vm.APIRequest("/1.0/provisioning/updates/:refresh?wait=true", method="POST", use_os_proxy=False)
+        if result["status_code"] != 200:
+            raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+        found_update = False
+
+        # Verify that we get back an expected update with the same version that the system is currently running.
+        result = vm.APIRequest("/1.0/provisioning/updates?recursion=1", use_os_proxy=False)
+        if result["status_code"] != 200:
+            raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+        for update in result["metadata"]:
+            if update["version"] == os_version and update["update_status"] == "ready":
+                found_update = True
+
+        if not found_update:
+            raise IncusOSException("Operations Center failed to fetch available updates")
+
+        # Install the debug application via local Operations Center
+        result = vm.APIRequest("/1.0/applications", method="POST", body="""{"name":"debug"}""")
+        if result["status_code"] != 200:
+            raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+        vm.WaitExpectedLog("incus-osd", "Downloading application update application=debug channel=stable version="+os_version)
+        vm.WaitExpectedLog("incus-osd", "Initializing application name=debug version="+os_version)


### PR DESCRIPTION
* Add tests to exercise all currently available seeds
* Reorganize and group install and seed tests
* Extend sleep time required while waiting for Operations Center to perform its factory reset
* Extend existing Operations Center test to use it as a provider when installing an application post-install

Also update the seed reference documentation

Closes #458