### PR TITLE
incus-osd: Include subsystems info when getting targets

### DIFF
--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -456,7 +456,7 @@ func getAllTargets(ctx context.Context, sourceDevice string) ([]storage.BlockDev
 	// Get NVME drives first.
 	nvmeTargets := storage.LsblkOutput{}
 
-	output, err := subprocess.RunCommandContext(ctx, "lsblk", "-N", "-iJnpb", "-e", "1,2", "-o", "KNAME,ID_LINK,SIZE")
+	output, err := subprocess.RunCommandContext(ctx, "lsblk", "-N", "-iJnpb", "-e", "1,2", "-o", "KNAME,ID_LINK,SIZE,SUBSYSTEMS")
 	if err != nil {
 		return []storage.BlockDevices{}, err
 	}
@@ -471,7 +471,7 @@ func getAllTargets(ctx context.Context, sourceDevice string) ([]storage.BlockDev
 	// Get SCSI drives second.
 	scsiTargets := storage.LsblkOutput{}
 
-	output, err = subprocess.RunCommandContext(ctx, "lsblk", "-S", "-iJnpb", "-e", "1,2", "-o", "KNAME,ID_LINK,SIZE")
+	output, err = subprocess.RunCommandContext(ctx, "lsblk", "-S", "-iJnpb", "-e", "1,2", "-o", "KNAME,ID_LINK,SIZE,SUBSYSTEMS")
 	if err != nil {
 		return []storage.BlockDevices{}, err
 	}
@@ -487,7 +487,7 @@ func getAllTargets(ctx context.Context, sourceDevice string) ([]storage.BlockDev
 	mmcTargets := storage.LsblkOutput{}
 
 	// MMC block devices have major number 179 (https://www.kernel.org/doc/Documentation/admin-guide/devices.txt)
-	output, err = subprocess.RunCommandContext(ctx, "lsblk", "-I", "179", "-iJnpb", "-o", "KNAME,ID_LINK,SIZE")
+	output, err = subprocess.RunCommandContext(ctx, "lsblk", "-I", "179", "-iJnpb", "-o", "KNAME,ID_LINK,SIZE,SUBSYSTEMS")
 	if err != nil {
 		return []storage.BlockDevices{}, err
 	}
@@ -502,7 +502,7 @@ func getAllTargets(ctx context.Context, sourceDevice string) ([]storage.BlockDev
 	// Get virtual drives last.
 	virtualTargets := storage.LsblkOutput{}
 
-	output, err = subprocess.RunCommandContext(ctx, "lsblk", "-v", "-iJnpb", "-e", "1,2", "-o", "KNAME,ID_LINK,SIZE")
+	output, err = subprocess.RunCommandContext(ctx, "lsblk", "-v", "-iJnpb", "-e", "1,2", "-o", "KNAME,ID_LINK,SIZE,SUBSYSTEMS")
 	if err != nil {
 		return []storage.BlockDevices{}, err
 	}

--- a/incus-osd/tests/incusos_tests/seed/test_install.py
+++ b/incus-osd/tests/incusos_tests/seed/test_install.py
@@ -27,8 +27,8 @@ def TestSeedInstallReboot(install_image):
         vm.WaitAgentRunning()
         vm.WaitExpectedLog("incus-osd", "System check error: install media detected, but the system is already installed; please remove USB/CDROM and reboot the system")
 
-def TestSeedInstallTarget(install_image):
-    test_name = "seed-install-target"
+def TestSeedInstallTargetID(install_image):
+    test_name = "seed-install-target-id"
     test_seed = {
         "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}"""
     }
@@ -43,6 +43,26 @@ def TestSeedInstallTarget(install_image):
             vm.StartVM()
             vm.WaitAgentRunning()
             vm.WaitExpectedLog("incus-osd", "Installing " + os_name + " source=/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0 target=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root")
+            vm.WaitExpectedLog("incus-osd", os_name + " was successfully installed")
+
+def TestSeedInstallTargetBus(install_image):
+    test_name = "seed-install-target-bus"
+    test_seed = {
+        "install.json": """{"target":{"bus":"nvme","sort_order":"smallest"}}"""
+    }
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img:
+        disk_img.truncate(55*1024*1024*1024)
+
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+            vm.AddDevice("disk1", "disk", "source="+disk_img.name, "io.bus=nvme")
+
+            # Perform IncusOS install.
+            vm.StartVM()
+            vm.WaitAgentRunning()
+            vm.WaitExpectedLog("incus-osd", "Installing " + os_name + " source=/dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:01.0:00.6-4-0:0 target=/dev/disk/by-id/nvme-QEMU_NVMe_Ctrl_incus_disk1")
             vm.WaitExpectedLog("incus-osd", os_name + " was successfully installed")
 
 def TestSeedInstallForce(install_image):


### PR DESCRIPTION
I used the IncusOS image downloader WEB UI wizard to create an installation image, but the installer was not being able to find and pick the specific nvme when the "Target drive bus" field was filled in with "nvme".

I believe this patch should fix the issue.

Example:
```
$ lsblk -N -iJnpb -e 1,2 -o KNAME,ID_LINK,SIZE 
{
   "blockdevices": [
      {
         "kname": "/dev/nvme0n1",
         "id-link": "nvme-eui.001b448b491b9b6c",
         "size": 512110190592
      }
   ]
}
$ 
$ lsblk -N -iJnpb -e 1,2 -o KNAME,ID_LINK,SIZE,SUBSYSTEMS
{
   "blockdevices": [
      {
         "kname": "/dev/nvme0n1",
         "id-link": "nvme-eui.001b448b491b9b6c",
         "size": 512110190592,
         "subsystems": "block:nvme:pci"
      }
   ]
}
$ 
```