### PR TITLE
Ensure MAC addresses are unique in network configuration

### DIFF
--- a/incus-osd/cli/cli_system_info_resources.go
+++ b/incus-osd/cli/cli_system_info_resources.go
@@ -22,135 +22,147 @@ func renderResourcesInfo(resp *incusapi.Response) error {
 	renderResourcesSystem(resources.System)
 
 	// Load.
-	fmt.Print("\nLoad:\n") //nolint:forbidigo
+	_, _ = fmt.Print("\nLoad:\n") //nolint:forbidigo
 
 	if resources.Load.Processes > 0 {
-		fmt.Printf("  Processes: %d\n", resources.Load.Processes)                                                                      //nolint:forbidigo
-		fmt.Printf("  Average: %.2f %.2f %.2f\n", resources.Load.Average1Min, resources.Load.Average5Min, resources.Load.Average10Min) //nolint:forbidigo
+		_, _ = fmt.Printf("  Processes: %d\n", resources.Load.Processes)                                                                      //nolint:forbidigo
+		_, _ = fmt.Printf("  Average: %.2f %.2f %.2f\n", resources.Load.Average1Min, resources.Load.Average5Min, resources.Load.Average10Min) //nolint:forbidigo
 	}
 
 	// CPU.
 	if len(resources.CPU.Sockets) == 1 {
-		fmt.Print("\nCPU:\n")                                          //nolint:forbidigo
-		fmt.Printf("  Architecture: %s\n", resources.CPU.Architecture) //nolint:forbidigo
+		_, _ = fmt.Print("\nCPU:\n")                                          //nolint:forbidigo
+		_, _ = fmt.Printf("  Architecture: %s\n", resources.CPU.Architecture) //nolint:forbidigo
 		renderResourcesCPU(resources.CPU.Sockets[0], "  ")
 	} else if len(resources.CPU.Sockets) > 1 {
-		fmt.Print("CPUs:\n")                                           //nolint:forbidigo
-		fmt.Printf("  Architecture: %s\n", resources.CPU.Architecture) //nolint:forbidigo
+		_, _ = fmt.Print("CPUs:\n")                                           //nolint:forbidigo
+		_, _ = fmt.Printf("  Architecture: %s\n", resources.CPU.Architecture) //nolint:forbidigo
 
 		for _, socket := range resources.CPU.Sockets {
-			fmt.Printf("  Socket %d:\n", socket.Socket) //nolint:forbidigo
+			_, _ = fmt.Printf("  Socket %d:\n", socket.Socket) //nolint:forbidigo
 			renderResourcesCPU(socket, "    ")
 		}
 	}
 
 	// Memory.
-	fmt.Print("\nMemory:\n") //nolint:forbidigo
+	_, _ = fmt.Print("\nMemory:\n") //nolint:forbidigo
 
 	if resources.Memory.HugepagesTotal > 0 {
-		fmt.Print("  Hugepages:\n")                                                                                                        //nolint:forbidigo
-		fmt.Printf("    Free: %v\n", units.GetByteSizeStringIEC(int64(resources.Memory.HugepagesTotal-resources.Memory.HugepagesUsed), 2)) //nolint:forbidigo,gosec
-		fmt.Printf("    Used: %v\n", units.GetByteSizeStringIEC(int64(resources.Memory.HugepagesUsed), 2))                                 //nolint:forbidigo,gosec
-		fmt.Printf("    Total: %v\n", units.GetByteSizeStringIEC(int64(resources.Memory.HugepagesTotal), 2))                               //nolint:forbidigo,gosec
+		_, _ = fmt.Print("  Hugepages:\n")                                                                                                        //nolint:forbidigo
+		_, _ = fmt.Printf("    Free: %v\n", units.GetByteSizeStringIEC(int64(resources.Memory.HugepagesTotal-resources.Memory.HugepagesUsed), 2)) //nolint:forbidigo,gosec
+		_, _ = fmt.Printf("    Used: %v\n", units.GetByteSizeStringIEC(int64(resources.Memory.HugepagesUsed), 2))                                 //nolint:forbidigo,gosec
+		_, _ = fmt.Printf("    Total: %v\n", units.GetByteSizeStringIEC(int64(resources.Memory.HugepagesTotal), 2))                               //nolint:forbidigo,gosec
 	}
 
 	if len(resources.Memory.Nodes) > 1 {
-		fmt.Print("  NUMA nodes:\n") //nolint:forbidigo
+		_, _ = fmt.Print("  NUMA nodes:\n") //nolint:forbidigo
 
 		for _, node := range resources.Memory.Nodes {
-			fmt.Printf("    Node %d:\n", node.NUMANode) //nolint:forbidigo
+			_, _ = fmt.Printf("    Node %d:\n", node.NUMANode) //nolint:forbidigo
 
 			if node.HugepagesTotal > 0 {
-				fmt.Print("      Hugepages:" + "\n")                                                                              //nolint:forbidigo
-				fmt.Printf("        Free: %v"+"\n", units.GetByteSizeStringIEC(int64(node.HugepagesTotal-node.HugepagesUsed), 2)) //nolint:forbidigo,gosec
-				fmt.Printf("        Used: %v"+"\n", units.GetByteSizeStringIEC(int64(node.HugepagesUsed), 2))                     //nolint:forbidigo,gosec
-				fmt.Printf("        Total: %v"+"\n", units.GetByteSizeStringIEC(int64(node.HugepagesTotal), 2))                   //nolint:forbidigo,gosec
+				_, _ = fmt.Print("      Hugepages:" + "\n")                                                                              //nolint:forbidigo
+				_, _ = fmt.Printf("        Free: %v"+"\n", units.GetByteSizeStringIEC(int64(node.HugepagesTotal-node.HugepagesUsed), 2)) //nolint:forbidigo,gosec
+				_, _ = fmt.Printf("        Used: %v"+"\n", units.GetByteSizeStringIEC(int64(node.HugepagesUsed), 2))                     //nolint:forbidigo,gosec
+				_, _ = fmt.Printf("        Total: %v"+"\n", units.GetByteSizeStringIEC(int64(node.HugepagesTotal), 2))                   //nolint:forbidigo,gosec
 			}
 
-			fmt.Printf("      Free: %v"+"\n", units.GetByteSizeStringIEC(int64(node.Total-node.Used), 2)) //nolint:forbidigo,gosec
-			fmt.Printf("      Used: %v"+"\n", units.GetByteSizeStringIEC(int64(node.Used), 2))            //nolint:forbidigo,gosec
-			fmt.Printf("      Total: %v"+"\n", units.GetByteSizeStringIEC(int64(node.Total), 2))          //nolint:forbidigo,gosec
+			_, _ = fmt.Printf("      Free: %v"+"\n", units.GetByteSizeStringIEC(int64(node.Total-node.Used), 2)) //nolint:forbidigo,gosec
+			_, _ = fmt.Printf("      Used: %v"+"\n", units.GetByteSizeStringIEC(int64(node.Used), 2))            //nolint:forbidigo,gosec
+			_, _ = fmt.Printf("      Total: %v"+"\n", units.GetByteSizeStringIEC(int64(node.Total), 2))          //nolint:forbidigo,gosec
 		}
 	}
 
-	fmt.Printf("  "+"Free: %v\n", units.GetByteSizeStringIEC(int64(resources.Memory.Total-resources.Memory.Used), 2)) //nolint:forbidigo,gosec
-	fmt.Printf("  "+"Used: %v\n", units.GetByteSizeStringIEC(int64(resources.Memory.Used), 2))                        //nolint:forbidigo,gosec
-	fmt.Printf("  "+"Total: %v\n", units.GetByteSizeStringIEC(int64(resources.Memory.Total), 2))                      //nolint:forbidigo,gosec
+	_, _ = fmt.Printf("  "+"Free: %v\n", units.GetByteSizeStringIEC(int64(resources.Memory.Total-resources.Memory.Used), 2)) //nolint:forbidigo,gosec
+	_, _ = fmt.Printf("  "+"Used: %v\n", units.GetByteSizeStringIEC(int64(resources.Memory.Used), 2))                        //nolint:forbidigo,gosec
+	_, _ = fmt.Printf("  "+"Total: %v\n", units.GetByteSizeStringIEC(int64(resources.Memory.Total), 2))                      //nolint:forbidigo,gosec
 
 	// GPUs.
 	if len(resources.GPU.Cards) == 1 {
-		fmt.Print("\nGPU:\n") //nolint:forbidigo
+		_, _ = fmt.Print("\nGPU:\n") //nolint:forbidigo
+
 		renderResourcesGPU(resources.GPU.Cards[0], "  ", true)
 	} else if len(resources.GPU.Cards) > 1 {
-		fmt.Print("\nGPUs:\n") //nolint:forbidigo
+		_, _ = fmt.Print("\nGPUs:\n") //nolint:forbidigo
 
 		for id, gpu := range resources.GPU.Cards {
-			fmt.Printf("  Card %d:\n", id) //nolint:forbidigo
+			_, _ = fmt.Printf("  Card %d:\n", id) //nolint:forbidigo
+
 			renderResourcesGPU(gpu, "    ", true)
 		}
 	}
 
 	// NICs.
 	if len(resources.Network.Cards) == 1 {
-		fmt.Print("\nNIC:\n") //nolint:forbidigo
+		_, _ = fmt.Print("\nNIC:\n") //nolint:forbidigo
+
 		renderResourcesNIC(resources.Network.Cards[0], "  ", true)
 	} else if len(resources.Network.Cards) > 1 {
-		fmt.Print("\nNICs:\n") //nolint:forbidigo
+		_, _ = fmt.Print("\nNICs:\n") //nolint:forbidigo
 
 		for id, nic := range resources.Network.Cards {
-			fmt.Printf("  Card %d:\n", id) //nolint:forbidigo
+			_, _ = fmt.Printf("  Card %d:\n", id) //nolint:forbidigo
+
 			renderResourcesNIC(nic, "    ", true)
 		}
 	}
 
 	// Storage.
 	if len(resources.Storage.Disks) == 1 {
-		fmt.Print("\nDisk:\n") //nolint:forbidigo
+		_, _ = fmt.Print("\nDisk:\n") //nolint:forbidigo
+
 		renderResourcesDisk(resources.Storage.Disks[0], "  ", true)
 	} else if len(resources.Storage.Disks) > 1 {
-		fmt.Print("\nDisks:\n") //nolint:forbidigo
+		_, _ = fmt.Print("\nDisks:\n") //nolint:forbidigo
 
 		for id, disk := range resources.Storage.Disks {
-			fmt.Printf("  Disk %d:\n", id) //nolint:forbidigo
+			_, _ = fmt.Printf("  Disk %d:\n", id) //nolint:forbidigo
+
 			renderResourcesDisk(disk, "    ", true)
 		}
 	}
 
 	// USB.
 	if len(resources.USB.Devices) == 1 {
-		fmt.Print("\nUSB device:\n") //nolint:forbidigo
+		_, _ = fmt.Print("\nUSB device:\n") //nolint:forbidigo
+
 		renderResourcesUSB(resources.USB.Devices[0], "  ")
 	} else if len(resources.USB.Devices) > 1 {
-		fmt.Print("\nUSB devices:\n") //nolint:forbidigo
+		_, _ = fmt.Print("\nUSB devices:\n") //nolint:forbidigo
 
 		for id, usb := range resources.USB.Devices {
-			fmt.Printf("  Device %d:\n", id) //nolint:forbidigo
+			_, _ = fmt.Printf("  Device %d:\n", id) //nolint:forbidigo
+
 			renderResourcesUSB(usb, "    ")
 		}
 	}
 
 	// PCI.
 	if len(resources.PCI.Devices) == 1 {
-		fmt.Print("\nPCI device:\n") //nolint:forbidigo
+		_, _ = fmt.Print("\nPCI device:\n") //nolint:forbidigo
+
 		renderResourcesPCI(resources.PCI.Devices[0], "  ")
 	} else if len(resources.PCI.Devices) > 1 {
-		fmt.Print("\nPCI devices:\n") //nolint:forbidigo
+		_, _ = fmt.Print("\nPCI devices:\n") //nolint:forbidigo
 
 		for id, pci := range resources.PCI.Devices {
-			fmt.Printf("  Device %d:\n", id) //nolint:forbidigo
+			_, _ = fmt.Printf("  Device %d:\n", id) //nolint:forbidigo
+
 			renderResourcesPCI(pci, "    ")
 		}
 	}
 
 	// Serial.
 	if len(resources.Serial.Devices) == 1 {
-		fmt.Print("\nSerial device:\n") //nolint:forbidigo
+		_, _ = fmt.Print("\nSerial device:\n") //nolint:forbidigo
+
 		renderResourcesSerial(resources.Serial.Devices[0], "  ")
 	} else if len(resources.Serial.Devices) > 1 {
-		fmt.Print("\nSerial devices:\n") //nolint:forbidigo
+		_, _ = fmt.Print("\nSerial devices:\n") //nolint:forbidigo
 
 		for id, serial := range resources.Serial.Devices {
-			fmt.Printf("  Device %d:\n", id) //nolint:forbidigo
+			_, _ = fmt.Printf("  Device %d:\n", id) //nolint:forbidigo
+
 			renderResourcesSerial(serial, "    ")
 		}
 	}
@@ -159,205 +171,205 @@ func renderResourcesInfo(resp *incusapi.Response) error {
 }
 
 func renderResourcesSystem(system incusapi.ResourcesSystem) {
-	fmt.Print("System:\n") //nolint:forbidigo
+	_, _ = fmt.Print("System:\n") //nolint:forbidigo
 
 	if system.UUID != "" {
-		fmt.Printf("  "+"UUID: %v\n", system.UUID) //nolint:forbidigo
+		_, _ = fmt.Printf("  "+"UUID: %v\n", system.UUID) //nolint:forbidigo
 	}
 
 	if system.Vendor != "" {
-		fmt.Printf("  "+"Vendor: %v\n", system.Vendor) //nolint:forbidigo
+		_, _ = fmt.Printf("  "+"Vendor: %v\n", system.Vendor) //nolint:forbidigo
 	}
 
 	if system.Product != "" {
-		fmt.Printf("  "+"Product: %v\n", system.Product) //nolint:forbidigo
+		_, _ = fmt.Printf("  "+"Product: %v\n", system.Product) //nolint:forbidigo
 	}
 
 	if system.Family != "" {
-		fmt.Printf("  "+"Family: %v\n", system.Family) //nolint:forbidigo
+		_, _ = fmt.Printf("  "+"Family: %v\n", system.Family) //nolint:forbidigo
 	}
 
 	if system.Version != "" {
-		fmt.Printf("  "+"Version: %v\n", system.Version) //nolint:forbidigo
+		_, _ = fmt.Printf("  "+"Version: %v\n", system.Version) //nolint:forbidigo
 	}
 
 	if system.Sku != "" {
-		fmt.Printf("  "+"SKU: %v\n", system.Sku) //nolint:forbidigo
+		_, _ = fmt.Printf("  "+"SKU: %v\n", system.Sku) //nolint:forbidigo
 	}
 
 	if system.Serial != "" {
-		fmt.Printf("  "+"Serial: %v\n", system.Serial) //nolint:forbidigo
+		_, _ = fmt.Printf("  "+"Serial: %v\n", system.Serial) //nolint:forbidigo
 	}
 
 	if system.Type != "" {
-		fmt.Printf("  "+"Type: %s\n", system.Type) //nolint:forbidigo
+		_, _ = fmt.Printf("  "+"Type: %s\n", system.Type) //nolint:forbidigo
 	}
 
 	// System: Chassis.
 	if system.Chassis != nil {
-		fmt.Print("  Chassis:\n") //nolint:forbidigo
+		_, _ = fmt.Print("  Chassis:\n") //nolint:forbidigo
 
 		if system.Chassis.Vendor != "" {
-			fmt.Printf("      Vendor: %s\n", system.Chassis.Vendor) //nolint:forbidigo
+			_, _ = fmt.Printf("      Vendor: %s\n", system.Chassis.Vendor) //nolint:forbidigo
 		}
 
 		if system.Chassis.Type != "" {
-			fmt.Printf("      Type: %s\n", system.Chassis.Type) //nolint:forbidigo
+			_, _ = fmt.Printf("      Type: %s\n", system.Chassis.Type) //nolint:forbidigo
 		}
 
 		if system.Chassis.Version != "" {
-			fmt.Printf("      Version: %s\n", system.Chassis.Version) //nolint:forbidigo
+			_, _ = fmt.Printf("      Version: %s\n", system.Chassis.Version) //nolint:forbidigo
 		}
 
 		if system.Chassis.Serial != "" {
-			fmt.Printf("      Serial: %s\n", system.Chassis.Serial) //nolint:forbidigo
+			_, _ = fmt.Printf("      Serial: %s\n", system.Chassis.Serial) //nolint:forbidigo
 		}
 	}
 
 	// System: Motherboard.
 	if system.Motherboard != nil {
-		fmt.Print("  Motherboard:\n") //nolint:forbidigo
+		_, _ = fmt.Print("  Motherboard:\n") //nolint:forbidigo
 
 		if system.Motherboard.Vendor != "" {
-			fmt.Printf("      Vendor: %s\n", system.Motherboard.Vendor) //nolint:forbidigo
+			_, _ = fmt.Printf("      Vendor: %s\n", system.Motherboard.Vendor) //nolint:forbidigo
 		}
 
 		if system.Motherboard.Product != "" {
-			fmt.Printf("      Product: %s\n", system.Motherboard.Product) //nolint:forbidigo
+			_, _ = fmt.Printf("      Product: %s\n", system.Motherboard.Product) //nolint:forbidigo
 		}
 
 		if system.Motherboard.Serial != "" {
-			fmt.Printf("      Serial: %s\n", system.Motherboard.Serial) //nolint:forbidigo
+			_, _ = fmt.Printf("      Serial: %s\n", system.Motherboard.Serial) //nolint:forbidigo
 		}
 
 		if system.Motherboard.Version != "" {
-			fmt.Printf("      Version: %s\n", system.Motherboard.Version) //nolint:forbidigo
+			_, _ = fmt.Printf("      Version: %s\n", system.Motherboard.Version) //nolint:forbidigo
 		}
 	}
 
 	// System: Firmware.
 	if system.Firmware != nil {
-		fmt.Print("  Firmware:\n") //nolint:forbidigo
+		_, _ = fmt.Print("  Firmware:\n") //nolint:forbidigo
 
 		if system.Firmware.Vendor != "" {
-			fmt.Printf("      Vendor: %s\n", system.Firmware.Vendor) //nolint:forbidigo
+			_, _ = fmt.Printf("      Vendor: %s\n", system.Firmware.Vendor) //nolint:forbidigo
 		}
 
 		if system.Firmware.Version != "" {
-			fmt.Printf("      Version: %s\n", system.Firmware.Version) //nolint:forbidigo
+			_, _ = fmt.Printf("      Version: %s\n", system.Firmware.Version) //nolint:forbidigo
 		}
 
 		if system.Firmware.Date != "" {
-			fmt.Printf("      Date: %s\n", system.Firmware.Date) //nolint:forbidigo
+			_, _ = fmt.Printf("      Date: %s\n", system.Firmware.Date) //nolint:forbidigo
 		}
 	}
 }
 
 func renderResourcesCPU(cpu incusapi.ResourcesCPUSocket, prefix string) {
 	if cpu.Vendor != "" {
-		fmt.Printf(prefix+"Vendor: %v\n", cpu.Vendor) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"Vendor: %v\n", cpu.Vendor) //nolint:forbidigo
 	}
 
 	if cpu.Name != "" {
-		fmt.Printf(prefix+"Name: %v\n", cpu.Name) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"Name: %v\n", cpu.Name) //nolint:forbidigo
 	}
 
 	if cpu.Cache != nil {
-		fmt.Print(prefix + "Caches:\n") //nolint:forbidigo
+		_, _ = fmt.Print(prefix + "Caches:\n") //nolint:forbidigo
 
 		for _, cache := range cpu.Cache {
-			fmt.Printf(prefix+"  - Level %d (type: %s): %s\n", cache.Level, cache.Type, units.GetByteSizeStringIEC(int64(cache.Size), 0)) //nolint:forbidigo,gosec
+			_, _ = fmt.Printf(prefix+"  - Level %d (type: %s): %s\n", cache.Level, cache.Type, units.GetByteSizeStringIEC(int64(cache.Size), 0)) //nolint:forbidigo,gosec
 		}
 	}
 
-	fmt.Print(prefix + "Cores:\n") //nolint:forbidigo
+	_, _ = fmt.Print(prefix + "Cores:\n") //nolint:forbidigo
 
 	for _, core := range cpu.Cores {
-		fmt.Printf(prefix+"  - Core %d\n", core.Core)               //nolint:forbidigo
-		fmt.Printf(prefix+"    Frequency: %vMhz\n", core.Frequency) //nolint:forbidigo
-		fmt.Print(prefix + "    Threads:\n")                        //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"  - Core %d\n", core.Core)               //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"    Frequency: %vMhz\n", core.Frequency) //nolint:forbidigo
+		_, _ = fmt.Print(prefix + "    Threads:\n")                        //nolint:forbidigo
 
 		for _, thread := range core.Threads {
-			fmt.Printf(prefix+"      - %d (id: %d, online: %v, NUMA node: %v)\n", thread.Thread, thread.ID, thread.Online, thread.NUMANode) //nolint:forbidigo
+			_, _ = fmt.Printf(prefix+"      - %d (id: %d, online: %v, NUMA node: %v)\n", thread.Thread, thread.ID, thread.Online, thread.NUMANode) //nolint:forbidigo
 		}
 	}
 
 	if cpu.Frequency > 0 {
 		if cpu.FrequencyTurbo > 0 && cpu.FrequencyMinimum > 0 {
-			fmt.Printf(prefix+"Frequency: %vMhz (min: %vMhz, max: %vMhz)\n", cpu.Frequency, cpu.FrequencyMinimum, cpu.FrequencyTurbo) //nolint:forbidigo
+			_, _ = fmt.Printf(prefix+"Frequency: %vMhz (min: %vMhz, max: %vMhz)\n", cpu.Frequency, cpu.FrequencyMinimum, cpu.FrequencyTurbo) //nolint:forbidigo
 		} else {
-			fmt.Printf(prefix+"Frequency: %vMhz\n", cpu.Frequency) //nolint:forbidigo
+			_, _ = fmt.Printf(prefix+"Frequency: %vMhz\n", cpu.Frequency) //nolint:forbidigo
 		}
 	}
 }
 
 func renderResourcesGPU(gpu incusapi.ResourcesGPUCard, prefix string, initial bool) {
 	if initial {
-		fmt.Print(prefix) //nolint:forbidigo
+		_, _ = fmt.Print(prefix) //nolint:forbidigo
 	}
 
-	fmt.Printf("NUMA node: %v\n", gpu.NUMANode) //nolint:forbidigo
+	_, _ = fmt.Printf("NUMA node: %v\n", gpu.NUMANode) //nolint:forbidigo
 
 	if gpu.Vendor != "" {
-		fmt.Printf(prefix+"Vendor: %v (%v)\n", gpu.Vendor, gpu.VendorID) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"Vendor: %v (%v)\n", gpu.Vendor, gpu.VendorID) //nolint:forbidigo
 	}
 
 	if gpu.Product != "" {
-		fmt.Printf(prefix+"Product: %v (%v)\n", gpu.Product, gpu.ProductID) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"Product: %v (%v)\n", gpu.Product, gpu.ProductID) //nolint:forbidigo
 	}
 
 	if gpu.PCIAddress != "" {
-		fmt.Printf(prefix+"PCI address: %v\n", gpu.PCIAddress) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"PCI address: %v\n", gpu.PCIAddress) //nolint:forbidigo
 	}
 
 	if gpu.Driver != "" {
-		fmt.Printf(prefix+"Driver: %v (%v)\n", gpu.Driver, gpu.DriverVersion) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"Driver: %v (%v)\n", gpu.Driver, gpu.DriverVersion) //nolint:forbidigo
 	}
 
 	if gpu.DRM != nil {
-		fmt.Print(prefix + "DRM:\n")                   //nolint:forbidigo
-		fmt.Printf(prefix+"  "+"ID: %d\n", gpu.DRM.ID) //nolint:forbidigo
+		_, _ = fmt.Print(prefix + "DRM:\n")                   //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"  "+"ID: %d\n", gpu.DRM.ID) //nolint:forbidigo
 
 		if gpu.DRM.CardName != "" {
-			fmt.Printf(prefix+"  "+"Card: %s (%s)\n", gpu.DRM.CardName, gpu.DRM.CardDevice) //nolint:forbidigo
+			_, _ = fmt.Printf(prefix+"  "+"Card: %s (%s)\n", gpu.DRM.CardName, gpu.DRM.CardDevice) //nolint:forbidigo
 		}
 
 		if gpu.DRM.ControlName != "" {
-			fmt.Printf(prefix+"  "+"Control: %s (%s)\n", gpu.DRM.ControlName, gpu.DRM.ControlDevice) //nolint:forbidigo
+			_, _ = fmt.Printf(prefix+"  "+"Control: %s (%s)\n", gpu.DRM.ControlName, gpu.DRM.ControlDevice) //nolint:forbidigo
 		}
 
 		if gpu.DRM.RenderName != "" {
-			fmt.Printf(prefix+"  "+"Render: %s (%s)\n", gpu.DRM.RenderName, gpu.DRM.RenderDevice) //nolint:forbidigo
+			_, _ = fmt.Printf(prefix+"  "+"Render: %s (%s)\n", gpu.DRM.RenderName, gpu.DRM.RenderDevice) //nolint:forbidigo
 		}
 	}
 
 	if gpu.Nvidia != nil {
-		fmt.Print(prefix + "NVIDIA information:\n")                           //nolint:forbidigo
-		fmt.Printf(prefix+"  "+"Architecture: %v\n", gpu.Nvidia.Architecture) //nolint:forbidigo
-		fmt.Printf(prefix+"  "+"Brand: %v\n", gpu.Nvidia.Brand)               //nolint:forbidigo
-		fmt.Printf(prefix+"  "+"Model: %v\n", gpu.Nvidia.Model)               //nolint:forbidigo
-		fmt.Printf(prefix+"  "+"CUDA Version: %v\n", gpu.Nvidia.CUDAVersion)  //nolint:forbidigo
-		fmt.Printf(prefix+"  "+"NVRM Version: %v\n", gpu.Nvidia.NVRMVersion)  //nolint:forbidigo
-		fmt.Printf(prefix+"  "+"UUID: %v\n", gpu.Nvidia.UUID)                 //nolint:forbidigo
+		_, _ = fmt.Print(prefix + "NVIDIA information:\n")                           //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"  "+"Architecture: %v\n", gpu.Nvidia.Architecture) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"  "+"Brand: %v\n", gpu.Nvidia.Brand)               //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"  "+"Model: %v\n", gpu.Nvidia.Model)               //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"  "+"CUDA Version: %v\n", gpu.Nvidia.CUDAVersion)  //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"  "+"NVRM Version: %v\n", gpu.Nvidia.NVRMVersion)  //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"  "+"UUID: %v\n", gpu.Nvidia.UUID)                 //nolint:forbidigo
 	}
 
 	if gpu.SRIOV != nil {
-		fmt.Print(prefix + "SR-IOV information:\n")                                 //nolint:forbidigo
-		fmt.Printf(prefix+"  "+"Current number of VFs: %d\n", gpu.SRIOV.CurrentVFs) //nolint:forbidigo
-		fmt.Printf(prefix+"  "+"Maximum number of VFs: %d\n", gpu.SRIOV.MaximumVFs) //nolint:forbidigo
+		_, _ = fmt.Print(prefix + "SR-IOV information:\n")                                 //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"  "+"Current number of VFs: %d\n", gpu.SRIOV.CurrentVFs) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"  "+"Maximum number of VFs: %d\n", gpu.SRIOV.MaximumVFs) //nolint:forbidigo
 
 		if len(gpu.SRIOV.VFs) > 0 {
-			fmt.Printf(prefix+"  "+"VFs: %d\n", gpu.SRIOV.MaximumVFs) //nolint:forbidigo
+			_, _ = fmt.Printf(prefix+"  "+"VFs: %d\n", gpu.SRIOV.MaximumVFs) //nolint:forbidigo
 
 			for _, vf := range gpu.SRIOV.VFs {
-				fmt.Print(prefix + "  - ") //nolint:forbidigo
+				_, _ = fmt.Print(prefix + "  - ") //nolint:forbidigo
 				renderResourcesGPU(vf, prefix+"    ", false)
 			}
 		}
 	}
 
 	if gpu.Mdev != nil {
-		fmt.Print(prefix + "Mdev profiles:\n") //nolint:forbidigo
+		_, _ = fmt.Print(prefix + "Mdev profiles:\n") //nolint:forbidigo
 
 		keys := make([]string, 0, len(gpu.Mdev))
 		for k := range gpu.Mdev {
@@ -369,11 +381,11 @@ func renderResourcesGPU(gpu incusapi.ResourcesGPUCard, prefix string, initial bo
 		for _, k := range keys {
 			v := gpu.Mdev[k]
 
-			fmt.Println(prefix + "  - " + fmt.Sprintf("%s (%s) (%d available)", k, v.Name, v.Available)) //nolint:forbidigo
+			_, _ = fmt.Println(prefix + "  - " + fmt.Sprintf("%s (%s) (%d available)", k, v.Name, v.Available)) //nolint:forbidigo
 
 			if v.Description != "" {
 				for line := range strings.SplitSeq(v.Description, "\n") {
-					fmt.Printf(prefix+"      %s\n", line) //nolint:forbidigo
+					_, _ = fmt.Printf(prefix+"      %s\n", line) //nolint:forbidigo
 				}
 			}
 		}
@@ -382,29 +394,29 @@ func renderResourcesGPU(gpu incusapi.ResourcesGPUCard, prefix string, initial bo
 
 func renderResourcesNIC(nic incusapi.ResourcesNetworkCard, prefix string, initial bool) {
 	if initial {
-		fmt.Print(prefix) //nolint:forbidigo
+		_, _ = fmt.Print(prefix) //nolint:forbidigo
 	}
 
-	fmt.Printf("NUMA node: %v\n", nic.NUMANode) //nolint:forbidigo
+	_, _ = fmt.Printf("NUMA node: %v\n", nic.NUMANode) //nolint:forbidigo
 
 	if nic.Vendor != "" {
-		fmt.Printf(prefix+"Vendor: %v (%v)\n", nic.Vendor, nic.VendorID) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"Vendor: %v (%v)\n", nic.Vendor, nic.VendorID) //nolint:forbidigo
 	}
 
 	if nic.Product != "" {
-		fmt.Printf(prefix+"Product: %v (%v)\n", nic.Product, nic.ProductID) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"Product: %v (%v)\n", nic.Product, nic.ProductID) //nolint:forbidigo
 	}
 
 	if nic.PCIAddress != "" {
-		fmt.Printf(prefix+"PCI address: %v\n", nic.PCIAddress) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"PCI address: %v\n", nic.PCIAddress) //nolint:forbidigo
 	}
 
 	if nic.Driver != "" {
-		fmt.Printf(prefix+"Driver: %v (%v)\n", nic.Driver, nic.DriverVersion) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"Driver: %v (%v)\n", nic.Driver, nic.DriverVersion) //nolint:forbidigo
 	}
 
 	if len(nic.Ports) > 0 {
-		fmt.Print(prefix + "Ports:\n") //nolint:forbidigo
+		_, _ = fmt.Print(prefix + "Ports:\n") //nolint:forbidigo
 
 		for _, port := range nic.Ports {
 			renderResourcesNICPort(port, prefix)
@@ -412,15 +424,15 @@ func renderResourcesNIC(nic incusapi.ResourcesNetworkCard, prefix string, initia
 	}
 
 	if nic.SRIOV != nil {
-		fmt.Print(prefix + "SR-IOV information:\n")                                 //nolint:forbidigo
-		fmt.Printf(prefix+"  "+"Current number of VFs: %d\n", nic.SRIOV.CurrentVFs) //nolint:forbidigo
-		fmt.Printf(prefix+"  "+"Maximum number of VFs: %d\n", nic.SRIOV.MaximumVFs) //nolint:forbidigo
+		_, _ = fmt.Print(prefix + "SR-IOV information:\n")                                 //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"  "+"Current number of VFs: %d\n", nic.SRIOV.CurrentVFs) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"  "+"Maximum number of VFs: %d\n", nic.SRIOV.MaximumVFs) //nolint:forbidigo
 
 		if len(nic.SRIOV.VFs) > 0 {
-			fmt.Printf(prefix+"  "+"VFs: %d\n", nic.SRIOV.MaximumVFs) //nolint:forbidigo
+			_, _ = fmt.Printf(prefix+"  "+"VFs: %d\n", nic.SRIOV.MaximumVFs) //nolint:forbidigo
 
 			for _, vf := range nic.SRIOV.VFs {
-				fmt.Print(prefix + "  - ") //nolint:forbidigo
+				_, _ = fmt.Print(prefix + "  - ") //nolint:forbidigo
 				renderResourcesNIC(vf, prefix+"    ", false)
 			}
 		}
@@ -428,127 +440,127 @@ func renderResourcesNIC(nic incusapi.ResourcesNetworkCard, prefix string, initia
 }
 
 func renderResourcesNICPort(port incusapi.ResourcesNetworkCardPort, prefix string) {
-	fmt.Printf(prefix+"  "+"- Port %d (%s)\n", port.Port, port.Protocol) //nolint:forbidigo
-	fmt.Printf(prefix+"    "+"ID: %s\n", port.ID)                        //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"  "+"- Port %d (%s)\n", port.Port, port.Protocol) //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"    "+"ID: %s\n", port.ID)                        //nolint:forbidigo
 
 	if port.Address != "" {
-		fmt.Printf(prefix+"    "+"Address: %s\n", port.Address) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"    "+"Address: %s\n", port.Address) //nolint:forbidigo
 	}
 
 	if port.SupportedModes != nil {
-		fmt.Printf(prefix+"    "+"Supported modes: %s\n", strings.Join(port.SupportedModes, ", ")) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"    "+"Supported modes: %s\n", strings.Join(port.SupportedModes, ", ")) //nolint:forbidigo
 	}
 
 	if port.SupportedPorts != nil {
-		fmt.Printf(prefix+"    "+"Supported ports: %s\n", strings.Join(port.SupportedPorts, ", ")) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"    "+"Supported ports: %s\n", strings.Join(port.SupportedPorts, ", ")) //nolint:forbidigo
 	}
 
 	if port.PortType != "" {
-		fmt.Printf(prefix+"    "+"Port type: %s\n", port.PortType) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"    "+"Port type: %s\n", port.PortType) //nolint:forbidigo
 	}
 
 	if port.TransceiverType != "" {
-		fmt.Printf(prefix+"    "+"Transceiver type: %s\n", port.TransceiverType) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"    "+"Transceiver type: %s\n", port.TransceiverType) //nolint:forbidigo
 	}
 
-	fmt.Printf(prefix+"    "+"Auto negotiation: %v\n", port.AutoNegotiation) //nolint:forbidigo
-	fmt.Printf(prefix+"    "+"Link detected: %v\n", port.LinkDetected)       //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"    "+"Auto negotiation: %v\n", port.AutoNegotiation) //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"    "+"Link detected: %v\n", port.LinkDetected)       //nolint:forbidigo
 
 	if port.LinkSpeed > 0 {
-		fmt.Printf(prefix+"    "+"Link speed: %dMbit/s (%s duplex)\n", port.LinkSpeed, port.LinkDuplex) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"    "+"Link speed: %dMbit/s (%s duplex)\n", port.LinkSpeed, port.LinkDuplex) //nolint:forbidigo
 	}
 
 	if port.Infiniband != nil {
-		fmt.Print(prefix + "    " + "Infiniband:\n") //nolint:forbidigo
+		_, _ = fmt.Print(prefix + "    " + "Infiniband:\n") //nolint:forbidigo
 
 		if port.Infiniband.IsSMName != "" {
-			fmt.Printf(prefix+"    "+"  "+"IsSM: %s (%s)\n", port.Infiniband.IsSMName, port.Infiniband.IsSMDevice) //nolint:forbidigo
+			_, _ = fmt.Printf(prefix+"    "+"  "+"IsSM: %s (%s)\n", port.Infiniband.IsSMName, port.Infiniband.IsSMDevice) //nolint:forbidigo
 		}
 
 		if port.Infiniband.MADName != "" {
-			fmt.Printf(prefix+"    "+"  "+"MAD: %s (%s)\n", port.Infiniband.MADName, port.Infiniband.MADDevice) //nolint:forbidigo
+			_, _ = fmt.Printf(prefix+"    "+"  "+"MAD: %s (%s)\n", port.Infiniband.MADName, port.Infiniband.MADDevice) //nolint:forbidigo
 		}
 
 		if port.Infiniband.VerbName != "" {
-			fmt.Printf(prefix+"    "+"  "+"Verb: %s (%s)\n", port.Infiniband.VerbName, port.Infiniband.VerbDevice) //nolint:forbidigo
+			_, _ = fmt.Printf(prefix+"    "+"  "+"Verb: %s (%s)\n", port.Infiniband.VerbName, port.Infiniband.VerbDevice) //nolint:forbidigo
 		}
 	}
 }
 
 func renderResourcesDisk(disk incusapi.ResourcesStorageDisk, prefix string, initial bool) {
 	if initial {
-		fmt.Print(prefix) //nolint:forbidigo
+		_, _ = fmt.Print(prefix) //nolint:forbidigo
 	}
 
-	fmt.Printf("NUMA node: %v\n", disk.NUMANode) //nolint:forbidigo
+	_, _ = fmt.Printf("NUMA node: %v\n", disk.NUMANode) //nolint:forbidigo
 
-	fmt.Printf(prefix+"ID: %s\n", disk.ID)         //nolint:forbidigo
-	fmt.Printf(prefix+"Device: %s\n", disk.Device) //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"ID: %s\n", disk.ID)         //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Device: %s\n", disk.Device) //nolint:forbidigo
 
 	if disk.Model != "" {
-		fmt.Printf(prefix+"Model: %s\n", disk.Model) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"Model: %s\n", disk.Model) //nolint:forbidigo
 	}
 
 	if disk.Type != "" {
-		fmt.Printf(prefix+"Type: %s\n", disk.Type) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"Type: %s\n", disk.Type) //nolint:forbidigo
 	}
 
-	fmt.Printf(prefix+"Size: %s\n", units.GetByteSizeStringIEC(int64(disk.Size), 2)) //nolint:forbidigo,gosec
+	_, _ = fmt.Printf(prefix+"Size: %s\n", units.GetByteSizeStringIEC(int64(disk.Size), 2)) //nolint:forbidigo,gosec
 
 	if disk.WWN != "" {
-		fmt.Printf(prefix+"WWN: %s\n", disk.WWN) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"WWN: %s\n", disk.WWN) //nolint:forbidigo
 	}
 
-	fmt.Printf(prefix+"Read-Only: %v\n", disk.ReadOnly)  //nolint:forbidigo
-	fmt.Printf(prefix+"Removable: %v\n", disk.Removable) //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Read-Only: %v\n", disk.ReadOnly)  //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Removable: %v\n", disk.Removable) //nolint:forbidigo
 
 	if len(disk.Partitions) != 0 {
-		fmt.Print(prefix + "Partitions:\n") //nolint:forbidigo
+		_, _ = fmt.Print(prefix + "Partitions:\n") //nolint:forbidigo
 
 		for _, partition := range disk.Partitions {
-			fmt.Printf(prefix+"  "+"- Partition %d\n", partition.Partition)                              //nolint:forbidigo
-			fmt.Printf(prefix+"    "+"ID: %s\n", partition.ID)                                           //nolint:forbidigo
-			fmt.Printf(prefix+"    "+"Device: %s\n", partition.Device)                                   //nolint:forbidigo
-			fmt.Printf(prefix+"    "+"Read-Only: %v\n", partition.ReadOnly)                              //nolint:forbidigo
-			fmt.Printf(prefix+"    "+"Size: %s\n", units.GetByteSizeStringIEC(int64(partition.Size), 2)) //nolint:forbidigo,gosec
+			_, _ = fmt.Printf(prefix+"  "+"- Partition %d\n", partition.Partition)                              //nolint:forbidigo
+			_, _ = fmt.Printf(prefix+"    "+"ID: %s\n", partition.ID)                                           //nolint:forbidigo
+			_, _ = fmt.Printf(prefix+"    "+"Device: %s\n", partition.Device)                                   //nolint:forbidigo
+			_, _ = fmt.Printf(prefix+"    "+"Read-Only: %v\n", partition.ReadOnly)                              //nolint:forbidigo
+			_, _ = fmt.Printf(prefix+"    "+"Size: %s\n", units.GetByteSizeStringIEC(int64(partition.Size), 2)) //nolint:forbidigo,gosec
 		}
 	}
 }
 
 func renderResourcesUSB(usb incusapi.ResourcesUSBDevice, prefix string) {
-	fmt.Printf(prefix+"Vendor: %v\n", usb.Vendor)                //nolint:forbidigo
-	fmt.Printf(prefix+"Vendor ID: %v\n", usb.VendorID)           //nolint:forbidigo
-	fmt.Printf(prefix+"Product: %v\n", usb.Product)              //nolint:forbidigo
-	fmt.Printf(prefix+"Product ID: %v\n", usb.ProductID)         //nolint:forbidigo
-	fmt.Printf(prefix+"Bus Address: %v\n", usb.BusAddress)       //nolint:forbidigo
-	fmt.Printf(prefix+"Device Address: %v\n", usb.DeviceAddress) //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Vendor: %v\n", usb.Vendor)                //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Vendor ID: %v\n", usb.VendorID)           //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Product: %v\n", usb.Product)              //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Product ID: %v\n", usb.ProductID)         //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Bus Address: %v\n", usb.BusAddress)       //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Device Address: %v\n", usb.DeviceAddress) //nolint:forbidigo
 
 	if len(usb.Serial) > 0 {
-		fmt.Printf(prefix+"Serial Number: %v\n", usb.Serial) //nolint:forbidigo
+		_, _ = fmt.Printf(prefix+"Serial Number: %v\n", usb.Serial) //nolint:forbidigo
 	}
 }
 
 func renderResourcesPCI(pci incusapi.ResourcesPCIDevice, prefix string) {
-	fmt.Printf(prefix+"Address: %v\n", pci.PCIAddress)     //nolint:forbidigo
-	fmt.Printf(prefix+"Vendor: %v\n", pci.Vendor)          //nolint:forbidigo
-	fmt.Printf(prefix+"Vendor ID: %v\n", pci.VendorID)     //nolint:forbidigo
-	fmt.Printf(prefix+"Product: %v\n", pci.Product)        //nolint:forbidigo
-	fmt.Printf(prefix+"Product ID: %v\n", pci.ProductID)   //nolint:forbidigo
-	fmt.Printf(prefix+"NUMA node: %v\n", pci.NUMANode)     //nolint:forbidigo
-	fmt.Printf(prefix+"IOMMU group: %v\n", pci.IOMMUGroup) //nolint:forbidigo
-	fmt.Printf(prefix+"Driver: %v\n", pci.Driver)          //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Address: %v\n", pci.PCIAddress)     //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Vendor: %v\n", pci.Vendor)          //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Vendor ID: %v\n", pci.VendorID)     //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Product: %v\n", pci.Product)        //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Product ID: %v\n", pci.ProductID)   //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"NUMA node: %v\n", pci.NUMANode)     //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"IOMMU group: %v\n", pci.IOMMUGroup) //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Driver: %v\n", pci.Driver)          //nolint:forbidigo
 }
 
 func renderResourcesSerial(serial incusapi.ResourcesSerialDevice, prefix string) {
-	fmt.Printf(prefix+"Id: %v\n", serial.ID)                 //nolint:forbidigo
-	fmt.Printf(prefix+"Device: %v\n", serial.Device)         //nolint:forbidigo
-	fmt.Printf(prefix+"DeviceID: %v\n", serial.DeviceID)     //nolint:forbidigo
-	fmt.Printf(prefix+"DevicePath: %v\n", serial.DevicePath) //nolint:forbidigo
-	fmt.Printf(prefix+"Vendor: %v\n", serial.Vendor)         //nolint:forbidigo
-	fmt.Printf(prefix+"Vendor ID: %v\n", serial.VendorID)    //nolint:forbidigo
-	fmt.Printf(prefix+"Product: %v\n", serial.Product)       //nolint:forbidigo
-	fmt.Printf(prefix+"Product ID: %v\n", serial.ProductID)  //nolint:forbidigo
-	fmt.Printf(prefix+"Driver: %v\n", serial.Driver)         //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Id: %v\n", serial.ID)                 //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Device: %v\n", serial.Device)         //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"DeviceID: %v\n", serial.DeviceID)     //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"DevicePath: %v\n", serial.DevicePath) //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Vendor: %v\n", serial.Vendor)         //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Vendor ID: %v\n", serial.VendorID)    //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Product: %v\n", serial.Product)       //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Product ID: %v\n", serial.ProductID)  //nolint:forbidigo
+	_, _ = fmt.Printf(prefix+"Driver: %v\n", serial.Driver)         //nolint:forbidigo
 }
 
 // systemInfoResourcesCommand returns an info command for the system/resources endpoint.

--- a/incus-osd/cli/cli_system_info_storage.go
+++ b/incus-osd/cli/cli_system_info_storage.go
@@ -23,7 +23,7 @@ func renderStorageInfo(resp *incusapi.Response) error {
 	}
 
 	// Drives table.
-	fmt.Println("Drives:") //nolint:forbidigo
+	_, _ = fmt.Println("Drives:") //nolint:forbidigo
 
 	driveRows := make([][]string, 0, len(storage.State.Drives))
 	for _, drive := range storage.State.Drives {
@@ -58,7 +58,7 @@ func renderStorageInfo(resp *incusapi.Response) error {
 
 	// Pools table.
 	if len(storage.State.Pools) > 0 {
-		fmt.Println("\nPools:") //nolint:forbidigo
+		_, _ = fmt.Println("\nPools:") //nolint:forbidigo
 
 		poolRows := make([][]string, 0, len(storage.State.Pools))
 		for _, pool := range storage.State.Pools {

--- a/incus-osd/internal/systemd/networkd.go
+++ b/incus-osd/internal/systemd/networkd.go
@@ -203,14 +203,21 @@ func ValidateNetworkConfiguration(networkCfg *api.SystemNetworkConfig, requireVa
 		return errors.New("no network configuration provided")
 	}
 
-	// Check that all interface/bond/vlan names are unique.
+	// Check that all interface/bond/vlan names and MACs are unique.
 	names := []string{}
+	macs := []string{}
+
 	for _, iface := range networkCfg.Interfaces {
 		if slices.Contains(names, iface.Name) {
 			return errors.New("duplicate interface/bond/vlan/wireguard name: " + iface.Name)
 		}
 
+		if slices.Contains(macs, iface.Hwaddr) {
+			return errors.New("duplicate MAC address: " + iface.Hwaddr)
+		}
+
 		names = append(names, iface.Name)
+		macs = append(macs, iface.Hwaddr)
 	}
 
 	for _, bond := range networkCfg.Bonds {
@@ -218,7 +225,12 @@ func ValidateNetworkConfiguration(networkCfg *api.SystemNetworkConfig, requireVa
 			return errors.New("duplicate interface/bond/vlan/wireguard name: " + bond.Name)
 		}
 
+		if slices.Contains(macs, bond.Hwaddr) {
+			return errors.New("duplicate MAC address: " + bond.Hwaddr)
+		}
+
 		names = append(names, bond.Name)
+		macs = append(macs, bond.Hwaddr)
 	}
 
 	for _, vlan := range networkCfg.VLANs {

--- a/incus-osd/internal/systemd/networkd_test.go
+++ b/incus-osd/internal/systemd/networkd_test.go
@@ -286,6 +286,18 @@ wireguard:
       - 192.168.0.100/24
 `
 
+var badNetworkdConfig7 = `
+interfaces:
+  - name: nic1
+    addresses:
+    - dhcp4
+    hwaddr: 10:66:6a:b0:5f:02
+  - name: nic2
+    addresses:
+    - dhcp4
+    hwaddr: 10:66:6a:b0:5f:02
+`
+
 func TestBadNetworkConfig(t *testing.T) {
 	t.Parallel()
 
@@ -347,6 +359,16 @@ func TestBadNetworkConfig(t *testing.T) {
 
 		err = ValidateNetworkConfiguration(&cfg, false)
 		require.EqualError(t, err, "wireguard 0 port '65536' out of range")
+	}
+
+	{
+		var cfg api.SystemNetworkConfig
+
+		err := yaml.Load([]byte(badNetworkdConfig7), &cfg)
+		require.NoError(t, err)
+
+		err = ValidateNetworkConfiguration(&cfg, false)
+		require.EqualError(t, err, "duplicate MAC address: 10:66:6a:b0:5f:02")
 	}
 }
 

--- a/incus-osd/tests/incusos_tests/__init__.py
+++ b/incus-osd/tests/incusos_tests/__init__.py
@@ -1,8 +1,8 @@
 from inspect import getmembers, isfunction
 
 from . import tests_flasher_tool, tests_incusos_api, tests_incusos_api_applications, tests_incusos_api_debug, \
-    tests_incusos_api_network, tests_incusos_api_services, tests_incusos_api_system, tests_incusos_api_system_backup, \
-    tests_incusos_api_system_logging, tests_incusos_api_system_provider, tests_incusos_api_system_reset, \
+    tests_incusos_api_services, tests_incusos_api_system, tests_incusos_api_system_backup, tests_incusos_api_system_logging, \
+    tests_incusos_api_system_network, tests_incusos_api_system_provider, tests_incusos_api_system_reset, \
     tests_incusos_api_system_resources, tests_incusos_api_system_security, tests_incusos_api_system_storage, \
     tests_incusos_api_system_storage_local_pool, tests_incusos_live, tests_recovery, tests_upgrade
 
@@ -33,11 +33,11 @@ class IncusOSTests:
             tests_incusos_api,
             tests_incusos_api_applications,
             tests_incusos_api_debug,
-            tests_incusos_api_network,
             tests_incusos_api_services,
             tests_incusos_api_system,
             tests_incusos_api_system_backup,
             tests_incusos_api_system_logging,
+            tests_incusos_api_system_network,
             tests_incusos_api_system_provider,
             tests_incusos_api_system_reset,
             tests_incusos_api_system_resources,

--- a/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
+++ b/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
@@ -208,3 +208,23 @@ class IncusTestVM:
     def RunCommand(self, *cmd, capture_output=True, check=True):
         """Run a given command within the VM."""
         return subprocess.run(["incus", "exec", self.vm_name, "--", *cmd], capture_output=capture_output, check=check)
+
+class IncusTestNetwork:
+    def __init__(self):
+        self.name = util._get_random_string()
+
+    def __enter__(self):
+        """Create a temporary Incus bridge network for testing purposes."""
+
+        subprocess.run(["incus", "network", "create", self.name, "--type=bridge"], capture_output=True, check=True)
+
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Delete the test network."""
+
+        # Sleep a few seconds to allow sufficient time for the VM to have been deleted and
+        # Incus state updated to show nothing is using this network before we delete it.
+        time.sleep(5)
+
+        subprocess.run(["incus", "network", "delete", self.name], capture_output=True, check=True)

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_network.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_network.py
@@ -2,7 +2,7 @@ import json
 import os
 import time
 
-from .incus_test_vm import IncusTestVM, IncusOSException, util
+from .incus_test_vm import IncusTestNetwork, IncusTestVM, IncusOSException, util
 
 def _checkNetworkConnectivity(vm):
     IMAGES_SERVER = os.getenv("IMAGES_SERVER", "https://images.linuxcontainers.org")
@@ -273,3 +273,57 @@ def TestIncusOSAPISystemNetworkRollback(install_image):
 
         if result["error"] != "no network configuration is pending a confirmation":
             raise IncusOSException("unexpected error message: " + result["error"])
+
+def TestIncusOSAPISystemNetworkConfigInterfaces(install_image):
+    test_name = "incusos-api-system-network-config-interfaces"
+    test_seed = {
+        "install.json": "{}"
+    }
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with IncusTestNetwork() as network:
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+            vm.AddDevice("eth1", "nic", "network="+network.name)
+
+            vm.WaitSystemReady(os_version)
+
+            # Get current network configuration.
+            result = vm.APIRequest("/1.0/system/network")
+            if result["status_code"] != 200:
+                raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+            interfaces = result["metadata"]["state"]["interfaces"]
+
+            if "enp5s0" not in interfaces or "enp6s0" not in interfaces:
+                raise IncusOSException("expected interfaces enp5s0 and enp6s0 to exist")
+
+            enp5MAC = '"' + interfaces["enp5s0"]["hwaddr"] + '"'
+            enp6MAC = '"' + interfaces["enp6s0"]["hwaddr"] + '"'
+
+            # Apply a new network configuration that changes names and roles.
+            result = vm.APIRequest("/1.0/system/network", method="PUT", body="""{"config":{"time":{"timezone":"UTC"},"interfaces":[{"addresses":["dhcp4","slaac"],"hwaddr":""" + enp5MAC + ""","name":"management","required_for_online":"both","roles":["management","cluster","storage"]},{"hwaddr":""" + enp6MAC + ""","name":"vm","roles":["instances"]}]}}""")
+            if result["status_code"] != 200:
+                raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+            # Get the updated network configuration.
+            result = vm.APIRequest("/1.0/system/network")
+            if result["status_code"] != 200:
+                raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+            interfaces = result["metadata"]["state"]["interfaces"]
+
+            if "management" not in interfaces or "vm" not in interfaces:
+                raise IncusOSException("expected interfaces management and vm to exist")
+
+            if len(interfaces["management"]["addresses"]) != 2:
+                raise IncusOSException("expected management interface to have two addresses")
+
+            if "management" not in interfaces["management"]["roles"] or "cluster" not in interfaces["management"]["roles"] or "storage" not in interfaces["management"]["roles"] or len(interfaces["management"]["roles"]) != 3:
+                raise IncusOSException("missing expected roles for management interface: " + str(interfaces["management"]["roles"]))
+
+            if "addresses" in interfaces["vm"]:
+                raise IncusOSException("expected vm interface not to have any addresses")
+
+            if "instances" not in interfaces["vm"]["roles"] or len(interfaces["vm"]["roles"]) != 1:
+                raise IncusOSException("missing expected roles for vm interface: " + str(interfaces["vm"]["roles"]))


### PR DESCRIPTION
Return an error if the same MAC address appears more than once in the provided network configuration. Also add a network test exercising basic configuration of two different NICs.

Closes #1196