### PR TITLE
Improve S/MIME validation checks

### DIFF
--- a/.github/workflows/certificate-e2e.yml
+++ b/.github/workflows/certificate-e2e.yml
@@ -1,0 +1,93 @@
+name: Tests
+on:
+  schedule:
+  - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  certificate-e2e-tests:
+    name: IncusOS Certificate end-to-end tests
+    strategy:
+      fail-fast: false
+    timeout-minutes: 45
+    runs-on:
+      - self-hosted
+      - arch-amd64
+      - lxc-incusos-daily
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Install dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get install --yes \
+            linux-headers-$(uname -r)
+          sudo --preserve-env=DEBIAN_FRONTEND apt-get install --yes \
+            binutils \
+            curl \
+            debian-archive-keyring \
+            devscripts \
+            dosfstools \
+            efitools \
+            gdisk \
+            genisoimage \
+            libnbd-dev \
+            make \
+            mtools \
+            openssl \
+            parted \
+            pkgconf \
+            pipx \
+            qemu-utils \
+            zfsutils-linux \
+            zip
+
+      - name: Setup mkosi
+        run: |
+          pipx install git+https://github.com/systemd/mkosi.git@v25.3
+
+      - name: Setup Incus
+        run: |
+          curl https://pkgs.zabbly.com/get/incus-daily | sudo sh
+          sudo chmod 666 /var/lib/incus/unix.socket
+
+          echo "initializing incus with zfs backend and 200MB loop device"
+          incus admin init --auto --storage-backend=zfs --storage-create-loop=200
+
+          echo "setting zfs sync to disabled for better performance in CI environment"
+          sudo zfs set sync=disabled default
+
+      - name: Build local test image
+        run: |
+          export PATH="${PATH}:/${HOME}/.local/bin"
+
+          rm -rf certs/ incus-osd/certs/files/
+          make generate-test-certs
+
+          make
+
+          make publish-local-update
+
+          export VERSION=$(ls mkosi.output/*.efi 2>/dev/null | sed -e "s/.*_//g" -e "s/.efi//g" | sort -n | tail -1)
+          SIG_KEY=./certs/update-E1.key SIG_CERTIFICATE=./certs/update-E1.crt SIG_CHAIN=./incus-osd/certs/files/update-E1.crt ./incus-osd/image-publisher promote ./local-image-server/ ${VERSION} stable
+
+      - name: Run certificate end-to-end tests
+        run: |
+          export OSNAME=$(grep "ImageId=" mkosi.conf | cut -d '=' -f 2)
+          export VERSION=$(ls mkosi.output/*.efi 2>/dev/null | sed -e "s/.*_//g" -e "s/.efi//g" | sort -n | tail -1)
+          export SERVER_IP=$(incus network list incusbr0 -c 4 -f csv | cut -d '/' -f 1)
+          export IMAGES_SERVER="http://${SERVER_IP}:8123"
+
+          make start-local-image-server
+
+          incus-osd/tests/certificate-e2e-tests.py

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ ifeq (,$(wildcard ./local-image-server/${RELEASE}/))
 
 	zip -j ${OSNAME}-${RELEASE}-${ARCH}.zip upload/*
 
-	SIG_KEY=./certs/cas/root-E1.key SIG_CERTIFICATE=./incus-osd/certs/files/root-E1.crt SIG_CHAIN=./mkosi.crt ./incus-osd/image-publisher sync ./local-image-server/ ./${OSNAME}-${RELEASE}-${ARCH}.zip
+	SIG_KEY=./certs/update-E1.key SIG_CERTIFICATE=./certs/update-E1.crt SIG_CHAIN=./incus-osd/certs/files/update-E1.crt ./incus-osd/image-publisher sync ./local-image-server/ ./${OSNAME}-${RELEASE}-${ARCH}.zip
 
 	rm -rf ./upload/ ${OSNAME}-*-${ARCH}.zip
 endif

--- a/incus-osd/internal/providers/provider_images.go
+++ b/incus-osd/internal/providers/provider_images.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
@@ -63,7 +64,7 @@ type images struct {
 	state *state.State
 
 	serverURL string
-	updateCA  string
+	updateCA  *x509.Certificate
 	authParam bool
 	token     string
 	client    *http.Client
@@ -294,7 +295,6 @@ func (p *images) GetApplicationUpdate(ctx context.Context, name string) (Applica
 func (p *images) load(ctx context.Context) error {
 	// Set up the configuration.
 	p.serverURL = p.state.System.Provider.Config.Config["server_url"]
-	p.updateCA = p.state.System.Provider.Config.Config["update_ca"]
 	p.authParam = strings.ToLower(p.state.System.Provider.Config.Config["authentication_by_query_param"]) == "true"
 	p.token = p.state.System.Provider.Config.Config["token"]
 	p.client = &http.Client{}
@@ -304,24 +304,31 @@ func (p *images) load(ctx context.Context) error {
 		p.serverURL = "https://images.linuxcontainers.org/os"
 	}
 
-	// Set default update CA if not configured.
-	if p.updateCA == "" && !p.ignoreSignedJSON {
+	if p.state.System.Provider.Config.Config["update_ca"] != "" {
+		// Set a custom update CA, if provided.
+		pemBlock, _ := pem.Decode([]byte(p.state.System.Provider.Config.Config["update_ca"]))
+		if pemBlock == nil {
+			return errors.New("unable to decode provided update CA certificate")
+		}
+
+		if pemBlock.Type != "CERTIFICATE" {
+			return errors.New("provided update CA certificate isn't PEM-encoded")
+		}
+
+		var err error
+
+		p.updateCA, err = x509.ParseCertificate(pemBlock.Bytes)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Set the default update CA if one was not provided..
 		embeddedCerts, err := certs.GetEmbeddedCertificates()
 		if err != nil {
 			return err
 		}
 
-		var b bytes.Buffer
-
-		err = pem.Encode(&b, &pem.Block{
-			Type:  "CERTIFICATE",
-			Bytes: embeddedCerts.RootCACertificate.Raw,
-		})
-		if err != nil {
-			return err
-		}
-
-		p.updateCA = b.String()
+		p.updateCA = embeddedCerts.UpdateCACertificate
 	}
 
 	// Authenticated clients.
@@ -386,8 +393,13 @@ func (p *images) checkRelease(ctx context.Context) (*apiupdate.UpdateFull, error
 			return nil, errors.New("server failed to return expected file")
 		}
 
+		bodyContents, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
 		// Validate signed index.
-		verified, err := util.VerifySMIME(ctx, p.updateCA, resp.Body)
+		verified, err := util.VerifySMIME(ctx, []*x509.Certificate{p.updateCA}, bodyContents)
 		if err != nil {
 			return nil, err
 		}

--- a/incus-osd/internal/providers/provider_images.go
+++ b/incus-osd/internal/providers/provider_images.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
@@ -22,6 +23,7 @@ import (
 	"github.com/lxc/incus/v7/shared/osarch"
 
 	apiupdate "github.com/lxc/incus-os/incus-osd/api/images"
+	"github.com/lxc/incus-os/incus-osd/certs"
 	"github.com/lxc/incus-os/incus-osd/internal/auth"
 	"github.com/lxc/incus-os/incus-osd/internal/state"
 	"github.com/lxc/incus-os/incus-osd/internal/util"
@@ -304,12 +306,22 @@ func (p *images) load(ctx context.Context) error {
 
 	// Set default update CA if not configured.
 	if p.updateCA == "" && !p.ignoreSignedJSON {
-		var err error
-
-		p.updateCA, err = GetUpdateCACert()
+		embeddedCerts, err := certs.GetEmbeddedCertificates()
 		if err != nil {
 			return err
 		}
+
+		var b bytes.Buffer
+
+		err = pem.Encode(&b, &pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: embeddedCerts.RootCACertificate.Raw,
+		})
+		if err != nil {
+			return err
+		}
+
+		p.updateCA = b.String()
 	}
 
 	// Authenticated clients.

--- a/incus-osd/internal/providers/structs.go
+++ b/incus-osd/internal/providers/structs.go
@@ -1,14 +1,10 @@
 package providers
 
 import (
-	"bytes"
 	"context"
-	"encoding/pem"
 	"strconv"
 
 	ocapi "github.com/FuturFusion/operations-center/shared/api"
-
-	"github.com/lxc/incus-os/incus-osd/certs"
 )
 
 // CommonUpdate defines functions common to all update types.
@@ -71,24 +67,4 @@ func DatetimeComparison(a string, b string) bool {
 	}
 
 	return aInt > bInt
-}
-
-// GetUpdateCACert returns the certificate used to verify update metadata from the configured provider.
-func GetUpdateCACert() (string, error) {
-	embeddedCerts, err := certs.GetEmbeddedCertificates()
-	if err != nil {
-		return "", err
-	}
-
-	var b bytes.Buffer
-
-	err = pem.Encode(&b, &pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: embeddedCerts.RootCACertificate.Raw,
-	})
-	if err != nil {
-		return "", err
-	}
-
-	return b.String(), nil
 }

--- a/incus-osd/internal/recovery/recovery.go
+++ b/incus-osd/internal/recovery/recovery.go
@@ -118,6 +118,11 @@ func runHotfix(ctx context.Context, mountDir string) error {
 
 // RunSignedScript verifies and executes a signed hotfix script, returning the script output and any error.
 func RunSignedScript(ctx context.Context, signedScript []byte) (string, error) {
+	// Do a quick check that the input looks like it's been properly S/MIME-signed.
+	if !bytes.Contains(signedScript, []byte("Content-Type: multipart/signed; protocol=\"application/x-pkcs7-signature\";")) {
+		return "", errors.New("doesn't look like S/MIME-signed input")
+	}
+
 	slog.InfoContext(ctx, "Hotfix script detected, verifying signature")
 
 	// Load the embedded certificates.

--- a/incus-osd/internal/recovery/recovery.go
+++ b/incus-osd/internal/recovery/recovery.go
@@ -5,9 +5,9 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
-	"encoding/pem"
 	"errors"
 	"io"
 	"log/slog"
@@ -74,30 +74,14 @@ func CheckRunRecovery(ctx context.Context, s *state.State) error {
 		defer func() { s.System.Provider.Config.Name = "" }()
 	}
 
-	// Get the expected CA certificate to validate the update metadata.
-	embeddedCerts, err := certs.GetEmbeddedCertificates()
-	if err != nil {
-		return err
-	}
-
-	var b bytes.Buffer
-
-	err = pem.Encode(&b, &pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: embeddedCerts.RootCACertificate.Raw,
-	})
-	if err != nil {
-		return err
-	}
-
 	// Run the hotfix script, if any.
-	err = runHotfix(ctx, b.String(), mountDir)
+	err = runHotfix(ctx, mountDir)
 	if err != nil {
 		return err
 	}
 
 	// Apply the update(s), if any.
-	err = applyUpdate(ctx, s, b.String(), mountDir)
+	err = applyUpdate(ctx, s, mountDir)
 	if err != nil {
 		return err
 	}
@@ -107,20 +91,20 @@ func CheckRunRecovery(ctx context.Context, s *state.State) error {
 	return nil
 }
 
-func runHotfix(ctx context.Context, updateCA string, mountDir string) error {
+func runHotfix(ctx context.Context, mountDir string) error {
 	// Check if hotfix.sh.sig exists.
 	_, err := os.Stat(filepath.Join(mountDir, "hotfix.sh.sig"))
 	if err != nil {
-		return nil
+		// If a signed script isn't present, nothing to do.
+		return nil //nolint:nilerr
 	}
 
-	f, err := os.Open(filepath.Join(mountDir, "hotfix.sh.sig"))
+	scriptContents, err := os.ReadFile(filepath.Join(mountDir, "hotfix.sh.sig"))
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
-	output, err := RunSignedScript(ctx, updateCA, f)
+	output, err := RunSignedScript(ctx, scriptContents)
 	if err != nil {
 		return err
 	}
@@ -133,11 +117,17 @@ func runHotfix(ctx context.Context, updateCA string, mountDir string) error {
 }
 
 // RunSignedScript verifies and executes a signed hotfix script, returning the script output and any error.
-func RunSignedScript(ctx context.Context, updateCA string, signedScript io.Reader) (string, error) {
+func RunSignedScript(ctx context.Context, signedScript []byte) (string, error) {
 	slog.InfoContext(ctx, "Hotfix script detected, verifying signature")
 
-	// Validate the signed hotfix script.
-	verified, err := util.VerifySMIME(ctx, updateCA, signedScript)
+	// Load the embedded certificates.
+	embeddedCerts, err := certs.GetEmbeddedCertificates()
+	if err != nil {
+		return "", err
+	}
+
+	// Validate the signed hotfix script using the Support intermediate CA.
+	verified, err := util.VerifySMIME(ctx, []*x509.Certificate{embeddedCerts.SupportCACertificate}, signedScript)
 	if err != nil {
 		return "", err
 	}
@@ -173,7 +163,7 @@ func RunSignedScript(ctx context.Context, updateCA string, signedScript io.Reade
 	return output, err
 }
 
-func applyUpdate(ctx context.Context, s *state.State, updateCA string, mountDir string) error {
+func applyUpdate(ctx context.Context, s *state.State, mountDir string) error {
 	updateDir := filepath.Join(mountDir, "update")
 
 	// Check if update.sjson exists.
@@ -184,14 +174,19 @@ func applyUpdate(ctx context.Context, s *state.State, updateCA string, mountDir 
 
 	slog.InfoContext(ctx, "Update metadata detected, verifying signature")
 
-	f, err := os.Open(filepath.Join(updateDir, "update.sjson"))
+	updateContents, err := os.ReadFile(filepath.Join(updateDir, "update.sjson"))
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
-	// Validate the signed update.
-	verified, err := util.VerifySMIME(ctx, updateCA, f)
+	// Load the embedded certificates.
+	embeddedCerts, err := certs.GetEmbeddedCertificates()
+	if err != nil {
+		return err
+	}
+
+	// Validate the signed update json using either the Update intermediate CA.
+	verified, err := util.VerifySMIME(ctx, []*x509.Certificate{embeddedCerts.UpdateCACertificate}, updateContents)
 	if err != nil {
 		return err
 	}

--- a/incus-osd/internal/recovery/recovery.go
+++ b/incus-osd/internal/recovery/recovery.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"io"
 	"log/slog"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/lxc/incus-os/incus-osd/api"
 	apiupdate "github.com/lxc/incus-os/incus-osd/api/images"
+	"github.com/lxc/incus-os/incus-osd/certs"
 	"github.com/lxc/incus-os/incus-osd/internal/providers"
 	"github.com/lxc/incus-os/incus-osd/internal/state"
 	"github.com/lxc/incus-os/incus-osd/internal/update"
@@ -73,19 +75,29 @@ func CheckRunRecovery(ctx context.Context, s *state.State) error {
 	}
 
 	// Get the expected CA certificate to validate the update metadata.
-	updateCA, err := providers.GetUpdateCACert()
+	embeddedCerts, err := certs.GetEmbeddedCertificates()
+	if err != nil {
+		return err
+	}
+
+	var b bytes.Buffer
+
+	err = pem.Encode(&b, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: embeddedCerts.RootCACertificate.Raw,
+	})
 	if err != nil {
 		return err
 	}
 
 	// Run the hotfix script, if any.
-	err = runHotfix(ctx, updateCA, mountDir)
+	err = runHotfix(ctx, b.String(), mountDir)
 	if err != nil {
 		return err
 	}
 
 	// Apply the update(s), if any.
-	err = applyUpdate(ctx, s, updateCA, mountDir)
+	err = applyUpdate(ctx, s, b.String(), mountDir)
 	if err != nil {
 		return err
 	}

--- a/incus-osd/internal/rest/api_debug.go
+++ b/incus-osd/internal/rest/api_debug.go
@@ -1,10 +1,8 @@
 package rest
 
 import (
-	"bytes"
 	"encoding/hex"
 	"encoding/json"
-	"encoding/pem"
 	"errors"
 	"io"
 	"net/http"
@@ -16,7 +14,6 @@ import (
 	"github.com/google/go-eventlog/tcg"
 	"github.com/lxc/incus/v7/shared/subprocess"
 
-	"github.com/lxc/incus-os/incus-osd/certs"
 	"github.com/lxc/incus-os/incus-osd/internal/recovery"
 	"github.com/lxc/incus-os/incus-osd/internal/rest/response"
 	"github.com/lxc/incus-os/incus-osd/internal/secureboot"
@@ -542,20 +539,7 @@ func (*Server) apiDebugRunScript(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get the expected CA certificate to validate the signed script.
-	embeddedCerts, err := certs.GetEmbeddedCertificates()
-	if err != nil {
-		_ = response.InternalError(err).Render(w)
-
-		return
-	}
-
-	var b bytes.Buffer
-
-	err = pem.Encode(&b, &pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: embeddedCerts.RootCACertificate.Raw,
-	})
+	bodyContents, err := io.ReadAll(r.Body)
 	if err != nil {
 		_ = response.InternalError(err).Render(w)
 
@@ -563,7 +547,7 @@ func (*Server) apiDebugRunScript(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Verify the signature and run the script.
-	output, err := recovery.RunSignedScript(r.Context(), b.String(), r.Body)
+	output, err := recovery.RunSignedScript(r.Context(), bodyContents)
 	if err != nil {
 		_ = response.InternalError(errors.New(err.Error() + "\n\n" + output)).Render(w)
 

--- a/incus-osd/internal/rest/api_debug.go
+++ b/incus-osd/internal/rest/api_debug.go
@@ -1,8 +1,10 @@
 package rest
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"io"
 	"net/http"
@@ -14,7 +16,7 @@ import (
 	"github.com/google/go-eventlog/tcg"
 	"github.com/lxc/incus/v7/shared/subprocess"
 
-	"github.com/lxc/incus-os/incus-osd/internal/providers"
+	"github.com/lxc/incus-os/incus-osd/certs"
 	"github.com/lxc/incus-os/incus-osd/internal/recovery"
 	"github.com/lxc/incus-os/incus-osd/internal/rest/response"
 	"github.com/lxc/incus-os/incus-osd/internal/secureboot"
@@ -541,7 +543,19 @@ func (*Server) apiDebugRunScript(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the expected CA certificate to validate the signed script.
-	updateCA, err := providers.GetUpdateCACert()
+	embeddedCerts, err := certs.GetEmbeddedCertificates()
+	if err != nil {
+		_ = response.InternalError(err).Render(w)
+
+		return
+	}
+
+	var b bytes.Buffer
+
+	err = pem.Encode(&b, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: embeddedCerts.RootCACertificate.Raw,
+	})
 	if err != nil {
 		_ = response.InternalError(err).Render(w)
 
@@ -549,7 +563,7 @@ func (*Server) apiDebugRunScript(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Verify the signature and run the script.
-	output, err := recovery.RunSignedScript(r.Context(), updateCA, r.Body)
+	output, err := recovery.RunSignedScript(r.Context(), b.String(), r.Body)
 	if err != nil {
 		_ = response.InternalError(errors.New(err.Error() + "\n\n" + output)).Render(w)
 

--- a/incus-osd/internal/util/ssl.go
+++ b/incus-osd/internal/util/ssl.go
@@ -5,12 +5,17 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/lxc/incus/v7/shared/subprocess"
+	"github.com/smallstep/pkcs7"
+
+	"github.com/lxc/incus-os/incus-osd/certs"
 )
 
 // UpdateSystemCustomCACerts regenerates /etc/ssl/certs/ca-certificates.crt with any
@@ -95,27 +100,112 @@ func UpdateSystemCustomCACerts(pemCerts []string) error {
 	return nil
 }
 
-// VerifySMIME uses the supplied CA to verify a SMIME-signed message.
-func VerifySMIME(ctx context.Context, ca string, message io.Reader) (*bytes.Buffer, error) {
-	// Write the CA certificate.
-	rootCA, err := os.CreateTemp("", "")
+// VerifySMIME first verifies the provided S/MIME-signed message using the root CA as a trust
+// anchor. Then, if validation succeeded, it ensures one of the expected intermediate CAs is
+// present in the provided certificate chain. `openssl smime ...` doesn't provide a way to do
+// this, so we must perform a manual check ourselves. Upon success, the verified plain-text
+// message is returned.
+func VerifySMIME(ctx context.Context, expectedIntermediateCAs []*x509.Certificate, message []byte) (*bytes.Buffer, error) {
+	if len(expectedIntermediateCAs) == 0 {
+		return nil, errors.New("at least one intermediate CA must be provided when performing S/MIME validation")
+	}
+
+	for _, ca := range expectedIntermediateCAs {
+		if ca == nil {
+			return nil, errors.New("provided intermediate CA for S/MIME validation cannot be nil")
+		}
+	}
+
+	// Load the embedded certificates.
+	embeddedCerts, err := certs.GetEmbeddedCertificates()
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = rootCA.WriteString(ca)
+	// Get the root CA.
+	var rootCABuf bytes.Buffer
+
+	err = pem.Encode(&rootCABuf, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: embeddedCerts.RootCACertificate.Raw,
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	defer func() { _ = os.Remove(rootCA.Name()) }()
+	// Write the root CA to a temporary file.
+	rootCAFile, err := os.CreateTemp("", "")
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() { _ = os.Remove(rootCAFile.Name()) }()
+
+	_, err = rootCAFile.Write(rootCABuf.Bytes())
+	if err != nil {
+		return nil, err
+	}
+
+	err = rootCAFile.Close()
+	if err != nil {
+		return nil, err
+	}
 
 	// Verify the signed message.
 	verified := bytes.NewBuffer(nil)
 
-	err = subprocess.RunCommandWithFds(ctx, message, verified, "openssl", "smime", "-verify", "-text", "-CAfile", rootCA.Name())
+	err = subprocess.RunCommandWithFds(ctx, bytes.NewReader(message), verified, "openssl", "smime", "-verify", "-text", "-CAfile", rootCAFile.Name())
+	if err != nil {
+		// Return a nicer error if verification failed due to a missing/unverifiable CA.
+		if strings.Contains(err.Error(), "Verify error: unable to get local issuer certificate") {
+			return nil, errors.New("unable to verify S/MIME message due to its use of a missing or unverifiable CA")
+		}
+
+		return nil, err
+	}
+
+	// Get the now-verified message's certificate chain.
+	certChain := bytes.NewBuffer(nil)
+
+	err = subprocess.RunCommandWithFds(ctx, bytes.NewReader(message), certChain, "openssl", "smime", "-pk7out")
 	if err != nil {
 		return nil, err
+	}
+
+	// openssl seems to output PEM even if `-outform DER` was provided in the command
+	// above. So, we need to take an extra step to decode the output before it can be
+	// parsed as pkcs7.
+	block, _ := pem.Decode(certChain.Bytes())
+	if block == nil {
+		return nil, errors.New("unable to parse PEM-encoded pkcs7 data")
+	}
+
+	pkcs, err := pkcs7.Parse(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	foundIntermediateCA := false
+
+	for _, cert := range pkcs.Certificates {
+		if slices.ContainsFunc(expectedIntermediateCAs, func(c *x509.Certificate) bool {
+			return bytes.Equal(cert.Raw, c.Raw)
+		}) {
+			foundIntermediateCA = true
+
+			break
+		}
+	}
+
+	if !foundIntermediateCA {
+		expectedSubjects := []string{}
+		for _, ca := range expectedIntermediateCAs {
+			if !slices.Contains(expectedSubjects, ca.Subject.String()) {
+				expectedSubjects = append(expectedSubjects, ca.Subject.String())
+			}
+		}
+
+		return nil, errors.New("S/MIME message contained a valid signature, but was not signed by one of the following expected intermediate CAs: '" + strings.Join(expectedSubjects, "', '") + "'")
 	}
 
 	return verified, nil

--- a/incus-osd/tests/api-tests.py
+++ b/incus-osd/tests/api-tests.py
@@ -6,9 +6,9 @@ import json
 import os
 import requests
 import shutil
-import subprocess
 import urllib.request
 
+from common import _check_deps
 from incusos_tests import IncusOSTests
 from incusos_tests.incus_test_vm import IncusOSException
 
@@ -17,16 +17,7 @@ current_release = None
 prior_stable_release = None
 urls = []
 
-# Expand PATH to include /usr/sbin/
-os.environ["PATH"] = os.environ["PATH"] + ":/usr/sbin"
-
-# Check that expected commands are available before running any tests
-for cmd in ["curl", "gdisk", "go", "mkfs.vfat", "mcopy", "mdeltree", "mkisofs", "openssl", "truncate"]:
-    try:
-        subprocess.run(["which", cmd], capture_output=True, check=True)
-    except:
-        print("Missing command: " + cmd)
-        exit(1)
+_check_deps()
 
 IMAGES_SERVER = os.getenv("IMAGES_SERVER", "https://images.linuxcontainers.org")
 

--- a/incus-osd/tests/certificate-e2e-tests.py
+++ b/incus-osd/tests/certificate-e2e-tests.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+
+import os
+
+from common import _check_deps
+from incusos_tests.incus_test_vm import IncusTestVM, util
+from incusos_tests.tests_certificate_e2e import TestUpdateMetadata, TestScriptAPI, TestScriptRecovery
+
+_check_deps()
+
+# Symlink the raw IncusOS image so it has the expected name
+install_image = os.path.join(os.getcwd(), os.environ["OSNAME"] + "_" + os.environ["VERSION"] + ".img")
+os.symlink(os.path.join(os.getcwd(), "mkosi.output", os.environ["OSNAME"] + "_" + os.environ["VERSION"] + ".raw"), install_image)
+
+# Create the test VM
+test_name = "certificate-e2e-tests"
+test_seed = {
+    "install.json": "{}",
+}
+
+print("Beginning end-to-end certificate tests", flush=True)
+
+test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+    vm.WaitSystemReady(os_version)
+
+    TestUpdateMetadata(vm)
+
+    TestScriptAPI(vm)
+
+    TestScriptRecovery(vm)
+
+print("End-to-end certificate tests completed successfully", flush=True)

--- a/incus-osd/tests/common.py
+++ b/incus-osd/tests/common.py
@@ -1,0 +1,14 @@
+import os
+import subprocess
+
+def _check_deps():
+    # Expand PATH to include /usr/sbin/
+    os.environ["PATH"] = os.environ["PATH"] + ":/usr/sbin"
+
+    # Check that expected commands are available before running any tests
+    for cmd in ["curl", "gdisk", "go", "mkfs.vfat", "mcopy", "mdeltree", "mkisofs", "openssl", "truncate"]:
+        try:
+            subprocess.run(["which", cmd], capture_output=True, check=True)
+        except:
+            print("Missing command: " + cmd)
+            exit(1)

--- a/incus-osd/tests/incusos_tests/tests_certificate_e2e.py
+++ b/incus-osd/tests/incusos_tests/tests_certificate_e2e.py
@@ -1,0 +1,119 @@
+import os
+import subprocess
+import tempfile
+
+from .incus_test_vm import IncusOSException, util
+
+def TestUpdateMetadata(vm):
+    """Test verification of update metadata consumed by the images provider."""
+
+    print("  Running provider update metadata tests", flush=True)
+
+    # At this point we expect to have a fresh IncusOS running with Incus installed.
+    # The update index.sjson has been properly validated using the Update intermediate CA.
+
+    # Sign the update index.sjson using an incorrect intermediate CA and expect to get an openssl verification error.
+    subprocess.run(["./incus-osd/image-publisher", "demote", "./local-image-server/", os.environ["VERSION"], "stable"], env={"PATH": "/usr/bin", "SIG_KEY": "./certs/update-E1.key", "SIG_CERTIFICATE": "./certs/update-E1.crt", "SIG_CHAIN": "./incus-osd/certs/files/support-E1.crt"}, capture_output=True, check=True)
+
+    # Trigger an update check
+    result = vm.APIRequest("/1.0/system/update/:check", method="POST")
+    if result["status_code"] != 200:
+        raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+    vm.WaitExpectedLog("incus-osd", "Failed to check for Secure Boot key updates err=unable to verify S/MIME message due to its use of a missing or unverifiable CA")
+
+    # Clear out the journal logs
+    vm.RunCommand("journalctl", "--rotate")
+    vm.RunCommand("journalctl", "--vacuum-time=1ms")
+
+    # Sign the update index.sjson with both an incorrect certificate and intermediate CA which will result
+    # in a valid signature, but expect IncusOS to properly catch and return an error.
+    subprocess.run(["./incus-osd/image-publisher", "promote", "./local-image-server/", os.environ["VERSION"], "stable"], env={"PATH": "/usr/bin", "SIG_KEY": "./certs/support-E1.key", "SIG_CERTIFICATE": "./certs/support-E1.crt", "SIG_CHAIN": "./incus-osd/certs/files/support-E1.crt"}, capture_output=True, check=True)
+
+    # Trigger an update check
+    result = vm.APIRequest("/1.0/system/update/:check", method="POST")
+    if result["status_code"] != 200:
+        raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+    vm.WaitExpectedLog("incus-osd", "Failed to check for Secure Boot key updates err=S/MIME message contained a valid signature, but was not signed by one of the following expected intermediate CAs: 'CN=TestOS - Update E1,O=TestOS'")
+
+    # Clear out the journal logs
+    vm.RunCommand("journalctl", "--rotate")
+    vm.RunCommand("journalctl", "--vacuum-time=1ms")
+
+    # Restore the update index.sjson to a correct state
+    subprocess.run(["./incus-osd/image-publisher", "demote", "./local-image-server/", os.environ["VERSION"], "stable"], env={"PATH": "/usr/bin", "SIG_KEY": "./certs/update-E1.key", "SIG_CERTIFICATE": "./certs/update-E1.crt", "SIG_CHAIN": "./incus-osd/certs/files/update-E1.crt"}, capture_output=True, check=True)
+    subprocess.run(["./incus-osd/image-publisher", "promote", "./local-image-server/", os.environ["VERSION"], "stable"], env={"PATH": "/usr/bin", "SIG_KEY": "./certs/update-E1.key", "SIG_CERTIFICATE": "./certs/update-E1.crt", "SIG_CHAIN": "./incus-osd/certs/files/update-E1.crt"}, capture_output=True, check=True)
+
+def TestScriptAPI(vm):
+    """Test verification and running of a hotfix script via the debug API."""
+
+    print("  Running hotfix script via debug API tests", flush=True)
+
+    # Input that doesn't look like a S/MIME-signed message should be rejected.
+    result = vm.APIRequest("/1.0/debug/:run-script", method="POST", body="#!/bin/sh\necho 'unsigned script'\n")
+    if result["status_code"] == 200:
+        raise IncusOSException("unexpected success, should have received an error")
+
+    if result["error"] != "doesn't look like S/MIME-signed input\n\n":
+        raise IncusOSException("got an unexpected error: " + result["error"])
+
+    # Prepare a simple hotfix script and verify that it runs as expected.
+    signed_script = subprocess.run(["openssl", "smime", "-sign", "-signer", "./certs/support-E1.crt", "-inkey", "./certs/support-E1.key", "-certfile", "./incus-osd/certs/files/support-E1.crt", "-text"], input="#!/bin/sh\necho 'Hello from hotfix script API'\n".encode("utf-8"), capture_output=True, check=True)
+
+    result = vm.APIRequest("/1.0/debug/:run-script", method="POST", body=signed_script.stdout)
+    if result["status_code"] != 200:
+        raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+    if result["metadata"] != "Hello from hotfix script API\n":
+        raise IncusOSException("failed to run hotfix script, got: " + result["metadata"])
+
+    # Prepare a simple hotfix script but sign it with an incorrect intermediate CA and expect to get an openssl verification error.
+    signed_script = subprocess.run(["openssl", "smime", "-sign", "-signer", "./certs/support-E1.crt", "-inkey", "./certs/support-E1.key", "-certfile", "./incus-osd/certs/files/update-E1.crt", "-text"], input="#!/bin/sh\necho 'Hello from hotfix script API'\n".encode("utf-8"), capture_output=True, check=True)
+
+    result = vm.APIRequest("/1.0/debug/:run-script", method="POST", body=signed_script.stdout)
+    if result["status_code"] == 200:
+        raise IncusOSException("unexpected success, should have received an error")
+
+    if result["error"] != "unable to verify S/MIME message due to its use of a missing or unverifiable CA\n\n":
+        raise IncusOSException("got an unexpected error: " + result["error"])
+
+    # Prepare a simple hotfix script but sign it with both an incorrect certificate and intermediate CA which will result
+    # in a valid signature, but expect IncusOS to properly catch and return an error.
+    signed_script = subprocess.run(["openssl", "smime", "-sign", "-signer", "./certs/update-E1.crt", "-inkey", "./certs/update-E1.key", "-certfile", "./incus-osd/certs/files/update-E1.crt", "-text"], input="#!/bin/sh\necho 'Hello from hotfix script API'\n".encode("utf-8"), capture_output=True, check=True)
+
+    result = vm.APIRequest("/1.0/debug/:run-script", method="POST", body=signed_script.stdout)
+    if result["status_code"] == 200:
+        raise IncusOSException("unexpected success, should have received an error")
+
+    if result["error"] != "S/MIME message contained a valid signature, but was not signed by one of the following expected intermediate CAs: 'CN=TestOS - Support E1,O=TestOS'\n\n":
+        raise IncusOSException("got an unexpected error: " + result["error"])
+
+def TestScriptRecovery(vm):
+    """Test verification and running of a hotfix script from recovery media."""
+
+    print("  Running hotfix script via recovery media tests", flush=True)
+
+    # Note that we only test a simple success case here, since running a hotfix script
+    # via the debug API exercises the same code path for various errors.
+
+    with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmp_dir:
+        with tempfile.NamedTemporaryFile(dir=os.getcwd()) as recovery_img:
+            # Prepare a simple hotfix script and verify that it runs as expected.
+            signed_script = subprocess.run(["openssl", "smime", "-sign", "-out", os.path.join(tmp_dir, "hotfix.sh.sig"), "-signer", "./certs/support-E1.crt", "-inkey", "./certs/support-E1.key", "-certfile", "./incus-osd/certs/files/support-E1.crt", "-text"], input="#!/bin/sh\necho 'Hello from hotfix script media'\n".encode("utf-8"), capture_output=True, check=True)
+
+            # Create a vfat partition labeled RESCUE_DATA and copy the hotfix script.
+            util._create_user_media(recovery_img, tmp_dir, "img", 4*1024*1024*1024, "RESCUE_DATA")
+
+            # Stop the VM and attach the recovery media.
+            vm.StopVM()
+            vm.AddDevice("recovery", "disk", "source="+recovery_img.name, "io.bus=usb")
+
+            # Start the VM and wait for the recovery script to run.
+            vm.StartVM()
+            vm.WaitAgentRunning()
+            vm.WaitExpectedLog("incus-osd", "Recovery partition detected")
+            vm.WaitExpectedLog("incus-osd", "Hotfix script detected, verifying signature")
+            vm.WaitExpectedLog("incus-osd", "Running hotfix script")
+            vm.WaitExpectedLog("incus-osd", "Hotfix script completed output=Hello from hotfix script media")
+            vm.WaitExpectedLog("incus-osd", "Recovery actions completed")

--- a/scripts/test/generate-test-certificates.sh
+++ b/scripts/test/generate-test-certificates.sh
@@ -39,35 +39,55 @@ openssl ecparam -genkey -name prime256v1 -out "certs/cas/update-E1.key"
 openssl req -new -SHA384 -key "certs/cas/update-E1.key" -nodes -out "certs/cas/update-E1.csr" -subj "/CN=${OS_NAME} - Update E1/O=${OS_NAME}"
 openssl x509 -req -extensions v3_ca -extfile certs/cas/ssl.conf -SHA384 -days 3650 -in "certs/cas/update-E1.csr" -CA "incus-osd/certs/files/root-E1.crt" -CAkey "certs/cas/root-E1.key" -out "incus-osd/certs/files/update-E1.crt"
 
+# Hotfix CA
+openssl ecparam -genkey -name prime256v1 -out "certs/cas/hotfix-E1.key"
+openssl req -new -SHA384 -key "certs/cas/hotfix-E1.key" -nodes -out "certs/cas/hotfix-E1.csr" -subj "/CN=${OS_NAME} - Hotfix E1/O=${OS_NAME}"
+openssl x509 -req -extensions v3_ca -extfile certs/cas/ssl.conf -SHA384 -days 3650 -in "certs/cas/hotfix-E1.csr" -CA "incus-osd/certs/files/root-E1.crt" -CAkey "certs/cas/root-E1.key" -out "incus-osd/certs/files/hotfix-E1.crt"
+
+# Support CA
+openssl ecparam -genkey -name prime256v1 -out "certs/cas/support-E1.key"
+openssl req -new -SHA384 -key "certs/cas/support-E1.key" -nodes -out "certs/cas/support-E1.csr" -subj "/CN=${OS_NAME} - Support E1/O=${OS_NAME}"
+openssl x509 -req -extensions v3_ca -extfile certs/cas/ssl.conf -SHA384 -days 3650 -in "certs/cas/support-E1.csr" -CA "incus-osd/certs/files/root-E1.crt" -CAkey "certs/cas/root-E1.key" -out "incus-osd/certs/files/support-E1.crt"
+
 # PK
 openssl genrsa -out "certs/secureboot-PK-R1.key" 2048
 openssl req -new -SHA256 -key "certs/secureboot-PK-R1.key" -nodes -out "certs/secureboot-PK-R1.csr" -subj "/CN=${OS_NAME} - Secure Boot PK R1/O=${OS_NAME}"
-openssl x509 -req -extensions v3_ca -extfile certs/cas/ssl.conf -SHA256 -days 3650 -in "certs/secureboot-PK-R1.csr" -CA "incus-osd/certs/files/secureboot-E1.crt" -CAkey "certs/cas/secureboot-E1.key" -out "incus-osd/certs/files/secureboot-PK-R1.crt"
+openssl x509 -req -SHA256 -days 3650 -in "certs/secureboot-PK-R1.csr" -CA "incus-osd/certs/files/secureboot-E1.crt" -CAkey "certs/cas/secureboot-E1.key" -out "incus-osd/certs/files/secureboot-PK-R1.crt"
 
 # KEKs
 openssl genrsa -out "certs/secureboot-KEK-R1.key" 2048
 openssl req -new -SHA256 -key "certs/secureboot-KEK-R1.key" -nodes -out "certs/secureboot-KEK-R1.csr" -subj "/CN=${OS_NAME} - Secure Boot KEK R1/O=${OS_NAME}"
-openssl x509 -req -extensions v3_ca -extfile certs/cas/ssl.conf -SHA256 -days 3650 -in "certs/secureboot-KEK-R1.csr" -CA "incus-osd/certs/files/secureboot-E1.crt" -CAkey "certs/cas/secureboot-E1.key" -out "incus-osd/certs/files/secureboot-KEK-R1.crt"
+openssl x509 -req -SHA256 -days 3650 -in "certs/secureboot-KEK-R1.csr" -CA "incus-osd/certs/files/secureboot-E1.crt" -CAkey "certs/cas/secureboot-E1.key" -out "incus-osd/certs/files/secureboot-KEK-R1.crt"
 
 openssl genrsa -out "certs/secureboot-KEK-R2.key" 2048
 openssl req -new -SHA256 -key "certs/secureboot-KEK-R2.key" -nodes -out "certs/secureboot-KEK-R2.csr" -subj "/CN=${OS_NAME} - Secure Boot KEK R2/O=${OS_NAME}"
-openssl x509 -req -extensions v3_ca -extfile certs/cas/ssl.conf -SHA256 -days 3650 -in "certs/secureboot-KEK-R2.csr" -CA "incus-osd/certs/files/secureboot-E1.crt" -CAkey "certs/cas/secureboot-E1.key" -out "incus-osd/certs/files/secureboot-KEK-R2.crt"
+openssl x509 -req -SHA256 -days 3650 -in "certs/secureboot-KEK-R2.csr" -CA "incus-osd/certs/files/secureboot-E1.crt" -CAkey "certs/cas/secureboot-E1.key" -out "incus-osd/certs/files/secureboot-KEK-R2.crt"
 
 # Secure Boot keys
 openssl genrsa -out "certs/secureboot-DB-1-R1.key" 2048
 openssl req -new -SHA256 -key "certs/secureboot-DB-1-R1.key" -nodes -out "certs/secureboot-DB-1-R1.csr" -subj "/CN=${OS_NAME} - Secure Boot 1 R1/O=${OS_NAME}"
-openssl x509 -req -extensions v3_ca -extfile certs/cas/ssl.conf -SHA256 -days 3650 -in "certs/secureboot-DB-1-R1.csr" -CA "incus-osd/certs/files/secureboot-E1.crt" -CAkey "certs/cas/secureboot-E1.key" -out "incus-osd/certs/files/secureboot-DB-1-R1.crt"
+openssl x509 -req -SHA256 -days 3650 -in "certs/secureboot-DB-1-R1.csr" -CA "incus-osd/certs/files/secureboot-E1.crt" -CAkey "certs/cas/secureboot-E1.key" -out "incus-osd/certs/files/secureboot-DB-1-R1.crt"
 
 openssl genrsa -out "certs/secureboot-DB-2-R1.key" 2048
 openssl req -new -SHA256 -key "certs/secureboot-DB-2-R1.key" -nodes -out "certs/secureboot-DB-2-R1.csr" -subj "/CN=${OS_NAME} - Secure Boot 2 R1/O=${OS_NAME}"
-openssl x509 -req -extensions v3_ca -extfile certs/cas/ssl.conf -SHA256 -days 3650 -in "certs/secureboot-DB-2-R1.csr" -CA "incus-osd/certs/files/secureboot-E1.crt" -CAkey "certs/cas/secureboot-E1.key" -out "incus-osd/certs/files/secureboot-DB-2-R1.crt"
+openssl x509 -req -SHA256 -days 3650 -in "certs/secureboot-DB-2-R1.csr" -CA "incus-osd/certs/files/secureboot-E1.crt" -CAkey "certs/cas/secureboot-E1.key" -out "incus-osd/certs/files/secureboot-DB-2-R1.crt"
 
 openssl genrsa -out "certs/secureboot-DB-3-R1.key" 2048
 openssl req -new -SHA256 -key "certs/secureboot-DB-3-R1.key" -nodes -out "certs/secureboot-DB-3-R1.csr" -subj "/CN=${OS_NAME} - Secure Boot 3 R1/O=${OS_NAME}"
-openssl x509 -req -extensions v3_ca -extfile certs/cas/ssl.conf -SHA256 -days 3650 -in "certs/secureboot-DB-3-R1.csr" -CA "incus-osd/certs/files/secureboot-E1.crt" -CAkey "certs/cas/secureboot-E1.key" -out "incus-osd/certs/files/secureboot-DB-3-R1.crt"
+openssl x509 -req -SHA256 -days 3650 -in "certs/secureboot-DB-3-R1.csr" -CA "incus-osd/certs/files/secureboot-E1.crt" -CAkey "certs/cas/secureboot-E1.key" -out "incus-osd/certs/files/secureboot-DB-3-R1.crt"
 
 openssl genrsa -out "certs/secureboot-DBX-1-R1.key" 2048
 openssl req -new -SHA256 -key "certs/secureboot-DBX-1-R1.key" -nodes -out "certs/secureboot-DBX-1-R1.csr" -subj "/CN=${OS_NAME} - Secure Boot 4 R1/O=${OS_NAME}"
-openssl x509 -req -extensions v3_ca -extfile certs/cas/ssl.conf -SHA256 -days 3650 -in "certs/secureboot-DBX-1-R1.csr" -CA "incus-osd/certs/files/secureboot-E1.crt" -CAkey "certs/cas/secureboot-E1.key" -out "incus-osd/certs/files/secureboot-DBX-1-R1.crt"
+openssl x509 -req -SHA256 -days 3650 -in "certs/secureboot-DBX-1-R1.csr" -CA "incus-osd/certs/files/secureboot-E1.crt" -CAkey "certs/cas/secureboot-E1.key" -out "incus-osd/certs/files/secureboot-DBX-1-R1.crt"
+
+# Test update signing certificate
+openssl ecparam -genkey -name prime256v1 -out "certs/update-E1.key"
+openssl req -new -SHA384 -key "certs/update-E1.key" -nodes -out "certs/update-E1.csr" -subj "/CN=${OS_NAME} - Update Test Cert E1/O=${OS_NAME}"
+openssl x509 -req -SHA384 -days 3650 -in "certs/update-E1.csr" -CA "incus-osd/certs/files/update-E1.crt" -CAkey "certs/cas/update-E1.key" -out "certs/update-E1.crt"
+
+# Test support signing certificate
+openssl ecparam -genkey -name prime256v1 -out "certs/support-E1.key"
+openssl req -new -SHA384 -key "certs/support-E1.key" -nodes -out "certs/support-E1.csr" -subj "/CN=${OS_NAME} - Support Test Cert E1/O=${OS_NAME}"
+openssl x509 -req -SHA384 -days 3650 -in "certs/support-E1.csr" -CA "incus-osd/certs/files/support-E1.crt" -CAkey "certs/cas/support-E1.key" -out "certs/support-E1.crt"
 
 find certs/ -name '*.csr' -delete


### PR DESCRIPTION
Currently, IncusOS verifies S/MIME content by using the built-in root CA as a trust anchor and relies on the S/MIME message to include a proper certificate chain consisting of an intermediate CA and the actual signing certificate. This works fine, but would allow for a compromised intermediate CA to issue certificates and make signatures for sources of data that it shouldn't. This PR introduces additional checks so that only an expected CA can be used to sign certain updates:

* The `images` provider will rely json indices being signed by the Update CA (current behavior)
* Any hotfix scripts must be signed by the Support CA (this will be the Update CA for IncusOS, but different for HypervisorOS)
* Any recovery update json indices must be signed by the Update CA (current behavior)