### PR TITLE
incus-osd/providers/images: Only load default update CA if we'll actually be using it

### DIFF
--- a/incus-osd/internal/providers/provider_images.go
+++ b/incus-osd/internal/providers/provider_images.go
@@ -336,8 +336,8 @@ func (p *images) load(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-	} else {
-		// Set the default update CA if one was not provided..
+	} else if !p.ignoreSignedJSON {
+		// Set the default update CA if one was not provided.
 		embeddedCerts, err := certs.GetEmbeddedCertificates()
 		if err != nil {
 			return err


### PR DESCRIPTION
Closes #1227