### PR TITLE
base: Fix OS name in error message

### DIFF
--- a/mkosi.images/base/mkosi.extra/usr/lib/systemd/system/print-incus-osd-journal-errors.service
+++ b/mkosi.images/base/mkosi.extra/usr/lib/systemd/system/print-incus-osd-journal-errors.service
@@ -6,7 +6,6 @@ DefaultDependencies=no
 Type=oneshot
 
 EnvironmentFile=/usr/lib/os-release
-Environment=MSG="$NAME failed to start. journal contents follow:"
 Environment=TTYS="/dev/tty1 /dev/ttyS0"
 
-ExecStart=/bin/sh -c "for TTY in $TTYS; do echo $MSG > $TTY || true; journalctl -b 0 -u incus-osd > $TTY || true; done"
+ExecStart=/bin/sh -c "for TTY in $TTYS; do echo \"$NAME failed to start. journal contents follow:\" > $TTY || true; journalctl -b 0 -u incus-osd > $TTY || true; done"


### PR DESCRIPTION
systemd service variable definitions don't perform variable substitution

Closes #1219