### PR TITLE
gpu-support docs: clarify this excludes out of tree drivers

### DIFF
--- a/doc/reference/applications/gpu-support.md
+++ b/doc/reference/applications/gpu-support.md
@@ -2,6 +2,10 @@
 
 The GPU support (`gpu-support`) application includes the required firmware files for GPUs from one of:
 
-* `amd`
-* `nvidia`
-* `intel`
+* `amdgpu`
+* `nouveau` (Nvidia)
+* `i915` (Intel)
+
+```{note}
+The out of tree Nvidia drivers are not included.
+```


### PR DESCRIPTION
Update GPU support documentation to reflect correct driver names, and add a note to clarify out of tree Nvidia drivers are not included.