### PR TITLE
gpu-support docs: clarify this does not include drivers

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -85,6 +85,7 @@ NetBird's
 networkctl
 NICs
 NTP
+Nvidia
 NVMe
 NVRAM
 OCI

--- a/doc/reference/applications/gpu-support.md
+++ b/doc/reference/applications/gpu-support.md
@@ -5,3 +5,8 @@ The GPU support (`gpu-support`) application includes the required firmware files
 * `amd`
 * `nvidia`
 * `intel`
+
+```{note}
+`gpu-support` only includes firmware files - it does not include any drivers (Kernel modules are always part of the IncusOS base image, never leaf images like `gpu-support`).
+The out of tree Nvidia drivers are not available on an IncusOS host.
+```


### PR DESCRIPTION
Clarify gpu-support includes only firmware files and not drivers. Added note about kernel modules and Nvidia drivers.