### PR TITLE
Better handle corrupt/incomplete sysext image updates

### DIFF
--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -280,34 +280,9 @@ func run(ctx context.Context, s *state.State) error {
 	}
 
 	// Check if we have enough free disk space.
-	freeSpace, err := storage.GetFreeSpaceInGiB("/")
+	err = storage.CheckMinimumDiskSpace(ctx, "/")
 	if err != nil {
 		return err
-	}
-
-	if freeSpace < 1.0 {
-		slog.ErrorContext(ctx, fmt.Sprintf("Only %.02fGiB free space available in /, attempting emergency disk cleanup", freeSpace))
-
-		// Clear old journal entries.
-		_, err = subprocess.RunCommandContext(ctx, "journalctl", "--vacuum-files=1")
-		if err != nil {
-			return err
-		}
-
-		// Clear anything in /var/cache/.
-		cacheEntries, err := os.ReadDir("/var/cache/")
-		if err != nil {
-			return err
-		}
-
-		for _, entry := range cacheEntries {
-			err := os.RemoveAll(filepath.Join("/var/cache", entry.Name()))
-			if err != nil {
-				return err
-			}
-		}
-	} else if freeSpace < 5.0 {
-		slog.WarnContext(ctx, fmt.Sprintf("Only %.02fGiB free space available in /", freeSpace))
 	}
 
 	// Create runtime path if missing.

--- a/incus-osd/internal/applications/sysext.go
+++ b/incus-osd/internal/applications/sysext.go
@@ -37,7 +37,15 @@ func RefreshExtensions(ctx context.Context, s *state.State) error {
 		return nil
 	}
 
-	// Begin by collecting information about the expected version(s) that exist
+	// Remove any corrupt sysext images that exist on disk.
+	for _, app := range apps {
+		err := removeCorruptSysextImages(ctx, app.Name(), app.Version())
+		if err != nil {
+			return err
+		}
+	}
+
+	// Gather information about the expected version(s) that exist
 	// on-disk for each installed application.
 	appVersions, err := getApplicationsVersions(apps)
 	if err != nil {
@@ -301,6 +309,52 @@ func removeStaleSysextImages(appName string, skipVersions []string) error {
 		_, err := os.Stat(filepath.Join(systemd.LocalExtensionsPath, entry.Name(), appName+".raw"))
 		if err == nil {
 			err := os.Remove(filepath.Join(systemd.LocalExtensionsPath, entry.Name(), appName+".raw"))
+			if err != nil {
+				return err
+			}
+
+			// Opportunistically attempt to remove the directory. This will fail
+			// if it is non-empty, which is OK.
+			_ = os.Remove(filepath.Join(systemd.LocalExtensionsPath, entry.Name()))
+		}
+	}
+
+	return nil
+}
+
+func removeCorruptSysextImages(ctx context.Context, appName string, currentVersion string) error {
+	dirEntries, err := os.ReadDir(systemd.LocalExtensionsPath)
+	if err != nil {
+		return err
+	}
+
+	// Iterate through each directory under /var/lib/incus-os-extensions/, which
+	// corresponds to the version of one or more installed applications.
+	for _, entry := range dirEntries {
+		sysextFile := filepath.Join(systemd.LocalExtensionsPath, entry.Name(), appName+".raw")
+
+		// Check if the application sysext image exists.
+		_, err := os.Stat(sysextFile)
+		if err != nil {
+			continue
+		}
+
+		// Check if the sysext image is valid.
+		err = systemd.VerifyExtension(ctx, sysextFile)
+		if err == nil {
+			continue
+		}
+
+		// Remove the corrupt sysext image.
+		if currentVersion == entry.Name() {
+			// We cannot easily remove the sysext image for the current application version. Doing so
+			// would require updates to state and somehow picking an appropriate other version. It's
+			// better to just log an error and let the application fail to load.
+			slog.ErrorContext(ctx, "Current application sysext image is corrupt", "application", appName, "version", entry.Name())
+		} else {
+			slog.WarnContext(ctx, "Removing corrupt application sysext image", "application", appName, "version", entry.Name())
+
+			err := os.Remove(sysextFile)
 			if err != nil {
 				return err
 			}

--- a/incus-osd/internal/providers/provider_debug.go
+++ b/incus-osd/internal/providers/provider_debug.go
@@ -12,6 +12,7 @@ import (
 	ocapi "github.com/FuturFusion/operations-center/shared/api"
 
 	"github.com/lxc/incus-os/incus-osd/internal/state"
+	"github.com/lxc/incus-os/incus-osd/internal/systemd"
 )
 
 // DebugPath defines a hard-coded path to where the debug provider will look for updates.
@@ -288,10 +289,22 @@ func (a *debugApplication) Download(ctx context.Context, targetPath string, prog
 			continue
 		}
 
-		// If the application sysext image already exists on disk, don't re-copy it.
-		_, err := os.Stat(filepath.Join(targetPath, filepath.Base(asset)))
+		sysextFile := filepath.Join(targetPath, filepath.Base(asset))
+
+		// Check if the application sysext image exists on disk and is valid.
+		_, err := os.Stat(sysextFile)
 		if err == nil {
-			continue
+			err := systemd.VerifyExtension(ctx, sysextFile)
+			if err == nil {
+				// If the sysext is valid, no point in re-downloading it.
+				continue
+			}
+
+			// Remove the corrupt sysext image and re-download it.
+			err = os.Remove(sysextFile)
+			if err != nil {
+				return err
+			}
 		}
 
 		// Copy the application.

--- a/incus-osd/internal/providers/provider_images.go
+++ b/incus-osd/internal/providers/provider_images.go
@@ -28,6 +28,7 @@ import (
 	"github.com/lxc/incus-os/incus-osd/certs"
 	"github.com/lxc/incus-os/incus-osd/internal/auth"
 	"github.com/lxc/incus-os/incus-osd/internal/state"
+	"github.com/lxc/incus-os/incus-osd/internal/systemd"
 	"github.com/lxc/incus-os/incus-osd/internal/util"
 )
 
@@ -548,10 +549,22 @@ func (a *imagesApplication) Download(ctx context.Context, targetPath string, pro
 		fileURL := a.provider.serverURL + "/" + a.latestUpdate.Version + "/" + file.Filename
 		targetName := strings.TrimSuffix(filepath.Base(file.Filename), ".gz")
 
-		// If the application sysext image already exists on disk, don't re-download it.
-		_, err := os.Stat(filepath.Join(targetPath, targetName))
+		sysextFile := filepath.Join(targetPath, targetName)
+
+		// Check if the application sysext image exists on disk and is valid.
+		_, err := os.Stat(sysextFile)
 		if err == nil {
-			continue
+			err := systemd.VerifyExtension(ctx, sysextFile)
+			if err == nil {
+				// If the sysext is valid, no point in re-downloading it.
+				continue
+			}
+
+			// Remove the corrupt sysext image and re-download it.
+			err = os.Remove(sysextFile)
+			if err != nil {
+				return err
+			}
 		}
 
 		// Download the application.

--- a/incus-osd/internal/providers/provider_operations_center.go
+++ b/incus-osd/internal/providers/provider_operations_center.go
@@ -30,6 +30,7 @@ import (
 	apiupdate "github.com/lxc/incus-os/incus-osd/api/images"
 	"github.com/lxc/incus-os/incus-osd/internal/applications"
 	"github.com/lxc/incus-os/incus-osd/internal/state"
+	"github.com/lxc/incus-os/incus-osd/internal/systemd"
 )
 
 // API structs.
@@ -635,10 +636,22 @@ func (a *operationsCenterApplication) Download(ctx context.Context, targetPath s
 
 		targetName := strings.TrimSuffix(filepath.Base(file.Filename), ".gz")
 
-		// If the application sysext image already exists on disk, don't re-download it.
-		_, err := os.Stat(filepath.Join(targetPath, targetName))
+		sysextFile := filepath.Join(targetPath, targetName)
+
+		// Check if the application sysext image exists on disk and is valid.
+		_, err := os.Stat(sysextFile)
 		if err == nil {
-			continue
+			err := systemd.VerifyExtension(ctx, sysextFile)
+			if err == nil {
+				// If the sysext is valid, no point in re-downloading it.
+				continue
+			}
+
+			// Remove the corrupt sysext image and re-download it.
+			err = os.Remove(sysextFile)
+			if err != nil {
+				return err
+			}
 		}
 
 		// Download the application.

--- a/incus-osd/internal/providers/utils.go
+++ b/incus-osd/internal/providers/utils.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/lxc/incus/v7/shared/revert"
 )
 
 func downloadAsset(ctx context.Context, osName string, osVersion string, client *http.Client, assetURL string, expectedSHA256 string, target string, progressFunc func(float64)) error {
@@ -65,6 +67,14 @@ func downloadAsset(ctx context.Context, osName string, osVersion string, client 
 
 	defer fd.Close()
 
+	// Setup a reverter to cleanup any failed downloads.
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	reverter.Add(func() {
+		_ = os.Remove(target)
+	})
+
 	// Read from the decompressor in chunks to avoid excessive memory consumption.
 	count := int64(0)
 
@@ -90,6 +100,8 @@ func downloadAsset(ctx context.Context, osName string, osVersion string, client 
 	if expectedSHA256 != "" && expectedSHA256 != hex.EncodeToString(h.Sum(nil)) {
 		return errors.New("sha256 mismatch for file " + target)
 	}
+
+	reverter.Success()
 
 	return nil
 }

--- a/incus-osd/internal/storage/storage.go
+++ b/incus-osd/internal/storage/storage.go
@@ -248,8 +248,8 @@ func GetUnderlyingDevice() (string, error) {
 	return "", errors.New("unable to determine underlying device")
 }
 
-// GetFreeSpaceInGiB returns the amount of free space in GiB for the underlying filesystem of the given path.
-func GetFreeSpaceInGiB(path string) (float64, error) {
+// getFreeSpaceInGiB returns the amount of free space in GiB for the underlying filesystem of the given path.
+func getFreeSpaceInGiB(path string) (float64, error) {
 	var s unix.Statfs_t
 
 	err := unix.Statfs(path, &s)
@@ -258,6 +258,42 @@ func GetFreeSpaceInGiB(path string) (float64, error) {
 	}
 
 	return float64(s.Bsize*int64(s.Bfree)) / 1024.0 / 1024.0 / 1024.0, nil // #nosec G115
+}
+
+// CheckMinimumDiskSpace checks if a minimum amount of disk space exists. If less than 1 GiB,
+// make some attempt to cleanup old logs and cached files.
+func CheckMinimumDiskSpace(ctx context.Context, path string) error {
+	freeSpace, err := getFreeSpaceInGiB(path)
+	if err != nil {
+		return err
+	}
+
+	if freeSpace < 1.0 {
+		slog.ErrorContext(ctx, fmt.Sprintf("Only %.02fGiB free space available in "+path+", attempting emergency disk cleanup", freeSpace))
+
+		// Clear old journal entries.
+		_, err = subprocess.RunCommandContext(ctx, "journalctl", "--vacuum-files=1")
+		if err != nil {
+			return err
+		}
+
+		// Clear anything in /var/cache/.
+		cacheEntries, err := os.ReadDir("/var/cache/")
+		if err != nil {
+			return err
+		}
+
+		for _, entry := range cacheEntries {
+			err := os.RemoveAll(filepath.Join("/var/cache", entry.Name()))
+			if err != nil {
+				return err
+			}
+		}
+	} else if freeSpace < 5.0 {
+		slog.WarnContext(ctx, fmt.Sprintf("Only %.02fGiB free space available in "+path, freeSpace))
+	}
+
+	return nil
 }
 
 // DeviceToID takes a device path like /dev/sda and determines its "by-id" mapping, for example /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root.

--- a/incus-osd/internal/update/update.go
+++ b/incus-osd/internal/update/update.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lxc/incus-os/incus-osd/internal/providers"
 	"github.com/lxc/incus-os/incus-osd/internal/secureboot"
 	"github.com/lxc/incus-os/incus-osd/internal/state"
+	"github.com/lxc/incus-os/incus-osd/internal/storage"
 	"github.com/lxc/incus-os/incus-osd/internal/systemd"
 	"github.com/lxc/incus-os/incus-osd/internal/tui"
 )
@@ -427,6 +428,12 @@ func CheckAndDownloadUpdate(ctx context.Context, s *state.State, t *tui.TUI, p p
 
 	// Apply the update.
 	if updateNeeded {
+		// Before applying the update, check current disk space.
+		err := storage.CheckMinimumDiskSpace(ctx, "/")
+		if err != nil {
+			return "", err
+		}
+
 		return applyUpdate(ctx, s, t, update, appName, isStartupCheck)
 	} else if isStartupCheck {
 		if ut == TypeApplication {

--- a/incus-osd/internal/update/update.go
+++ b/incus-osd/internal/update/update.go
@@ -471,6 +471,8 @@ func applyUpdate(ctx context.Context, s *state.State, t *tui.TUI, update provide
 	// Download the update.
 	err := update.Download(ctx, targetPath, updateModal.UpdateProgress)
 	if err != nil {
+		updateModal.Done()
+
 		return "", err
 	}
 


### PR DESCRIPTION
* Add logic to remove corrupt sysext images
* Only skip downloading existing sysext image if it exists and is valid
* Properly cleanup any failed downloads
* Check for minimum free disk space before downloading update

Closes #1247