### PR TITLE
Avoid double tracking of traffic when br_netfilter is in use

### DIFF
--- a/incus-osd/internal/nftables/nft.go
+++ b/incus-osd/internal/nftables/nft.go
@@ -44,6 +44,68 @@ func SetupChains(ctx context.Context) error {
 		return err
 	}
 
+	// Ensure we have a conntrack bypass chain (hooked ahead of nf_conntrack_bridge at -200).
+	_, err = subprocess.RunCommandContext(ctx, "nft", "add", "chain", "bridge", "incus-osd", "conntrack-bypass", "{ type filter hook prerouting priority -300 ; policy accept ; }")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ApplyNotrackFilters excludes host uplink traffic entering the managed bridges from bridge conntrack.
+// When nf_conntrack_bridge is active (loaded by Incus for bridge NIC ACLs), traffic already tracked and
+// NATed at the IP layer would otherwise be re-tracked with its post-NAT tuple on entering the bridge
+// through the host-side veth, then dropped on conntrack insertion clash at bridge postrouting.
+func ApplyNotrackFilters(ctx context.Context, networkCfg *api.SystemNetworkConfig) error {
+	// Make sure we have the expected chains.
+	err := SetupChains(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Empty the chain.
+	_, err = subprocess.RunCommandContext(ctx, "nft", "flush", "chain", "bridge", "incus-osd", "conntrack-bypass")
+	if err != nil {
+		return err
+	}
+
+	// Get the list of bridge-side veth devices for the managed bridges.
+	ifaces := []string{}
+
+	for _, iface := range networkCfg.Interfaces {
+		if iface.Hwaddr == "" {
+			continue
+		}
+
+		ifaces = append(ifaces, "_i"+strings.ToLower(strings.ReplaceAll(iface.Hwaddr, ":", "")))
+	}
+
+	for _, iface := range networkCfg.Bonds {
+		hwaddr := iface.Hwaddr
+		if hwaddr == "" && len(iface.Members) > 0 {
+			hwaddr = iface.Members[0]
+		}
+
+		if hwaddr == "" {
+			continue
+		}
+
+		ifaces = append(ifaces, "_i"+strings.ToLower(strings.ReplaceAll(hwaddr, ":", "")))
+	}
+
+	if len(ifaces) == 0 {
+		return nil
+	}
+
+	// Disable connection tracking for host traffic entering the bridge.
+	set := "{" + strings.Join(ifaces, ",") + "}"
+
+	_, err = subprocess.RunCommandContext(ctx, "nft", "add", "rule", "bridge", "incus-osd", "conntrack-bypass", "iifname", set, "notrack")
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/incus-osd/internal/systemd/networkd.go
+++ b/incus-osd/internal/systemd/networkd.go
@@ -140,6 +140,12 @@ func ApplyNetworkConfiguration(ctx context.Context, s *state.State, networkCfg *
 		return err
 	}
 
+	// Apply the conntrack bypass rules.
+	err = nftables.ApplyNotrackFilters(ctx, networkCfg)
+	if err != nil {
+		return err
+	}
+
 	// Restart networking after new config files have been generated.
 	err = RestartUnit(ctx, "systemd-networkd")
 	if err != nil {


### PR DESCRIPTION
Similar to a previous issue (which we worked around in Incus instead), there are a bunch of weird issues caused by NAT+br_netfilter effectively causing traffic to be double tracked and dropped.

This workaround injects a higher priority chain into the set, then that chain gets a rule for each IncusOS bridge matching its _i* interfaces (bridge side of host veth) and marks the traffic as notrack. This then leads to the traffic being tracked exactly once and things to work correctly.