### PR TITLE
incus-osd/systemd/network: Configure physical, bridge, and bonds with maximum MTUs

### DIFF
--- a/incus-osd/internal/systemd/networkd.go
+++ b/incus-osd/internal/systemd/networkd.go
@@ -986,7 +986,7 @@ ff02::2 ip6-allrouters
 
 // generateNetworkConfiguration clears any existing configuration from /run/systemd/network/ and generates
 // new config files from the supplied NetworkConfig struct.
-func generateNetworkConfiguration(_ context.Context, networkCfg *api.SystemNetworkConfig) error {
+func generateNetworkConfiguration(ctx context.Context, networkCfg *api.SystemNetworkConfig) error {
 	// Remove any existing configuration.
 	err := os.RemoveAll(SystemdNetworkConfigPath)
 	if err != nil {
@@ -999,7 +999,12 @@ func generateNetworkConfiguration(_ context.Context, networkCfg *api.SystemNetwo
 	}
 
 	// Generate .link files.
-	for _, cfg := range generateLinkFileContents(*networkCfg) {
+	cfgs, err := generateLinkFileContents(ctx, *networkCfg)
+	if err != nil {
+		return err
+	}
+
+	for _, cfg := range cfgs {
 		err := os.WriteFile(filepath.Join(SystemdNetworkConfigPath, cfg.Name), []byte(cfg.Contents), 0o644)
 		if err != nil {
 			return err
@@ -1015,7 +1020,12 @@ func generateNetworkConfiguration(_ context.Context, networkCfg *api.SystemNetwo
 	}
 
 	// Generate .network files.
-	for _, cfg := range generateNetworkFileContents(*networkCfg) {
+	cfgs, err = generateNetworkFileContents(ctx, *networkCfg)
+	if err != nil {
+		return err
+	}
+
+	for _, cfg := range cfgs {
 		err := os.WriteFile(filepath.Join(SystemdNetworkConfigPath, cfg.Name), []byte(cfg.Contents), 0o644)
 		if err != nil {
 			return err
@@ -1260,7 +1270,7 @@ func waitForSystemdTimesyncd(ctx context.Context, timeout time.Duration) error {
 
 // generateLinkFileContents generates the contents of systemd.link files. Returns an array of ConfigFile structs.
 // https://www.freedesktop.org/software/systemd/man/latest/systemd.link.html
-func generateLinkFileContents(networkCfg api.SystemNetworkConfig) []networkdConfigFile {
+func generateLinkFileContents(ctx context.Context, networkCfg api.SystemNetworkConfig) ([]networkdConfigFile, error) {
 	ret := []networkdConfigFile{}
 
 	generateEthernet := func(s *api.SystemNetworkEthernet) string {
@@ -1315,6 +1325,11 @@ Enable=false`
 	}
 
 	for _, i := range networkCfg.Interfaces {
+		maxMTU, err := getMaxMTUForMAC(ctx, i.Hwaddr)
+		if err != nil {
+			return nil, err
+		}
+
 		strippedHwaddr := strings.ToLower(strings.ReplaceAll(i.Hwaddr, ":", ""))
 		ret = append(ret, networkdConfigFile{
 			Name: fmt.Sprintf("00-_p%s.link", strippedHwaddr),
@@ -1325,12 +1340,18 @@ PermanentMACAddress=%s
 MACAddressPolicy=random
 NamePolicy=
 Name=_p%s
-%s`, i.Hwaddr, strippedHwaddr, generateEthernet(i.Ethernet)),
+MTUBytes=%d
+%s`, i.Hwaddr, strippedHwaddr, maxMTU, generateEthernet(i.Ethernet)),
 		})
 	}
 
 	for _, b := range networkCfg.Bonds {
 		for _, member := range b.Members {
+			maxMTU, err := getMaxMTUForMAC(ctx, member)
+			if err != nil {
+				return nil, err
+			}
+
 			strippedHwaddr := strings.ToLower(strings.ReplaceAll(member, ":", ""))
 			ret = append(ret, networkdConfigFile{
 				Name: fmt.Sprintf("01-_p%s.link", strippedHwaddr),
@@ -1340,12 +1361,13 @@ PermanentMACAddress=%s
 [Link]
 NamePolicy=
 Name=_p%s
-%s`, member, strippedHwaddr, generateEthernet(b.Ethernet)),
+MTUBytes=%d
+%s`, member, strippedHwaddr, maxMTU, generateEthernet(b.Ethernet)),
 			})
 		}
 	}
 
-	return ret
+	return ret, nil
 }
 
 // generateNetdevFileContents generates the contents of systemd.netdev files. Returns an array of networkdConfigFile structs.
@@ -1355,22 +1377,16 @@ func generateNetdevFileContents(networkCfg api.SystemNetworkConfig) []networkdCo
 
 	// Create bridge and veth devices for each interface.
 	for _, i := range networkCfg.Interfaces {
-		mtuString := ""
-		if i.MTU != 0 {
-			mtuString = fmt.Sprintf("MTUBytes=%d", i.MTU)
-		}
-
 		// Bridge.
 		ret = append(ret, networkdConfigFile{
 			Name: fmt.Sprintf("10-%s.netdev", i.Name),
 			Contents: fmt.Sprintf(`[NetDev]
 Name=%s
 Kind=bridge
-%s
 
 [Bridge]
 VLANFiltering=true
-`, i.Name, mtuString),
+`, i.Name),
 		})
 
 		// veth.
@@ -1381,21 +1397,15 @@ VLANFiltering=true
 Name=_v%s
 Kind=veth
 MACAddress=%s
-%s
 
 [Peer]
 Name=_i%s
-`, i.Name, i.Hwaddr, mtuString, strippedHwaddr),
+`, i.Name, i.Hwaddr, strippedHwaddr),
 		})
 	}
 
 	// Create bond, bridge, and veth devices for each bond.
 	for _, b := range networkCfg.Bonds {
-		mtuString := ""
-		if b.MTU != 0 {
-			mtuString = fmt.Sprintf("MTUBytes=%d", b.MTU)
-		}
-
 		// Bond.
 		var sbMode strings.Builder
 		if b.Mode != "" {
@@ -1412,11 +1422,10 @@ Name=_i%s
 			Contents: fmt.Sprintf(`[NetDev]
 Name=_b%s
 Kind=bond
-%s
 
 [Bond]
 %s
-`, b.Name, mtuString, sbMode.String()),
+`, b.Name, sbMode.String()),
 		})
 
 		// Bridge.
@@ -1425,11 +1434,10 @@ Kind=bond
 			Contents: fmt.Sprintf(`[NetDev]
 Name=%s
 Kind=bridge
-%s
 
 [Bridge]
 VLANFiltering=true
-`, b.Name, mtuString),
+`, b.Name),
 		})
 
 		// veth.
@@ -1445,41 +1453,29 @@ VLANFiltering=true
 Name=_v%s
 Kind=veth
 MACAddress=%s
-%s
 
 [Peer]
 Name=_i%s
-`, b.Name, bondMacAddr, mtuString, strippedHwaddr),
+`, b.Name, bondMacAddr, strippedHwaddr),
 		})
 	}
 
 	// Create vlans.
 	for _, v := range networkCfg.VLANs {
-		mtuString := ""
-		if v.MTU != 0 {
-			mtuString = fmt.Sprintf("MTUBytes=%d", v.MTU)
-		}
-
 		ret = append(ret, networkdConfigFile{
 			Name: fmt.Sprintf("12-%s.netdev", v.Name),
 			Contents: fmt.Sprintf(`[NetDev]
 Name=%s
 Kind=vlan
-%s
 
 [VLAN]
 Id=%d
-`, v.Name, mtuString, v.ID),
+`, v.Name, v.ID),
 		})
 	}
 
 	// Create wireguard.
 	for _, w := range networkCfg.Wireguard {
-		mtuString := ""
-		if w.MTU != 0 {
-			mtuString = fmt.Sprintf("MTUBytes=%d", w.MTU)
-		}
-
 		listenPort := ""
 		if w.Port != 0 {
 			listenPort = fmt.Sprintf("ListenPort=%d", w.Port)
@@ -1490,13 +1486,12 @@ Id=%d
 		_, _ = fmt.Fprintf(&cfgBuffer, `[NetDev]
 Name=%s
 Kind=wireguard
-%s
 
 [WireGuard]
 PrivateKey=%s
 %s
 
-`, w.Name, mtuString, w.PrivateKey, listenPort)
+`, w.Name, w.PrivateKey, listenPort)
 
 		for _, peer := range w.Peers {
 			var options strings.Builder
@@ -1534,17 +1529,30 @@ PublicKey=%s
 
 // generateNetworkFileContents generates the contents of systemd.network files. Returns an array of networkdConfigFile structs.
 // https://www.freedesktop.org/software/systemd/man/latest/systemd.network.html
-func generateNetworkFileContents(networkCfg api.SystemNetworkConfig) []networkdConfigFile {
+func generateNetworkFileContents(ctx context.Context, networkCfg api.SystemNetworkConfig) ([]networkdConfigFile, error) { //nolint:revive
 	ret := []networkdConfigFile{}
 
 	// Create networks for each interface and its bridge.
 	for _, i := range networkCfg.Interfaces {
+		maxMTU, err := getMaxMTUForMAC(ctx, i.Hwaddr)
+		if err != nil {
+			return nil, err
+		}
+
+		configuredMTU := i.MTU
+		if configuredMTU == 0 {
+			configuredMTU = 1500
+		} else if configuredMTU > maxMTU {
+			configuredMTU = maxMTU
+		}
+
 		// User side of veth device.
 		cfgString := fmt.Sprintf(`[Match]
 Name=_v%s
 
 [Link]
 %s
+MTUBytes=%d
 
 [DHCP]
 ClientIdentifier=mac
@@ -1555,7 +1563,7 @@ UseMTU=true
 WithoutRA=solicit
 
 [Network]
-%s`, i.Name, generateLinkSectionContents(i.Addresses, i.RequiredForOnline), generateNetworkSectionContents(i.Name, networkCfg.VLANs, networkCfg.DNS, networkCfg.Time))
+%s`, i.Name, generateLinkSectionContents(i.Addresses, i.RequiredForOnline), configuredMTU, generateNetworkSectionContents(i.Name, networkCfg.VLANs, networkCfg.DNS, networkCfg.Time))
 
 		cfgString += processAddresses(i.Addresses)
 
@@ -1573,9 +1581,12 @@ WithoutRA=solicit
 		cfgString = fmt.Sprintf(`[Match]
 Name=_i%s
 
+[Link]
+MTUBytes=%d
+
 [Network]
 Bridge=%s
-`, strippedHwaddr, i.Name)
+`, strippedHwaddr, maxMTU, i.Name)
 
 		cfgString += generateVLANContents(i.Name, i.VLANTags, networkCfg.VLANs)
 
@@ -1588,17 +1599,16 @@ Bridge=%s
 		cfgString = fmt.Sprintf(`[Match]
 Name=_p%s
 
+[Link]
+MTUBytes=%d
+
 [Network]
 LLDP=%s
 EmitLLDP=%s
 Bridge=%s
-`, strippedHwaddr, strconv.FormatBool(i.LLDP), strconv.FormatBool(i.LLDP), i.Name)
+`, strippedHwaddr, maxMTU, strconv.FormatBool(i.LLDP), strconv.FormatBool(i.LLDP), i.Name)
 
 		cfgString += generateVLANContents(i.Name, i.VLANTags, networkCfg.VLANs)
-
-		if i.MTU != 0 {
-			cfgString += fmt.Sprintf("[Link]\nMTUBytes=%d\n", i.MTU)
-		}
 
 		ret = append(ret, networkdConfigFile{
 			Name:     fmt.Sprintf("20-_p%s.network", strippedHwaddr),
@@ -1609,14 +1619,13 @@ Bridge=%s
 		cfgString = fmt.Sprintf(`[Match]
 Name=%s
 
+[Link]
+MTUBytes=%d
+
 [Network]
 LinkLocalAddressing=no
 ConfigureWithoutCarrier=yes
-`, i.Name)
-
-		if i.MTU != 0 {
-			cfgString += fmt.Sprintf("[Link]\nMTUBytes=%d\n", i.MTU)
-		}
+`, i.Name, maxMTU)
 
 		ret = append(ret, networkdConfigFile{
 			Name:     fmt.Sprintf("20-%s.network", i.Name),
@@ -1626,12 +1635,53 @@ ConfigureWithoutCarrier=yes
 
 	// Create networks for each bond, its member(s), and its bridge.
 	for _, b := range networkCfg.Bonds {
+		maxMTU := 9000
+
+		// Bond members.
+		for index, member := range b.Members {
+			mtu, err := getMaxMTUForMAC(ctx, member)
+			if err != nil {
+				return nil, err
+			}
+
+			// Set the maximum MTU for the bond to be the smallest of the member's
+			// maximum MTU.
+			if maxMTU > mtu {
+				maxMTU = mtu
+			}
+
+			memberStrippedHwaddr := strings.ToLower(strings.ReplaceAll(member, ":", ""))
+
+			ret = append(ret, networkdConfigFile{
+				Name: fmt.Sprintf("21-_b%s-dev%d.network", b.Name, index),
+				Contents: fmt.Sprintf(`[Match]
+Name=_p%s
+
+[Link]
+MTUBytes=%d
+
+[Network]
+LLDP=%s
+EmitLLDP=%s
+Bond=_b%s
+`, memberStrippedHwaddr, mtu, strconv.FormatBool(b.LLDP), strconv.FormatBool(b.LLDP), b.Name),
+			})
+		}
+
+		configuredMTU := b.MTU
+		if configuredMTU == 0 {
+			configuredMTU = 1500
+		} else if configuredMTU > maxMTU {
+			configuredMTU = maxMTU
+		}
+
 		// User side of veth device.
 		cfgString := fmt.Sprintf(`[Match]
 Name=_v%s
 
 [Link]
 %s
+MTUBytes=%d
 
 [DHCP]
 ClientIdentifier=mac
@@ -1642,7 +1692,7 @@ UseMTU=true
 WithoutRA=solicit
 
 [Network]
-%s`, b.Name, generateLinkSectionContents(b.Addresses, b.RequiredForOnline), generateNetworkSectionContents(b.Name, networkCfg.VLANs, networkCfg.DNS, networkCfg.Time))
+%s`, b.Name, generateLinkSectionContents(b.Addresses, b.RequiredForOnline), configuredMTU, generateNetworkSectionContents(b.Name, networkCfg.VLANs, networkCfg.DNS, networkCfg.Time))
 
 		cfgString += processAddresses(b.Addresses)
 
@@ -1666,9 +1716,12 @@ WithoutRA=solicit
 		cfgString = fmt.Sprintf(`[Match]
 Name=_i%s
 
+[Link]
+MTUBytes=%d
+
 [Network]
 Bridge=%s
-`, strippedHwaddr, b.Name)
+`, strippedHwaddr, maxMTU, b.Name)
 
 		cfgString += generateVLANContents(b.Name, b.VLANTags, networkCfg.VLANs)
 
@@ -1681,11 +1734,14 @@ Bridge=%s
 		cfgString = fmt.Sprintf(`[Match]
 Name=_b%s
 
+[Link]
+MTUBytes=%d
+
 [Network]
 LinkLocalAddressing=no
 ConfigureWithoutCarrier=yes
 Bridge=%s
-`, b.Name, b.Name)
+`, b.Name, maxMTU, b.Name)
 
 		cfgString += generateVLANContents(b.Name, b.VLANTags, networkCfg.VLANs)
 
@@ -1698,41 +1754,35 @@ Bridge=%s
 		cfgString = fmt.Sprintf(`[Match]
 Name=%s
 
+[Link]
+MTUBytes=%d
+
 [Network]
 LinkLocalAddressing=no
 ConfigureWithoutCarrier=yes
-`, b.Name)
+`, b.Name, maxMTU)
 
 		ret = append(ret, networkdConfigFile{
 			Name:     fmt.Sprintf("21-%s.network", b.Name),
 			Contents: cfgString,
 		})
-
-		// Bond members.
-		for index, member := range b.Members {
-			memberStrippedHwaddr := strings.ToLower(strings.ReplaceAll(member, ":", ""))
-
-			ret = append(ret, networkdConfigFile{
-				Name: fmt.Sprintf("21-_b%s-dev%d.network", b.Name, index),
-				Contents: fmt.Sprintf(`[Match]
-Name=_p%s
-
-[Network]
-LLDP=%s
-EmitLLDP=%s
-Bond=_b%s
-`, memberStrippedHwaddr, strconv.FormatBool(b.LLDP), strconv.FormatBool(b.LLDP), b.Name),
-			})
-		}
 	}
 
 	// Create network for each VLAN.
 	for _, v := range networkCfg.VLANs {
+		configuredMTU := v.MTU
+		if configuredMTU == 0 {
+			configuredMTU = 1500
+		} else if configuredMTU > 9000 {
+			configuredMTU = 9000
+		}
+
 		cfgString := fmt.Sprintf(`[Match]
 Name=%s
 
 [Link]
 %s
+MTUBytes=%d
 
 [DHCP]
 ClientIdentifier=mac
@@ -1743,7 +1793,7 @@ UseMTU=true
 WithoutRA=solicit
 
 [Network]
-%s`, v.Name, generateLinkSectionContents(v.Addresses, v.RequiredForOnline), generateNetworkSectionContents(v.Name, nil, networkCfg.DNS, networkCfg.Time))
+%s`, v.Name, generateLinkSectionContents(v.Addresses, v.RequiredForOnline), configuredMTU, generateNetworkSectionContents(v.Name, nil, networkCfg.DNS, networkCfg.Time))
 
 		cfgString += processAddresses(v.Addresses)
 
@@ -1759,11 +1809,21 @@ WithoutRA=solicit
 
 	// Create network for each Wireguard.
 	for _, wg := range networkCfg.Wireguard {
+		configuredMTU := wg.MTU
+		if configuredMTU == 0 {
+			configuredMTU = 1500
+		} else if configuredMTU > 9000 {
+			configuredMTU = 9000
+		}
+
 		cfgString := fmt.Sprintf(`[Match]
 Name=%s
 
+[Link]
+MTUBytes=%d
+
 [Network]
-`, wg.Name)
+`, wg.Name, configuredMTU)
 
 		cfgString += processAddresses(wg.Addresses)
 
@@ -1777,7 +1837,7 @@ Name=%s
 		})
 	}
 
-	return ret
+	return ret, nil
 }
 
 func processAddresses(addresses []string) string {
@@ -2172,6 +2232,45 @@ func getMacForInterface(ctx context.Context, iface string) (string, error) {
 	}
 
 	return match[0][1], nil
+}
+
+// Determine the maximum MTU supported by a given device. Because device names can change,
+// we use the underlying MAC when getting the maximum MTU.
+func getMaxMTUForMAC(ctx context.Context, mac string) (int, error) {
+	// To support testing, if an empty context is provided, return a
+	// default unique maximum MTU.
+	if ctx == context.TODO() {
+		return 9009, nil
+	}
+
+	mtuRegex := regexp.MustCompile(mac + ` .+? minmtu \d+ maxmtu (\d+)`)
+
+	output, err := subprocess.RunCommandContext(ctx, "ip", "-d", "link")
+	if err != nil {
+		return -1, err
+	}
+
+	match := mtuRegex.FindAllStringSubmatch(output, -1)
+	if len(match) == 0 {
+		return -1, errors.New("unable to determine maximum MTU for " + mac)
+	}
+
+	mtu, err := strconv.Atoi(match[0][1])
+	if err != nil {
+		return -1, err
+	}
+
+	// Cap maximum MTU to 9000.
+	if mtu > 9000 {
+		mtu = 9000
+	}
+
+	// Make sure the MTU isn't too small for IPv6.
+	if mtu < 1280 {
+		return -1, fmt.Errorf("maximum MTU of %d for %s is too small to support IPv6", mtu, mac)
+	}
+
+	return mtu, nil
 }
 
 func getExpectedNewPhysicalDevices(ctx context.Context, config *api.SystemNetworkConfig) []expPhysDev {

--- a/incus-osd/internal/systemd/networkd_test.go
+++ b/incus-osd/internal/systemd/networkd_test.go
@@ -1,6 +1,7 @@
 package systemd
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -34,7 +35,7 @@ interfaces:
 bonds:
   - name: management
     mode: 802.3ad
-    mtu: 9000
+    mtu: 8750
     vlan_tags:
       - 100
     addresses:
@@ -95,7 +96,7 @@ wireguard:
 var networkdConfig2 = `
 interfaces:
   - name: management
-    mtu: 9000
+    mtu: 8500
     addresses:
       - dhcp4
       - slaac
@@ -151,7 +152,7 @@ bonds:
    mode: "802.3ad"
    hwaddr: "aa:bb:cc:dd:ee:e1"
    lldp: true
-   mtu: 9000
+   mtu: 8250
    members:
     - "aa:bb:cc:dd:ee:e1"
     - "aa:bb:cc:dd:ee:e2"
@@ -194,7 +195,7 @@ interfaces:
 bonds:
   - name: no-hw-tso
     mode: 802.3ad
-    mtu: 9000
+    mtu: 8000
     vlan_tags:
       - 100
     addresses:
@@ -397,7 +398,7 @@ func TestNetworkConfigMarshalling(t *testing.T) {
 		require.Equal(t, "storage", cfg.Interfaces[1].Roles[0])
 		require.Len(t, cfg.Bonds, 1)
 		require.Equal(t, "management", cfg.Bonds[0].Name)
-		require.Equal(t, 9000, cfg.Bonds[0].MTU)
+		require.Equal(t, 8750, cfg.Bonds[0].MTU)
 		require.Empty(t, cfg.Bonds[0].Hwaddr)
 		require.Len(t, cfg.Bonds[0].Routes, 2)
 		require.Len(t, cfg.Bonds[0].Members, 2)
@@ -521,7 +522,7 @@ func TestNetworkConfigMarshalling(t *testing.T) {
 		require.Equal(t, "802.3ad", cfg.Bonds[0].Mode)
 		require.Equal(t, "aa:bb:cc:dd:ee:e1", cfg.Bonds[0].Hwaddr)
 		require.True(t, cfg.Bonds[0].LLDP)
-		require.Equal(t, 9000, cfg.Bonds[0].MTU)
+		require.Equal(t, 8250, cfg.Bonds[0].MTU)
 		require.Len(t, cfg.Bonds[0].Members, 2)
 		require.Equal(t, "aa:bb:cc:dd:ee:e1", cfg.Bonds[0].Members[0])
 		require.Equal(t, "aa:bb:cc:dd:ee:e2", cfg.Bonds[0].Members[1])
@@ -557,72 +558,78 @@ func TestLinkFileGeneration(t *testing.T) {
 	err := yaml.Load([]byte(networkdConfig1), &networkCfg)
 	require.NoError(t, err)
 
-	cfgs := generateLinkFileContents(networkCfg)
+	cfgs, err := generateLinkFileContents(context.TODO(), networkCfg)
+	require.NoError(t, err)
 	require.Len(t, cfgs, 4)
 	require.Equal(t, "00-_paabbccddee01.link", cfgs[0].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:01\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=_paabbccddee01\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:01\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=_paabbccddee01\nMTUBytes=9009\n", cfgs[0].Contents)
 	require.Equal(t, "00-_paabbccddee02.link", cfgs[1].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:02\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=_paabbccddee02\n", cfgs[1].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:02\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=_paabbccddee02\nMTUBytes=9009\n", cfgs[1].Contents)
 	require.Equal(t, "01-_paabbccddee03.link", cfgs[2].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:03\n\n[Link]\nNamePolicy=\nName=_paabbccddee03\n", cfgs[2].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:03\n\n[Link]\nNamePolicy=\nName=_paabbccddee03\nMTUBytes=9009\n", cfgs[2].Contents)
 	require.Equal(t, "01-_paabbccddee04.link", cfgs[3].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:04\n\n[Link]\nNamePolicy=\nName=_paabbccddee04\n", cfgs[3].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:04\n\n[Link]\nNamePolicy=\nName=_paabbccddee04\nMTUBytes=9009\n", cfgs[3].Contents)
 
 	// Test second config .link file generation.
 	networkCfg = api.SystemNetworkConfig{}
 	err = yaml.Load([]byte(networkdConfig2), &networkCfg)
 	require.NoError(t, err)
 
-	cfgs = generateLinkFileContents(networkCfg)
+	cfgs, err = generateLinkFileContents(context.TODO(), networkCfg)
+	require.NoError(t, err)
 	require.Len(t, cfgs, 1)
 	require.Equal(t, "00-_paabbccddee01.link", cfgs[0].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:01\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=_paabbccddee01\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:01\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=_paabbccddee01\nMTUBytes=9009\n", cfgs[0].Contents)
 
 	// Test third config .link file generation.
 	networkCfg = api.SystemNetworkConfig{}
 	err = yaml.Load([]byte(networkdConfig3), &networkCfg)
 	require.NoError(t, err)
 
-	cfgs = generateLinkFileContents(networkCfg)
+	cfgs, err = generateLinkFileContents(context.TODO(), networkCfg)
+	require.NoError(t, err)
 	require.Len(t, cfgs, 1)
 	require.Equal(t, "00-_pffeeddccbbaa.link", cfgs[0].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=FF:EE:DD:CC:BB:AA\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=_pffeeddccbbaa\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=FF:EE:DD:CC:BB:AA\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=_pffeeddccbbaa\nMTUBytes=9009\n", cfgs[0].Contents)
 
 	// Test fourth config .link file generation.
 	networkCfg = api.SystemNetworkConfig{}
 	err = yaml.Load([]byte(networkdConfig4), &networkCfg)
 	require.NoError(t, err)
 
-	cfgs = generateLinkFileContents(networkCfg)
+	cfgs, err = generateLinkFileContents(context.TODO(), networkCfg)
+	require.NoError(t, err)
 	require.Len(t, cfgs, 2)
 	require.Equal(t, "01-_paabbccddeee1.link", cfgs[0].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=aa:bb:cc:dd:ee:e1\n\n[Link]\nNamePolicy=\nName=_paabbccddeee1\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=aa:bb:cc:dd:ee:e1\n\n[Link]\nNamePolicy=\nName=_paabbccddeee1\nMTUBytes=9009\n", cfgs[0].Contents)
 	require.Equal(t, "01-_paabbccddeee2.link", cfgs[1].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=aa:bb:cc:dd:ee:e2\n\n[Link]\nNamePolicy=\nName=_paabbccddeee2\n", cfgs[1].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=aa:bb:cc:dd:ee:e2\n\n[Link]\nNamePolicy=\nName=_paabbccddeee2\nMTUBytes=9009\n", cfgs[1].Contents)
 
 	// Test fifth config .link file generation.
 	networkCfg = api.SystemNetworkConfig{}
 	err = yaml.Load([]byte(networkdConfig5), &networkCfg)
 	require.NoError(t, err)
 
-	cfgs = generateLinkFileContents(networkCfg)
+	cfgs, err = generateLinkFileContents(context.TODO(), networkCfg)
+	require.NoError(t, err)
 	require.Len(t, cfgs, 3)
 	require.Equal(t, "00-_paabbccddee01.link", cfgs[0].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:01\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=_paabbccddee01\nGenericReceiveOffload=false\nGenericReceiveOffloadHardware=false\nGenericSegmentationOffload=false\nTCPSegmentationOffload=false\nTCP6SegmentationOffload=false\nWakeOnLan=magic\nWakeOnLan=secureon\nWakeOnLanPassword=11:22:33:44:55:66\n[EnergyEfficientEthernet]\nEnable=false\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:01\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=_paabbccddee01\nMTUBytes=9009\nGenericReceiveOffload=false\nGenericReceiveOffloadHardware=false\nGenericSegmentationOffload=false\nTCPSegmentationOffload=false\nTCP6SegmentationOffload=false\nWakeOnLan=magic\nWakeOnLan=secureon\nWakeOnLanPassword=11:22:33:44:55:66\n[EnergyEfficientEthernet]\nEnable=false\n", cfgs[0].Contents)
 	require.Equal(t, "01-_paabbccddee02.link", cfgs[1].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:02\n\n[Link]\nNamePolicy=\nName=_paabbccddee02\nTCPSegmentationOffload=false\nTCP6SegmentationOffload=false\n[EnergyEfficientEthernet]\nEnable=false\n", cfgs[1].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:02\n\n[Link]\nNamePolicy=\nName=_paabbccddee02\nMTUBytes=9009\nTCPSegmentationOffload=false\nTCP6SegmentationOffload=false\n[EnergyEfficientEthernet]\nEnable=false\n", cfgs[1].Contents)
 	require.Equal(t, "01-_paabbccddee03.link", cfgs[2].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:03\n\n[Link]\nNamePolicy=\nName=_paabbccddee03\nTCPSegmentationOffload=false\nTCP6SegmentationOffload=false\n[EnergyEfficientEthernet]\nEnable=false\n", cfgs[2].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:03\n\n[Link]\nNamePolicy=\nName=_paabbccddee03\nMTUBytes=9009\nTCPSegmentationOffload=false\nTCP6SegmentationOffload=false\n[EnergyEfficientEthernet]\nEnable=false\n", cfgs[2].Contents)
 
 	// Test sixth config .link file generation.
 	networkCfg = api.SystemNetworkConfig{}
 	err = yaml.Load([]byte(networkdConfig6), &networkCfg)
 	require.NoError(t, err)
 
-	cfgs = generateLinkFileContents(networkCfg)
+	cfgs, err = generateLinkFileContents(context.TODO(), networkCfg)
+	require.NoError(t, err)
 	require.Len(t, cfgs, 1)
 	require.Equal(t, "00-_paabbccddee01.link", cfgs[0].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:01\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=_paabbccddee01\nGenericReceiveOffload=false\nGenericReceiveOffloadHardware=false\nTCPSegmentationOffload=false\nTCP6SegmentationOffload=false\nWakeOnLan=magic\nWakeOnLan=secureon\nWakeOnLanPassword=11:22:33:44:55:66\n[EnergyEfficientEthernet]\nEnable=false\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:01\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=_paabbccddee01\nMTUBytes=9009\nGenericReceiveOffload=false\nGenericReceiveOffloadHardware=false\nTCPSegmentationOffload=false\nTCP6SegmentationOffload=false\nWakeOnLan=magic\nWakeOnLan=secureon\nWakeOnLanPassword=11:22:33:44:55:66\n[EnergyEfficientEthernet]\nEnable=false\n", cfgs[0].Contents)
 }
 
 func TestNetdevFileGeneration(t *testing.T) {
@@ -637,23 +644,23 @@ func TestNetdevFileGeneration(t *testing.T) {
 	cfgs := generateNetdevFileContents(networkCfg)
 	require.Len(t, cfgs, 9)
 	require.Equal(t, "10-san1.netdev", cfgs[0].Name)
-	require.Equal(t, "[NetDev]\nName=san1\nKind=bridge\n\n\n[Bridge]\nVLANFiltering=true\n", cfgs[0].Contents)
+	require.Equal(t, "[NetDev]\nName=san1\nKind=bridge\n\n[Bridge]\nVLANFiltering=true\n", cfgs[0].Contents)
 	require.Equal(t, "10-_vsan1.netdev", cfgs[1].Name)
-	require.Equal(t, "[NetDev]\nName=_vsan1\nKind=veth\nMACAddress=AA:BB:CC:DD:EE:01\n\n\n[Peer]\nName=_iaabbccddee01\n", cfgs[1].Contents)
+	require.Equal(t, "[NetDev]\nName=_vsan1\nKind=veth\nMACAddress=AA:BB:CC:DD:EE:01\n\n[Peer]\nName=_iaabbccddee01\n", cfgs[1].Contents)
 	require.Equal(t, "10-san2.netdev", cfgs[2].Name)
-	require.Equal(t, "[NetDev]\nName=san2\nKind=bridge\n\n\n[Bridge]\nVLANFiltering=true\n", cfgs[2].Contents)
+	require.Equal(t, "[NetDev]\nName=san2\nKind=bridge\n\n[Bridge]\nVLANFiltering=true\n", cfgs[2].Contents)
 	require.Equal(t, "10-_vsan2.netdev", cfgs[3].Name)
-	require.Equal(t, "[NetDev]\nName=_vsan2\nKind=veth\nMACAddress=AA:BB:CC:DD:EE:02\n\n\n[Peer]\nName=_iaabbccddee02\n", cfgs[3].Contents)
+	require.Equal(t, "[NetDev]\nName=_vsan2\nKind=veth\nMACAddress=AA:BB:CC:DD:EE:02\n\n[Peer]\nName=_iaabbccddee02\n", cfgs[3].Contents)
 	require.Equal(t, "11-_bmanagement.netdev", cfgs[4].Name)
-	require.Equal(t, "[NetDev]\nName=_bmanagement\nKind=bond\nMTUBytes=9000\n\n[Bond]\nMode=802.3ad\nTransmitHashPolicy=layer3+4\nLACPTransmitRate=fast\n", cfgs[4].Contents)
+	require.Equal(t, "[NetDev]\nName=_bmanagement\nKind=bond\n\n[Bond]\nMode=802.3ad\nTransmitHashPolicy=layer3+4\nLACPTransmitRate=fast\n", cfgs[4].Contents)
 	require.Equal(t, "11-management.netdev", cfgs[5].Name)
-	require.Equal(t, "[NetDev]\nName=management\nKind=bridge\nMTUBytes=9000\n\n[Bridge]\nVLANFiltering=true\n", cfgs[5].Contents)
+	require.Equal(t, "[NetDev]\nName=management\nKind=bridge\n\n[Bridge]\nVLANFiltering=true\n", cfgs[5].Contents)
 	require.Equal(t, "11-_vmanagement.netdev", cfgs[6].Name)
-	require.Equal(t, "[NetDev]\nName=_vmanagement\nKind=veth\nMACAddress=AA:BB:CC:DD:EE:03\nMTUBytes=9000\n\n[Peer]\nName=_iaabbccddee03\n", cfgs[6].Contents)
+	require.Equal(t, "[NetDev]\nName=_vmanagement\nKind=veth\nMACAddress=AA:BB:CC:DD:EE:03\n\n[Peer]\nName=_iaabbccddee03\n", cfgs[6].Contents)
 	require.Equal(t, "12-uplink.netdev", cfgs[7].Name)
-	require.Equal(t, "[NetDev]\nName=uplink\nKind=vlan\nMTUBytes=1500\n\n[VLAN]\nId=1234\n", cfgs[7].Contents)
+	require.Equal(t, "[NetDev]\nName=uplink\nKind=vlan\n\n[VLAN]\nId=1234\n", cfgs[7].Contents)
 	require.Equal(t, "13-wg0.netdev", cfgs[8].Name)
-	require.Equal(t, "[NetDev]\nName=wg0\nKind=wireguard\n\n\n[WireGuard]\nPrivateKey=AE1SCwtkp8ruDYlUa9x9wsoTzEOePl3P9sMdFFa9PmI=\nListenPort=51820\n\n[WireGuardPeer]\nPublicKey=rJhRcAtHUldTAA/J+TPQPQpr6G9C2Arf5FiTVwjOYCE=\nAllowedIPs=10.9.0.1/32\nAllowedIPs=fd25:6c9a:6c19::1/128\nAllowedIPs=192.168.1.0/24\nEndpoint=10.102.89.87:51820\n\n\n[WireGuardPeer]\nPublicKey=qPYSgwaJe0VZb4M8smTPpd2rfKHz0X0ypq54ZY4ATVQ=\nAllowedIPs=10.9.0.3/32\nAllowedIPs=fd25:6c9a:6c19::3/128\nEndpoint=10.180.60.231:51820\n\n\n", cfgs[8].Contents)
+	require.Equal(t, "[NetDev]\nName=wg0\nKind=wireguard\n\n[WireGuard]\nPrivateKey=AE1SCwtkp8ruDYlUa9x9wsoTzEOePl3P9sMdFFa9PmI=\nListenPort=51820\n\n[WireGuardPeer]\nPublicKey=rJhRcAtHUldTAA/J+TPQPQpr6G9C2Arf5FiTVwjOYCE=\nAllowedIPs=10.9.0.1/32\nAllowedIPs=fd25:6c9a:6c19::1/128\nAllowedIPs=192.168.1.0/24\nEndpoint=10.102.89.87:51820\n\n\n[WireGuardPeer]\nPublicKey=qPYSgwaJe0VZb4M8smTPpd2rfKHz0X0ypq54ZY4ATVQ=\nAllowedIPs=10.9.0.3/32\nAllowedIPs=fd25:6c9a:6c19::3/128\nEndpoint=10.180.60.231:51820\n\n\n", cfgs[8].Contents)
 
 	// Test second config .netdev file generation.
 	networkCfg = api.SystemNetworkConfig{}
@@ -663,11 +670,11 @@ func TestNetdevFileGeneration(t *testing.T) {
 	cfgs = generateNetdevFileContents(networkCfg)
 	require.Len(t, cfgs, 3)
 	require.Equal(t, "10-management.netdev", cfgs[0].Name)
-	require.Equal(t, "[NetDev]\nName=management\nKind=bridge\nMTUBytes=9000\n\n[Bridge]\nVLANFiltering=true\n", cfgs[0].Contents)
+	require.Equal(t, "[NetDev]\nName=management\nKind=bridge\n\n[Bridge]\nVLANFiltering=true\n", cfgs[0].Contents)
 	require.Equal(t, "10-_vmanagement.netdev", cfgs[1].Name)
-	require.Equal(t, "[NetDev]\nName=_vmanagement\nKind=veth\nMACAddress=AA:BB:CC:DD:EE:01\nMTUBytes=9000\n\n[Peer]\nName=_iaabbccddee01\n", cfgs[1].Contents)
+	require.Equal(t, "[NetDev]\nName=_vmanagement\nKind=veth\nMACAddress=AA:BB:CC:DD:EE:01\n\n[Peer]\nName=_iaabbccddee01\n", cfgs[1].Contents)
 	require.Equal(t, "13-wg0.netdev", cfgs[2].Name)
-	require.Equal(t, "[NetDev]\nName=wg0\nKind=wireguard\nMTUBytes=1420\n\n[WireGuard]\nPrivateKey=\n\n\n", cfgs[2].Contents)
+	require.Equal(t, "[NetDev]\nName=wg0\nKind=wireguard\n\n[WireGuard]\nPrivateKey=\n\n\n", cfgs[2].Contents)
 
 	// Test third config .netdev file generation.
 	networkCfg = api.SystemNetworkConfig{}
@@ -682,9 +689,9 @@ func TestNetdevFileGeneration(t *testing.T) {
 	cfgs = generateNetdevFileContents(networkCfg)
 	require.Len(t, cfgs, 2)
 	require.Equal(t, "10-ffeeddccbbaa.netdev", cfgs[0].Name)
-	require.Equal(t, "[NetDev]\nName=ffeeddccbbaa\nKind=bridge\n\n\n[Bridge]\nVLANFiltering=true\n", cfgs[0].Contents)
+	require.Equal(t, "[NetDev]\nName=ffeeddccbbaa\nKind=bridge\n\n[Bridge]\nVLANFiltering=true\n", cfgs[0].Contents)
 	require.Equal(t, "10-_vffeeddccbbaa.netdev", cfgs[1].Name)
-	require.Equal(t, "[NetDev]\nName=_vffeeddccbbaa\nKind=veth\nMACAddress=FF:EE:DD:CC:BB:AA\n\n\n[Peer]\nName=_iffeeddccbbaa\n", cfgs[1].Contents)
+	require.Equal(t, "[NetDev]\nName=_vffeeddccbbaa\nKind=veth\nMACAddress=FF:EE:DD:CC:BB:AA\n\n[Peer]\nName=_iffeeddccbbaa\n", cfgs[1].Contents)
 
 	// Test fourth config .netdev file generation.
 	networkCfg = api.SystemNetworkConfig{}
@@ -694,13 +701,13 @@ func TestNetdevFileGeneration(t *testing.T) {
 	cfgs = generateNetdevFileContents(networkCfg)
 	require.Len(t, cfgs, 4)
 	require.Equal(t, "11-_buplink.netdev", cfgs[0].Name)
-	require.Equal(t, "[NetDev]\nName=_buplink\nKind=bond\nMTUBytes=9000\n\n[Bond]\nMode=802.3ad\nTransmitHashPolicy=layer3+4\nLACPTransmitRate=fast\n", cfgs[0].Contents)
+	require.Equal(t, "[NetDev]\nName=_buplink\nKind=bond\n\n[Bond]\nMode=802.3ad\nTransmitHashPolicy=layer3+4\nLACPTransmitRate=fast\n", cfgs[0].Contents)
 	require.Equal(t, "11-uplink.netdev", cfgs[1].Name)
-	require.Equal(t, "[NetDev]\nName=uplink\nKind=bridge\nMTUBytes=9000\n\n[Bridge]\nVLANFiltering=true\n", cfgs[1].Contents)
+	require.Equal(t, "[NetDev]\nName=uplink\nKind=bridge\n\n[Bridge]\nVLANFiltering=true\n", cfgs[1].Contents)
 	require.Equal(t, "11-_vuplink.netdev", cfgs[2].Name)
-	require.Equal(t, "[NetDev]\nName=_vuplink\nKind=veth\nMACAddress=aa:bb:cc:dd:ee:e1\nMTUBytes=9000\n\n[Peer]\nName=_iaabbccddeee1\n", cfgs[2].Contents)
+	require.Equal(t, "[NetDev]\nName=_vuplink\nKind=veth\nMACAddress=aa:bb:cc:dd:ee:e1\n\n[Peer]\nName=_iaabbccddeee1\n", cfgs[2].Contents)
 	require.Equal(t, "12-management.netdev", cfgs[3].Name)
-	require.Equal(t, "[NetDev]\nName=management\nKind=vlan\nMTUBytes=1500\n\n[VLAN]\nId=10\n", cfgs[3].Contents)
+	require.Equal(t, "[NetDev]\nName=management\nKind=vlan\n\n[VLAN]\nId=10\n", cfgs[3].Contents)
 }
 
 func TestNetworkFileGeneration(t *testing.T) {
@@ -712,58 +719,60 @@ func TestNetworkFileGeneration(t *testing.T) {
 	err := yaml.Load([]byte(networkdConfig1), &networkCfg)
 	require.NoError(t, err)
 
-	cfgs := generateNetworkFileContents(networkCfg)
+	cfgs, err := generateNetworkFileContents(context.TODO(), networkCfg)
+	require.NoError(t, err)
 	require.Len(t, cfgs, 16)
 	require.Equal(t, "20-_vsan1.network", cfgs[0].Name)
-	require.Equal(t, "[Match]\nName=_vsan1\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=both\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.0.101.10/24\nAddress=fd40:1234:1234:101::10/64\nIPv6AcceptRA=false\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nName=_vsan1\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=both\nMTUBytes=1500\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.0.101.10/24\nAddress=fd40:1234:1234:101::10/64\nIPv6AcceptRA=false\n", cfgs[0].Contents)
 	require.Equal(t, "20-_iaabbccddee01.network", cfgs[1].Name)
-	require.Equal(t, "[Match]\nName=_iaabbccddee01\n\n[Network]\nBridge=san1\n", cfgs[1].Contents)
+	require.Equal(t, "[Match]\nName=_iaabbccddee01\n\n[Link]\nMTUBytes=9009\n\n[Network]\nBridge=san1\n", cfgs[1].Contents)
 	require.Equal(t, "20-_paabbccddee01.network", cfgs[2].Name)
-	require.Equal(t, "[Match]\nName=_paabbccddee01\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBridge=san1\n", cfgs[2].Contents)
+	require.Equal(t, "[Match]\nName=_paabbccddee01\n\n[Link]\nMTUBytes=9009\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBridge=san1\n", cfgs[2].Contents)
 	require.Equal(t, "20-san1.network", cfgs[3].Name)
-	require.Equal(t, "[Match]\nName=san1\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[3].Contents)
+	require.Equal(t, "[Match]\nName=san1\n\n[Link]\nMTUBytes=9009\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[3].Contents)
 	require.Equal(t, "20-_vsan2.network", cfgs[4].Name)
-	require.Equal(t, "[Match]\nName=_vsan2\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=both\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.0.102.10/24\nAddress=fd40:1234:1234:102::10/64\nIPv6AcceptRA=false\n", cfgs[4].Contents)
+	require.Equal(t, "[Match]\nName=_vsan2\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=both\nMTUBytes=1500\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.0.102.10/24\nAddress=fd40:1234:1234:102::10/64\nIPv6AcceptRA=false\n", cfgs[4].Contents)
 	require.Equal(t, "20-_iaabbccddee02.network", cfgs[5].Name)
-	require.Equal(t, "[Match]\nName=_iaabbccddee02\n\n[Network]\nBridge=san2\n\n[BridgeVLAN]\nVLAN=10\n", cfgs[5].Contents)
+	require.Equal(t, "[Match]\nName=_iaabbccddee02\n\n[Link]\nMTUBytes=9009\n\n[Network]\nBridge=san2\n\n[BridgeVLAN]\nVLAN=10\n", cfgs[5].Contents)
 	require.Equal(t, "20-_paabbccddee02.network", cfgs[6].Name)
-	require.Equal(t, "[Match]\nName=_paabbccddee02\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBridge=san2\n\n[BridgeVLAN]\nVLAN=10\n", cfgs[6].Contents)
+	require.Equal(t, "[Match]\nName=_paabbccddee02\n\n[Link]\nMTUBytes=9009\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBridge=san2\n\n[BridgeVLAN]\nVLAN=10\n", cfgs[6].Contents)
 	require.Equal(t, "20-san2.network", cfgs[7].Name)
-	require.Equal(t, "[Match]\nName=san2\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[7].Contents)
-	require.Equal(t, "21-_vmanagement.network", cfgs[8].Name)
-	require.Equal(t, "[Match]\nName=_vmanagement\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=any\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nVLAN=uplink\nLinkLocalAddressing=ipv6\nAddress=10.0.100.10/24\nAddress=fd40:1234:1234:100::10/64\nIPv6AcceptRA=false\n\n[Route]\nGateway=10.0.100.1\nDestination=0.0.0.0/0\n\n[Route]\nGateway=fd40:1234:1234:100::1\nDestination=::/0\n", cfgs[8].Contents)
-	require.Equal(t, "21-_iaabbccddee03.network", cfgs[9].Name)
-	require.Equal(t, "[Match]\nName=_iaabbccddee03\n\n[Network]\nBridge=management\n\n[BridgeVLAN]\nVLAN=100\n\n[BridgeVLAN]\nVLAN=1234\n", cfgs[9].Contents)
-	require.Equal(t, "21-_bmanagement.network", cfgs[10].Name)
-	require.Equal(t, "[Match]\nName=_bmanagement\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\nBridge=management\n\n[BridgeVLAN]\nVLAN=100\n\n[BridgeVLAN]\nVLAN=1234\n", cfgs[10].Contents)
-	require.Equal(t, "21-management.network", cfgs[11].Name)
-	require.Equal(t, "[Match]\nName=management\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[11].Contents)
-	require.Equal(t, "21-_bmanagement-dev0.network", cfgs[12].Name)
-	require.Equal(t, "[Match]\nName=_paabbccddee03\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBond=_bmanagement\n", cfgs[12].Contents)
-	require.Equal(t, "21-_bmanagement-dev1.network", cfgs[13].Name)
-	require.Equal(t, "[Match]\nName=_paabbccddee04\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBond=_bmanagement\n", cfgs[13].Contents)
+	require.Equal(t, "[Match]\nName=san2\n\n[Link]\nMTUBytes=9009\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[7].Contents)
+	require.Equal(t, "21-_bmanagement-dev0.network", cfgs[8].Name)
+	require.Equal(t, "[Match]\nName=_paabbccddee03\n\n[Link]\nMTUBytes=9009\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBond=_bmanagement\n", cfgs[8].Contents)
+	require.Equal(t, "21-_bmanagement-dev1.network", cfgs[9].Name)
+	require.Equal(t, "[Match]\nName=_paabbccddee04\n\n[Link]\nMTUBytes=9009\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBond=_bmanagement\n", cfgs[9].Contents)
+	require.Equal(t, "21-_vmanagement.network", cfgs[10].Name)
+	require.Equal(t, "[Match]\nName=_vmanagement\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=any\nMTUBytes=8750\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nVLAN=uplink\nLinkLocalAddressing=ipv6\nAddress=10.0.100.10/24\nAddress=fd40:1234:1234:100::10/64\nIPv6AcceptRA=false\n\n[Route]\nGateway=10.0.100.1\nDestination=0.0.0.0/0\n\n[Route]\nGateway=fd40:1234:1234:100::1\nDestination=::/0\n", cfgs[10].Contents)
+	require.Equal(t, "21-_iaabbccddee03.network", cfgs[11].Name)
+	require.Equal(t, "[Match]\nName=_iaabbccddee03\n\n[Link]\nMTUBytes=9000\n\n[Network]\nBridge=management\n\n[BridgeVLAN]\nVLAN=100\n\n[BridgeVLAN]\nVLAN=1234\n", cfgs[11].Contents)
+	require.Equal(t, "21-_bmanagement.network", cfgs[12].Name)
+	require.Equal(t, "[Match]\nName=_bmanagement\n\n[Link]\nMTUBytes=9000\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\nBridge=management\n\n[BridgeVLAN]\nVLAN=100\n\n[BridgeVLAN]\nVLAN=1234\n", cfgs[12].Contents)
+	require.Equal(t, "21-management.network", cfgs[13].Name)
+	require.Equal(t, "[Match]\nName=management\n\n[Link]\nMTUBytes=9000\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[13].Contents)
 	require.Equal(t, "22-uplink.network", cfgs[14].Name)
-	require.Equal(t, "[Match]\nName=uplink\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=ipv4\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=false\nDHCP=ipv4\n\n[Route]\nGateway=_dhcp4\nDestination=0.0.0.0/0\n", cfgs[14].Contents)
+	require.Equal(t, "[Match]\nName=uplink\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=ipv4\nMTUBytes=1500\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=false\nDHCP=ipv4\n\n[Route]\nGateway=_dhcp4\nDestination=0.0.0.0/0\n", cfgs[14].Contents)
 	require.Equal(t, "23-wg0.network", cfgs[15].Name)
-	require.Equal(t, "[Match]\nName=wg0\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.9.0.7/24\nAddress=fd25:6c9a:6c19::7/64\nIPv6AcceptRA=false\n\n[Route]\nGateway=10.9.0.3\nDestination=192.168.2.0/24\n", cfgs[15].Contents)
+	require.Equal(t, "[Match]\nName=wg0\n\n[Link]\nMTUBytes=1500\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.9.0.7/24\nAddress=fd25:6c9a:6c19::7/64\nIPv6AcceptRA=false\n\n[Route]\nGateway=10.9.0.3\nDestination=192.168.2.0/24\n", cfgs[15].Contents)
 
 	// Test second config .network file generation.
 	networkCfg = api.SystemNetworkConfig{}
 	err = yaml.Load([]byte(networkdConfig2), &networkCfg)
 	require.NoError(t, err)
 
-	cfgs = generateNetworkFileContents(networkCfg)
+	cfgs, err = generateNetworkFileContents(context.TODO(), networkCfg)
+	require.NoError(t, err)
 	require.Len(t, cfgs, 5)
 	require.Equal(t, "20-_vmanagement.network", cfgs[0].Name)
-	require.Equal(t, "[Match]\nName=_vmanagement\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=ipv6\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=true\nDHCP=ipv4\n\n[Route]\nGateway=_dhcp4\nDestination=0.0.0.0/0\n\n[Route]\nGateway=_ipv6ra\nDestination=::/0\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nName=_vmanagement\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=ipv6\nMTUBytes=8500\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=true\nDHCP=ipv4\n\n[Route]\nGateway=_dhcp4\nDestination=0.0.0.0/0\n\n[Route]\nGateway=_ipv6ra\nDestination=::/0\n", cfgs[0].Contents)
 	require.Equal(t, "20-_iaabbccddee01.network", cfgs[1].Name)
-	require.Equal(t, "[Match]\nName=_iaabbccddee01\n\n[Network]\nBridge=management\n", cfgs[1].Contents)
+	require.Equal(t, "[Match]\nName=_iaabbccddee01\n\n[Link]\nMTUBytes=9009\n\n[Network]\nBridge=management\n", cfgs[1].Contents)
 	require.Equal(t, "20-_paabbccddee01.network", cfgs[2].Name)
-	require.Equal(t, "[Match]\nName=_paabbccddee01\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBridge=management\n[Link]\nMTUBytes=9000\n", cfgs[2].Contents)
+	require.Equal(t, "[Match]\nName=_paabbccddee01\n\n[Link]\nMTUBytes=9009\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBridge=management\n", cfgs[2].Contents)
 	require.Equal(t, "20-management.network", cfgs[3].Name)
-	require.Equal(t, "[Match]\nName=management\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n[Link]\nMTUBytes=9000\n", cfgs[3].Contents)
+	require.Equal(t, "[Match]\nName=management\n\n[Link]\nMTUBytes=9009\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[3].Contents)
 	require.Equal(t, "23-wg0.network", cfgs[4].Name)
-	require.Equal(t, "[Match]\nName=wg0\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.9.0.7/24\nAddress=fd25:6c9a:6c19::7/64\nIPv6AcceptRA=false\n", cfgs[4].Contents)
+	require.Equal(t, "[Match]\nName=wg0\n\n[Link]\nMTUBytes=1420\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.9.0.7/24\nAddress=fd25:6c9a:6c19::7/64\nIPv6AcceptRA=false\n", cfgs[4].Contents)
 
 	// Test third config .network file generation.
 	networkCfg = api.SystemNetworkConfig{}
@@ -775,36 +784,38 @@ func TestNetworkFileGeneration(t *testing.T) {
 	err = ValidateNetworkConfiguration(&networkCfg, true)
 	require.NoError(t, err)
 
-	cfgs = generateNetworkFileContents(networkCfg)
+	cfgs, err = generateNetworkFileContents(context.TODO(), networkCfg)
+	require.NoError(t, err)
 	require.Len(t, cfgs, 4)
 	require.Equal(t, "20-_vffeeddccbbaa.network", cfgs[0].Name)
-	require.Equal(t, "[Match]\nName=_vffeeddccbbaa\n\n[Link]\nRequiredForOnline=no\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nDomains=example.org\nDNS=ns1.example.org\nDNS=ns2.example.org\nDNSOverTLS=yes\nNTP=pool.ntp.example.org\nNTP=10.10.10.10\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=false\nDHCP=ipv4\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nName=_vffeeddccbbaa\n\n[Link]\nRequiredForOnline=no\nMTUBytes=1500\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nDomains=example.org\nDNS=ns1.example.org\nDNS=ns2.example.org\nDNSOverTLS=yes\nNTP=pool.ntp.example.org\nNTP=10.10.10.10\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=false\nDHCP=ipv4\n", cfgs[0].Contents)
 	require.Equal(t, "20-_iffeeddccbbaa.network", cfgs[1].Name)
-	require.Equal(t, "[Match]\nName=_iffeeddccbbaa\n\n[Network]\nBridge=ffeeddccbbaa\n", cfgs[1].Contents)
+	require.Equal(t, "[Match]\nName=_iffeeddccbbaa\n\n[Link]\nMTUBytes=9009\n\n[Network]\nBridge=ffeeddccbbaa\n", cfgs[1].Contents)
 	require.Equal(t, "20-_pffeeddccbbaa.network", cfgs[2].Name)
-	require.Equal(t, "[Match]\nName=_pffeeddccbbaa\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBridge=ffeeddccbbaa\n", cfgs[2].Contents)
+	require.Equal(t, "[Match]\nName=_pffeeddccbbaa\n\n[Link]\nMTUBytes=9009\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBridge=ffeeddccbbaa\n", cfgs[2].Contents)
 	require.Equal(t, "20-ffeeddccbbaa.network", cfgs[3].Name)
-	require.Equal(t, "[Match]\nName=ffeeddccbbaa\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[3].Contents)
+	require.Equal(t, "[Match]\nName=ffeeddccbbaa\n\n[Link]\nMTUBytes=9009\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[3].Contents)
 
 	// Test fourth config .network file generation.
 	networkCfg = api.SystemNetworkConfig{}
 	err = yaml.Load([]byte(networkdConfig4), &networkCfg)
 	require.NoError(t, err)
 
-	cfgs = generateNetworkFileContents(networkCfg)
+	cfgs, err = generateNetworkFileContents(context.TODO(), networkCfg)
+	require.NoError(t, err)
 	require.Len(t, cfgs, 7)
-	require.Equal(t, "21-_vuplink.network", cfgs[0].Name)
-	require.Equal(t, "[Match]\nName=_vuplink\n\n[Link]\nRequiredForOnline=no\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nVLAN=management\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\nIPv6AcceptRA=false\n", cfgs[0].Contents)
-	require.Equal(t, "21-_iaabbccddeee1.network", cfgs[1].Name)
-	require.Equal(t, "[Match]\nName=_iaabbccddeee1\n\n[Network]\nBridge=uplink\n\n[BridgeVLAN]\nVLAN=10\n", cfgs[1].Contents)
-	require.Equal(t, "21-_buplink.network", cfgs[2].Name)
-	require.Equal(t, "[Match]\nName=_buplink\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\nBridge=uplink\n\n[BridgeVLAN]\nVLAN=10\n", cfgs[2].Contents)
-	require.Equal(t, "21-uplink.network", cfgs[3].Name)
-	require.Equal(t, "[Match]\nName=uplink\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[3].Contents)
-	require.Equal(t, "21-_buplink-dev0.network", cfgs[4].Name)
-	require.Equal(t, "[Match]\nName=_paabbccddeee1\n\n[Network]\nLLDP=true\nEmitLLDP=true\nBond=_buplink\n", cfgs[4].Contents)
-	require.Equal(t, "21-_buplink-dev1.network", cfgs[5].Name)
-	require.Equal(t, "[Match]\nName=_paabbccddeee2\n\n[Network]\nLLDP=true\nEmitLLDP=true\nBond=_buplink\n", cfgs[5].Contents)
+	require.Equal(t, "21-_buplink-dev0.network", cfgs[0].Name)
+	require.Equal(t, "[Match]\nName=_paabbccddeee1\n\n[Link]\nMTUBytes=9009\n\n[Network]\nLLDP=true\nEmitLLDP=true\nBond=_buplink\n", cfgs[0].Contents)
+	require.Equal(t, "21-_buplink-dev1.network", cfgs[1].Name)
+	require.Equal(t, "[Match]\nName=_paabbccddeee2\n\n[Link]\nMTUBytes=9009\n\n[Network]\nLLDP=true\nEmitLLDP=true\nBond=_buplink\n", cfgs[1].Contents)
+	require.Equal(t, "21-_vuplink.network", cfgs[2].Name)
+	require.Equal(t, "[Match]\nName=_vuplink\n\n[Link]\nRequiredForOnline=no\nMTUBytes=8250\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nVLAN=management\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\nIPv6AcceptRA=false\n", cfgs[2].Contents)
+	require.Equal(t, "21-_iaabbccddeee1.network", cfgs[3].Name)
+	require.Equal(t, "[Match]\nName=_iaabbccddeee1\n\n[Link]\nMTUBytes=9000\n\n[Network]\nBridge=uplink\n\n[BridgeVLAN]\nVLAN=10\n", cfgs[3].Contents)
+	require.Equal(t, "21-_buplink.network", cfgs[4].Name)
+	require.Equal(t, "[Match]\nName=_buplink\n\n[Link]\nMTUBytes=9000\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\nBridge=uplink\n\n[BridgeVLAN]\nVLAN=10\n", cfgs[4].Contents)
+	require.Equal(t, "21-uplink.network", cfgs[5].Name)
+	require.Equal(t, "[Match]\nName=uplink\n\n[Link]\nMTUBytes=9000\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[5].Contents)
 	require.Equal(t, "22-management.network", cfgs[6].Name)
-	require.Equal(t, "[Match]\nName=management\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=both\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=true\nDHCP=ipv4\n", cfgs[6].Contents)
+	require.Equal(t, "[Match]\nName=management\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=both\nMTUBytes=1500\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=true\nDHCP=ipv4\n", cfgs[6].Contents)
 }


### PR DESCRIPTION
Get the maximum supported MTU for physical devices, and use that to set the max MTU, capped at 9000. Apply the configured MTU, if present, on the veth/vlan/wireguard interface, defaulting to 1500.

Closes #1228