### PR TITLE
Network fixes

### DIFF
--- a/incus-osd/internal/systemd/networkd.go
+++ b/incus-osd/internal/systemd/networkd.go
@@ -1411,9 +1411,13 @@ Name=_i%s
 		if b.Mode != "" {
 			_, _ = sbMode.WriteString("Mode=" + b.Mode)
 
-			if b.Mode == "802.3ad" {
+			switch b.Mode {
+			case "802.3ad":
 				_, _ = sbMode.WriteString("\nTransmitHashPolicy=layer3+4")
 				_, _ = sbMode.WriteString("\nLACPTransmitRate=fast")
+			case "active-backup":
+				_, _ = sbMode.WriteString("\nMIIMonitorSec=100ms")
+			default:
 			}
 		}
 

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_network.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_network.py
@@ -91,7 +91,7 @@ def TestIncusOSAPISystemNetworkBadMAC(install_image):
         vm.WaitExpectedLog("incus-osd", "Auto-generating encryption recovery key, this may take a few seconds")
         vm.WaitExpectedLog("incus-osd", "Upgrading LUKS TPM PCR bindings, this may take a few seconds")
         vm.WaitExpectedLog("incus-osd", "Bringing up the network")
-        vm.WaitExpectedLog("incus-osd", "timed out waiting for configured network interfaces, missing interface(s): eth0 (00:11:22:33:44:55), eth1 (ff:ee:dd:cc:bb:aa)")
+        vm.WaitExpectedLog("incus-osd", "unable to determine maximum MTU for 00:11:22:33:44:55")
 
         # We shouldn't see anything about the system being ready.
         vm.LogDoesntContain("incus-osd", "System is ready version="+os_version)


### PR DESCRIPTION
* incus-osd/systemd/network: Enable MII link monitoring for active-backup bonds
* incus-osd/tests: Fix bad MAC expected log output