### PR TITLE
Refactor network config file generation

### DIFF
--- a/incus-osd/cmd/flasher-tool/main.go
+++ b/incus-osd/cmd/flasher-tool/main.go
@@ -22,10 +22,10 @@ import (
 	"go.yaml.in/yaml/v4"
 
 	apiseed "github.com/lxc/incus-os/incus-osd/api/seed"
+	"github.com/lxc/incus-os/incus-osd/internal/network"
 	"github.com/lxc/incus-os/incus-osd/internal/providers"
 	"github.com/lxc/incus-os/incus-osd/internal/seed"
 	"github.com/lxc/incus-os/incus-osd/internal/state"
-	"github.com/lxc/incus-os/incus-osd/internal/systemd"
 )
 
 var version = "dev"
@@ -439,7 +439,7 @@ func configureNetworkSeed(ctx context.Context) error {
 		return nil
 	}
 
-	err = systemd.ValidateNetworkConfiguration(&newSeed.SystemNetworkConfig, false)
+	err = network.ValidateNetworkConfiguration(&newSeed.SystemNetworkConfig, false)
 	if err != nil {
 		slog.ErrorContext(ctx, err.Error())
 

--- a/incus-osd/cmd/incus-osd/main.go
+++ b/incus-osd/cmd/incus-osd/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/lxc/incus-os/incus-osd/internal/install"
 	"github.com/lxc/incus-os/incus-osd/internal/kernel"
 	"github.com/lxc/incus-os/incus-osd/internal/keyring"
+	"github.com/lxc/incus-os/incus-osd/internal/network"
 	"github.com/lxc/incus-os/incus-osd/internal/nftables"
 	"github.com/lxc/incus-os/incus-osd/internal/providers"
 	"github.com/lxc/incus-os/incus-osd/internal/recovery"
@@ -719,7 +720,7 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 		return err
 	}
 
-	err = systemd.ApplyNetworkConfiguration(ctx, s, s.System.Network.Config, 30*time.Second, s.OS.SuccessfulBoot, providers.Notify, delayInitialUpdateCheck)
+	err = network.ApplyNetworkConfiguration(ctx, s, s.System.Network.Config, 30*time.Second, s.OS.SuccessfulBoot, providers.Notify, delayInitialUpdateCheck)
 	if err != nil {
 		return err
 	}
@@ -883,7 +884,7 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 		case <-s.TriggerSuspend:
 			action = "suspend"
 
-			systemd.RestoreWOLMACAddresses(ctx, s)
+			network.RestoreWOLMACAddresses(ctx, s)
 			_ = systemd.SystemSuspend(ctx)
 
 			goto waitSignal
@@ -907,7 +908,7 @@ func startup(ctx context.Context, s *state.State) error { //nolint:revive
 
 		switch action {
 		case "shutdown":
-			systemd.RestoreWOLMACAddresses(ctx, s)
+			network.RestoreWOLMACAddresses(ctx, s)
 			_ = systemd.SystemPowerOff(ctx)
 		case "reboot":
 			_ = systemd.SystemReboot(ctx)

--- a/incus-osd/internal/network/doc.go
+++ b/incus-osd/internal/network/doc.go
@@ -1,0 +1,2 @@
+// Package network contains logic for configuring the system's network.
+package network

--- a/incus-osd/internal/network/network_templates.go
+++ b/incus-osd/internal/network/network_templates.go
@@ -1,0 +1,41 @@
+package network
+
+import (
+	"github.com/lxc/incus-os/incus-osd/api"
+)
+
+type linkFileVariables struct {
+	Hwaddr    string
+	RandomMAC bool
+	Name      string
+	MTU       int
+	Ethernet  *api.SystemNetworkEthernet
+}
+
+type netdevFileVariables struct {
+	Type           string
+	Name           string
+	Hwaddr         string
+	StrippedHwaddr string
+	BondMode       string
+	VLANID         int
+	WGPrivateKey   string
+	WGPort         int
+	WGPeers        []api.SystemNetworkWireguardPeer
+}
+
+type networkFileVariables struct {
+	Type              string
+	Name              string
+	RequiredForOnline string
+	MTU               int
+	VLANs             []api.SystemNetworkVLAN
+	DNS               *api.SystemNetworkDNS
+	TimeConfig        *api.SystemNetworkTime
+	LLDP              string
+	Bond              string
+	Bridge            string
+	Addresses         []string
+	Routes            []api.SystemNetworkRoute
+	VLANTags          []int
+}

--- a/incus-osd/internal/network/networkd.go
+++ b/incus-osd/internal/network/networkd.go
@@ -3,6 +3,7 @@ package network
 import (
 	"bytes"
 	"context"
+	"embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"text/template"
 	"time"
 
 	ocapi "github.com/FuturFusion/operations-center/shared/api"
@@ -27,6 +29,9 @@ import (
 	"github.com/lxc/incus-os/incus-osd/internal/state"
 	"github.com/lxc/incus-os/incus-osd/internal/systemd"
 )
+
+//go:embed templates/*
+var templates embed.FS
 
 var muNetworkState sync.Mutex
 
@@ -1013,7 +1018,12 @@ func generateNetworkConfiguration(ctx context.Context, networkCfg *api.SystemNet
 	}
 
 	// Generate .netdev files.
-	for _, cfg := range generateNetdevFileContents(*networkCfg) {
+	cfgs, err = generateNetdevFileContents(*networkCfg)
+	if err != nil {
+		return err
+	}
+
+	for _, cfg := range cfgs {
 		err := os.WriteFile(filepath.Join(systemd.SystemdNetworkConfigPath, cfg.Name), []byte(cfg.Contents), 0o644)
 		if err != nil {
 			return err
@@ -1272,58 +1282,14 @@ func waitForSystemdTimesyncd(ctx context.Context, timeout time.Duration) error {
 // generateLinkFileContents generates the contents of systemd.link files. Returns an array of ConfigFile structs.
 // https://www.freedesktop.org/software/systemd/man/latest/systemd.link.html
 func generateLinkFileContents(ctx context.Context, networkCfg api.SystemNetworkConfig) ([]networkdConfigFile, error) {
+	t, err := template.ParseFS(templates, "templates/link.txt")
+	if err != nil {
+		return nil, err
+	}
+
 	ret := []networkdConfigFile{}
 
-	generateEthernet := func(s *api.SystemNetworkEthernet) string {
-		if s == nil {
-			return ""
-		}
-
-		segments := []string{}
-		if s.DisableGRO {
-			segments = append(segments, "GenericReceiveOffload=false", "GenericReceiveOffloadHardware=false")
-		}
-
-		if s.DisableGSO {
-			segments = append(segments, "GenericSegmentationOffload=false")
-		}
-
-		if s.DisableIPv4TSO {
-			segments = append(segments, "TCPSegmentationOffload=false")
-		}
-
-		if s.DisableIPv6TSO {
-			segments = append(segments, "TCP6SegmentationOffload=false")
-		}
-
-		if s.WakeOnLAN {
-			if len(s.WakeOnLANModes) > 0 {
-				for _, mode := range s.WakeOnLANModes {
-					segments = append(segments, "WakeOnLan="+mode)
-				}
-			} else {
-				segments = append(segments, "WakeOnLan=magic")
-			}
-
-			if slices.Contains(s.WakeOnLANModes, "secureon") {
-				segments = append(segments, "WakeOnLanPassword="+s.WakeOnLANPassword)
-			}
-		}
-
-		out := strings.Join(segments, "\n")
-
-		if s.DisableEnergyEfficient {
-			out += `
-[EnergyEfficientEthernet]
-Enable=false`
-		}
-
-		if out != "" {
-			out += "\n"
-		}
-
-		return out
-	}
+	var buf bytes.Buffer
 
 	for _, i := range networkCfg.Interfaces {
 		maxMTU, err := getMaxMTUForMAC(ctx, i.Hwaddr)
@@ -1332,17 +1298,23 @@ Enable=false`
 		}
 
 		strippedHwaddr := strings.ToLower(strings.ReplaceAll(i.Hwaddr, ":", ""))
-		ret = append(ret, networkdConfigFile{
-			Name: fmt.Sprintf("00-_p%s.link", strippedHwaddr),
-			Contents: fmt.Sprintf(`[Match]
-PermanentMACAddress=%s
 
-[Link]
-MACAddressPolicy=random
-NamePolicy=
-Name=_p%s
-MTUBytes=%d
-%s`, i.Hwaddr, strippedHwaddr, maxMTU, generateEthernet(i.Ethernet)),
+		buf.Reset()
+
+		err = t.Execute(&buf, linkFileVariables{
+			Hwaddr:    i.Hwaddr,
+			RandomMAC: true,
+			Name:      strippedHwaddr,
+			MTU:       maxMTU,
+			Ethernet:  i.Ethernet,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		ret = append(ret, networkdConfigFile{
+			Name:     fmt.Sprintf("00-_p%s.link", strippedHwaddr),
+			Contents: buf.String(),
 		})
 	}
 
@@ -1354,16 +1326,23 @@ MTUBytes=%d
 			}
 
 			strippedHwaddr := strings.ToLower(strings.ReplaceAll(member, ":", ""))
-			ret = append(ret, networkdConfigFile{
-				Name: fmt.Sprintf("01-_p%s.link", strippedHwaddr),
-				Contents: fmt.Sprintf(`[Match]
-PermanentMACAddress=%s
 
-[Link]
-NamePolicy=
-Name=_p%s
-MTUBytes=%d
-%s`, member, strippedHwaddr, maxMTU, generateEthernet(b.Ethernet)),
+			buf.Reset()
+
+			err = t.Execute(&buf, linkFileVariables{
+				Hwaddr:    member,
+				RandomMAC: false,
+				Name:      strippedHwaddr,
+				MTU:       maxMTU,
+				Ethernet:  b.Ethernet,
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			ret = append(ret, networkdConfigFile{
+				Name:     fmt.Sprintf("01-_p%s.link", strippedHwaddr),
+				Contents: buf.String(),
 			})
 		}
 	}
@@ -1373,169 +1352,177 @@ MTUBytes=%d
 
 // generateNetdevFileContents generates the contents of systemd.netdev files. Returns an array of networkdConfigFile structs.
 // https://www.freedesktop.org/software/systemd/man/latest/systemd.netdev.html
-func generateNetdevFileContents(networkCfg api.SystemNetworkConfig) []networkdConfigFile {
+func generateNetdevFileContents(networkCfg api.SystemNetworkConfig) ([]networkdConfigFile, error) {
+	t, err := template.ParseFS(templates, "templates/netdev.txt")
+	if err != nil {
+		return nil, err
+	}
+
 	ret := make([]networkdConfigFile, 0, 2*len(networkCfg.Interfaces)+3*len(networkCfg.Bonds)+len(networkCfg.Wireguard))
+
+	var buf bytes.Buffer
 
 	// Create bridge and veth devices for each interface.
 	for _, i := range networkCfg.Interfaces {
 		// Bridge.
-		ret = append(ret, networkdConfigFile{
-			Name: fmt.Sprintf("10-%s.netdev", i.Name),
-			Contents: fmt.Sprintf(`[NetDev]
-Name=%s
-Kind=bridge
+		buf.Reset()
 
-[Bridge]
-VLANFiltering=true
-`, i.Name),
+		err := t.Execute(&buf, netdevFileVariables{
+			Type: "bridge",
+			Name: i.Name,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		ret = append(ret, networkdConfigFile{
+			Name:     fmt.Sprintf("10-%s.netdev", i.Name),
+			Contents: buf.String(),
 		})
 
 		// veth.
-		strippedHwaddr := strings.ToLower(strings.ReplaceAll(i.Hwaddr, ":", ""))
-		ret = append(ret, networkdConfigFile{
-			Name: fmt.Sprintf("10-_v%s.netdev", i.Name),
-			Contents: fmt.Sprintf(`[NetDev]
-Name=_v%s
-Kind=veth
-MACAddress=%s
+		buf.Reset()
 
-[Peer]
-Name=_i%s
-`, i.Name, i.Hwaddr, strippedHwaddr),
+		err = t.Execute(&buf, netdevFileVariables{
+			Type:           "veth",
+			Name:           "_v" + i.Name,
+			Hwaddr:         i.Hwaddr,
+			StrippedHwaddr: strings.ToLower(strings.ReplaceAll(i.Hwaddr, ":", "")),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		ret = append(ret, networkdConfigFile{
+			Name:     fmt.Sprintf("10-_v%s.netdev", i.Name),
+			Contents: buf.String(),
 		})
 	}
 
 	// Create bond, bridge, and veth devices for each bond.
 	for _, b := range networkCfg.Bonds {
 		// Bond.
-		var sbMode strings.Builder
-		if b.Mode != "" {
-			_, _ = sbMode.WriteString("Mode=" + b.Mode)
+		buf.Reset()
 
-			switch b.Mode {
-			case "802.3ad":
-				_, _ = sbMode.WriteString("\nTransmitHashPolicy=layer3+4")
-				_, _ = sbMode.WriteString("\nLACPTransmitRate=fast")
-			case "active-backup":
-				_, _ = sbMode.WriteString("\nMIIMonitorSec=100ms")
-			default:
-			}
+		err := t.Execute(&buf, netdevFileVariables{
+			Type:     "bond",
+			Name:     "_b" + b.Name,
+			BondMode: b.Mode,
+		})
+		if err != nil {
+			return nil, err
 		}
 
 		ret = append(ret, networkdConfigFile{
-			Name: fmt.Sprintf("11-_b%s.netdev", b.Name),
-			Contents: fmt.Sprintf(`[NetDev]
-Name=_b%s
-Kind=bond
-
-[Bond]
-%s
-`, b.Name, sbMode.String()),
+			Name:     fmt.Sprintf("11-_b%s.netdev", b.Name),
+			Contents: buf.String(),
 		})
 
 		// Bridge.
-		ret = append(ret, networkdConfigFile{
-			Name: fmt.Sprintf("11-%s.netdev", b.Name),
-			Contents: fmt.Sprintf(`[NetDev]
-Name=%s
-Kind=bridge
+		buf.Reset()
 
-[Bridge]
-VLANFiltering=true
-`, b.Name),
+		err = t.Execute(&buf, netdevFileVariables{
+			Type: "bridge",
+			Name: b.Name,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		ret = append(ret, networkdConfigFile{
+			Name:     fmt.Sprintf("11-%s.netdev", b.Name),
+			Contents: buf.String(),
 		})
 
 		// veth.
+		buf.Reset()
+
 		bondMacAddr := b.Hwaddr
 		if bondMacAddr == "" {
 			bondMacAddr = b.Members[0]
 		}
 
-		strippedHwaddr := strings.ToLower(strings.ReplaceAll(bondMacAddr, ":", ""))
-		ret = append(ret, networkdConfigFile{
-			Name: fmt.Sprintf("11-_v%s.netdev", b.Name),
-			Contents: fmt.Sprintf(`[NetDev]
-Name=_v%s
-Kind=veth
-MACAddress=%s
+		err = t.Execute(&buf, netdevFileVariables{
+			Type:           "veth",
+			Name:           "_v" + b.Name,
+			Hwaddr:         bondMacAddr,
+			StrippedHwaddr: strings.ToLower(strings.ReplaceAll(bondMacAddr, ":", "")),
+		})
+		if err != nil {
+			return nil, err
+		}
 
-[Peer]
-Name=_i%s
-`, b.Name, bondMacAddr, strippedHwaddr),
+		ret = append(ret, networkdConfigFile{
+			Name:     fmt.Sprintf("11-_v%s.netdev", b.Name),
+			Contents: buf.String(),
 		})
 	}
 
 	// Create vlans.
 	for _, v := range networkCfg.VLANs {
-		ret = append(ret, networkdConfigFile{
-			Name: fmt.Sprintf("12-%s.netdev", v.Name),
-			Contents: fmt.Sprintf(`[NetDev]
-Name=%s
-Kind=vlan
+		buf.Reset()
 
-[VLAN]
-Id=%d
-`, v.Name, v.ID),
+		err := t.Execute(&buf, netdevFileVariables{
+			Type:   "vlan",
+			Name:   v.Name,
+			VLANID: v.ID,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		ret = append(ret, networkdConfigFile{
+			Name:     fmt.Sprintf("12-%s.netdev", v.Name),
+			Contents: buf.String(),
 		})
 	}
 
 	// Create wireguard.
 	for _, w := range networkCfg.Wireguard {
-		listenPort := ""
-		if w.Port != 0 {
-			listenPort = fmt.Sprintf("ListenPort=%d", w.Port)
-		}
+		buf.Reset()
 
-		var cfgBuffer strings.Builder
-
-		_, _ = fmt.Fprintf(&cfgBuffer, `[NetDev]
-Name=%s
-Kind=wireguard
-
-[WireGuard]
-PrivateKey=%s
-%s
-
-`, w.Name, w.PrivateKey, listenPort)
-
-		for _, peer := range w.Peers {
-			var options strings.Builder
-			for _, addr := range peer.AllowedIPs {
-				_, _ = fmt.Fprintf(&options, "AllowedIPs=%s\n", addr)
-			}
-
-			if peer.PresharedKey != "" {
-				_, _ = fmt.Fprintf(&options, "PresharedKey=%s\n", peer.PresharedKey)
-			}
-
-			if peer.Endpoint != "" {
-				_, _ = fmt.Fprintf(&options, "Endpoint=%s\n", peer.Endpoint)
-			}
-
-			if peer.PersistentKeepalive > 0 {
-				_, _ = fmt.Fprintf(&options, "PersistentKeepalive=%d\n", peer.PersistentKeepalive)
-			}
-
-			_, _ = fmt.Fprintf(&cfgBuffer, `[WireGuardPeer]
-PublicKey=%s
-%s
-
-`, peer.PublicKey, options.String())
+		err := t.Execute(&buf, netdevFileVariables{
+			Type:         "wireguard",
+			Name:         w.Name,
+			WGPrivateKey: w.PrivateKey,
+			WGPort:       w.Port,
+			WGPeers:      w.Peers,
+		})
+		if err != nil {
+			return nil, err
 		}
 
 		ret = append(ret, networkdConfigFile{
 			Name:     fmt.Sprintf("13-%s.netdev", w.Name),
-			Contents: cfgBuffer.String(),
+			Contents: buf.String(),
 		})
 	}
 
-	return ret
+	return ret, nil
 }
 
 // generateNetworkFileContents generates the contents of systemd.network files. Returns an array of networkdConfigFile structs.
 // https://www.freedesktop.org/software/systemd/man/latest/systemd.network.html
 func generateNetworkFileContents(ctx context.Context, networkCfg api.SystemNetworkConfig) ([]networkdConfigFile, error) { //nolint:revive
+	// Common template used by veth-user, vlan, and wireguard.
+	commonT, err := template.ParseFS(templates, "templates/network-common.txt")
+	if err != nil {
+		return nil, err
+	}
+
+	physicalT, err := template.ParseFS(templates, "templates/network-physical.txt")
+	if err != nil {
+		return nil, err
+	}
+
+	bondBridgeT, err := template.ParseFS(templates, "templates/network-bond-bridge.txt")
+	if err != nil {
+		return nil, err
+	}
+
 	ret := []networkdConfigFile{}
+
+	var buf bytes.Buffer
 
 	// Create networks for each interface and its bridge.
 	for _, i := range networkCfg.Interfaces {
@@ -1552,89 +1539,83 @@ func generateNetworkFileContents(ctx context.Context, networkCfg api.SystemNetwo
 		}
 
 		// User side of veth device.
-		cfgString := fmt.Sprintf(`[Match]
-Name=_v%s
+		buf.Reset()
 
-[Link]
-%s
-MTUBytes=%d
-
-[DHCP]
-ClientIdentifier=mac
-RouteMetric=100
-UseMTU=true
-
-[DHCPv6]
-WithoutRA=solicit
-
-[Network]
-%s`, i.Name, generateLinkSectionContents(i.Addresses, i.RequiredForOnline), configuredMTU, generateNetworkSectionContents(i.Name, networkCfg.VLANs, networkCfg.DNS, networkCfg.Time))
-
-		cfgString += processAddresses(i.Addresses)
-
-		if len(i.Routes) > 0 {
-			cfgString += processRoutes(i.Routes)
+		err = commonT.Execute(&buf, networkFileVariables{
+			Type:              "veth-user",
+			Name:              i.Name,
+			RequiredForOnline: i.RequiredForOnline,
+			MTU:               configuredMTU,
+			VLANs:             networkCfg.VLANs,
+			DNS:               networkCfg.DNS,
+			TimeConfig:        networkCfg.Time,
+			Addresses:         i.Addresses,
+			Routes:            i.Routes,
+		})
+		if err != nil {
+			return nil, err
 		}
 
 		ret = append(ret, networkdConfigFile{
 			Name:     fmt.Sprintf("20-_v%s.network", i.Name),
-			Contents: cfgString,
+			Contents: buf.String(),
 		})
 
 		// Bridge side of veth device.
+		buf.Reset()
+
 		strippedHwaddr := strings.ToLower(strings.ReplaceAll(i.Hwaddr, ":", ""))
-		cfgString = fmt.Sprintf(`[Match]
-Name=_i%s
 
-[Link]
-MTUBytes=%d
-
-[Network]
-Bridge=%s
-`, strippedHwaddr, maxMTU, i.Name)
-
-		cfgString += generateVLANContents(i.Name, i.VLANTags, networkCfg.VLANs)
+		err = bondBridgeT.Execute(&buf, networkFileVariables{
+			Type:     "veth-bridge",
+			Name:     strippedHwaddr,
+			MTU:      maxMTU,
+			Bridge:   i.Name,
+			VLANTags: getVLANTags(i.Name, i.VLANTags, networkCfg.VLANs),
+		})
+		if err != nil {
+			return nil, err
+		}
 
 		ret = append(ret, networkdConfigFile{
 			Name:     fmt.Sprintf("20-_i%s.network", strippedHwaddr),
-			Contents: cfgString,
+			Contents: buf.String(),
 		})
 
 		// Add underlying interface to bridge.
-		cfgString = fmt.Sprintf(`[Match]
-Name=_p%s
+		buf.Reset()
 
-[Link]
-MTUBytes=%d
-
-[Network]
-LLDP=%s
-EmitLLDP=%s
-Bridge=%s
-`, strippedHwaddr, maxMTU, strconv.FormatBool(i.LLDP), strconv.FormatBool(i.LLDP), i.Name)
-
-		cfgString += generateVLANContents(i.Name, i.VLANTags, networkCfg.VLANs)
+		err = physicalT.Execute(&buf, networkFileVariables{
+			Name:     strippedHwaddr,
+			MTU:      maxMTU,
+			Bridge:   i.Name,
+			LLDP:     strconv.FormatBool(i.LLDP),
+			VLANTags: getVLANTags(i.Name, i.VLANTags, networkCfg.VLANs),
+		})
+		if err != nil {
+			return nil, err
+		}
 
 		ret = append(ret, networkdConfigFile{
 			Name:     fmt.Sprintf("20-_p%s.network", strippedHwaddr),
-			Contents: cfgString,
+			Contents: buf.String(),
 		})
 
 		// Bridge.
-		cfgString = fmt.Sprintf(`[Match]
-Name=%s
+		buf.Reset()
 
-[Link]
-MTUBytes=%d
-
-[Network]
-LinkLocalAddressing=no
-ConfigureWithoutCarrier=yes
-`, i.Name, maxMTU)
+		err = bondBridgeT.Execute(&buf, networkFileVariables{
+			Type: "bridge",
+			Name: i.Name,
+			MTU:  maxMTU,
+		})
+		if err != nil {
+			return nil, err
+		}
 
 		ret = append(ret, networkdConfigFile{
 			Name:     fmt.Sprintf("20-%s.network", i.Name),
-			Contents: cfgString,
+			Contents: buf.String(),
 		})
 	}
 
@@ -1657,19 +1638,21 @@ ConfigureWithoutCarrier=yes
 
 			memberStrippedHwaddr := strings.ToLower(strings.ReplaceAll(member, ":", ""))
 
+			buf.Reset()
+
+			err = physicalT.Execute(&buf, networkFileVariables{
+				Name: memberStrippedHwaddr,
+				MTU:  mtu,
+				Bond: b.Name,
+				LLDP: strconv.FormatBool(b.LLDP),
+			})
+			if err != nil {
+				return nil, err
+			}
+
 			ret = append(ret, networkdConfigFile{
-				Name: fmt.Sprintf("21-_b%s-dev%d.network", b.Name, index),
-				Contents: fmt.Sprintf(`[Match]
-Name=_p%s
-
-[Link]
-MTUBytes=%d
-
-[Network]
-LLDP=%s
-EmitLLDP=%s
-Bond=_b%s
-`, memberStrippedHwaddr, mtu, strconv.FormatBool(b.LLDP), strconv.FormatBool(b.LLDP), b.Name),
+				Name:     fmt.Sprintf("21-_b%s-dev%d.network", b.Name, index),
+				Contents: buf.String(),
 			})
 		}
 
@@ -1681,36 +1664,31 @@ Bond=_b%s
 		}
 
 		// User side of veth device.
-		cfgString := fmt.Sprintf(`[Match]
-Name=_v%s
+		buf.Reset()
 
-[Link]
-%s
-MTUBytes=%d
-
-[DHCP]
-ClientIdentifier=mac
-RouteMetric=100
-UseMTU=true
-
-[DHCPv6]
-WithoutRA=solicit
-
-[Network]
-%s`, b.Name, generateLinkSectionContents(b.Addresses, b.RequiredForOnline), configuredMTU, generateNetworkSectionContents(b.Name, networkCfg.VLANs, networkCfg.DNS, networkCfg.Time))
-
-		cfgString += processAddresses(b.Addresses)
-
-		if len(b.Routes) > 0 {
-			cfgString += processRoutes(b.Routes)
+		err := commonT.Execute(&buf, networkFileVariables{
+			Type:              "veth-user",
+			Name:              b.Name,
+			RequiredForOnline: b.RequiredForOnline,
+			MTU:               configuredMTU,
+			VLANs:             networkCfg.VLANs,
+			DNS:               networkCfg.DNS,
+			TimeConfig:        networkCfg.Time,
+			Addresses:         b.Addresses,
+			Routes:            b.Routes,
+		})
+		if err != nil {
+			return nil, err
 		}
 
 		ret = append(ret, networkdConfigFile{
 			Name:     fmt.Sprintf("21-_v%s.network", b.Name),
-			Contents: cfgString,
+			Contents: buf.String(),
 		})
 
 		// Bridge side of veth device.
+		buf.Reset()
+
 		bondMacAddr := b.Hwaddr
 		if bondMacAddr == "" {
 			bondMacAddr = b.Members[0]
@@ -1718,58 +1696,56 @@ WithoutRA=solicit
 
 		strippedHwaddr := strings.ToLower(strings.ReplaceAll(bondMacAddr, ":", ""))
 
-		cfgString = fmt.Sprintf(`[Match]
-Name=_i%s
-
-[Link]
-MTUBytes=%d
-
-[Network]
-Bridge=%s
-`, strippedHwaddr, maxMTU, b.Name)
-
-		cfgString += generateVLANContents(b.Name, b.VLANTags, networkCfg.VLANs)
+		err = bondBridgeT.Execute(&buf, networkFileVariables{
+			Type:     "veth-bridge",
+			Name:     strippedHwaddr,
+			MTU:      maxMTU,
+			Bridge:   b.Name,
+			VLANTags: getVLANTags(b.Name, b.VLANTags, networkCfg.VLANs),
+		})
+		if err != nil {
+			return nil, err
+		}
 
 		ret = append(ret, networkdConfigFile{
 			Name:     fmt.Sprintf("21-_i%s.network", strippedHwaddr),
-			Contents: cfgString,
+			Contents: buf.String(),
 		})
 
 		// Add bond to bridge.
-		cfgString = fmt.Sprintf(`[Match]
-Name=_b%s
+		buf.Reset()
 
-[Link]
-MTUBytes=%d
-
-[Network]
-LinkLocalAddressing=no
-ConfigureWithoutCarrier=yes
-Bridge=%s
-`, b.Name, maxMTU, b.Name)
-
-		cfgString += generateVLANContents(b.Name, b.VLANTags, networkCfg.VLANs)
+		err = bondBridgeT.Execute(&buf, networkFileVariables{
+			Type:     "bond",
+			Name:     b.Name,
+			MTU:      maxMTU,
+			Bridge:   b.Name,
+			VLANTags: getVLANTags(b.Name, b.VLANTags, networkCfg.VLANs),
+		})
+		if err != nil {
+			return nil, err
+		}
 
 		ret = append(ret, networkdConfigFile{
 			Name:     fmt.Sprintf("21-_b%s.network", b.Name),
-			Contents: cfgString,
+			Contents: buf.String(),
 		})
 
 		// Bridge.
-		cfgString = fmt.Sprintf(`[Match]
-Name=%s
+		buf.Reset()
 
-[Link]
-MTUBytes=%d
-
-[Network]
-LinkLocalAddressing=no
-ConfigureWithoutCarrier=yes
-`, b.Name, maxMTU)
+		err = bondBridgeT.Execute(&buf, networkFileVariables{
+			Type: "bridge",
+			Name: b.Name,
+			MTU:  maxMTU,
+		})
+		if err != nil {
+			return nil, err
+		}
 
 		ret = append(ret, networkdConfigFile{
 			Name:     fmt.Sprintf("21-%s.network", b.Name),
-			Contents: cfgString,
+			Contents: buf.String(),
 		})
 	}
 
@@ -1782,33 +1758,25 @@ ConfigureWithoutCarrier=yes
 			configuredMTU = 9000
 		}
 
-		cfgString := fmt.Sprintf(`[Match]
-Name=%s
+		buf.Reset()
 
-[Link]
-%s
-MTUBytes=%d
-
-[DHCP]
-ClientIdentifier=mac
-RouteMetric=100
-UseMTU=true
-
-[DHCPv6]
-WithoutRA=solicit
-
-[Network]
-%s`, v.Name, generateLinkSectionContents(v.Addresses, v.RequiredForOnline), configuredMTU, generateNetworkSectionContents(v.Name, nil, networkCfg.DNS, networkCfg.Time))
-
-		cfgString += processAddresses(v.Addresses)
-
-		if len(v.Routes) > 0 {
-			cfgString += processRoutes(v.Routes)
+		err := commonT.Execute(&buf, networkFileVariables{
+			Type:              "vlan",
+			Name:              v.Name,
+			RequiredForOnline: v.RequiredForOnline,
+			MTU:               configuredMTU,
+			DNS:               networkCfg.DNS,
+			TimeConfig:        networkCfg.Time,
+			Addresses:         v.Addresses,
+			Routes:            v.Routes,
+		})
+		if err != nil {
+			return nil, err
 		}
 
 		ret = append(ret, networkdConfigFile{
 			Name:     fmt.Sprintf("22-%s.network", v.Name),
-			Contents: cfgString,
+			Contents: buf.String(),
 		})
 	}
 
@@ -1821,131 +1789,26 @@ WithoutRA=solicit
 			configuredMTU = 9000
 		}
 
-		cfgString := fmt.Sprintf(`[Match]
-Name=%s
+		buf.Reset()
 
-[Link]
-MTUBytes=%d
-
-[Network]
-`, wg.Name, configuredMTU)
-
-		cfgString += processAddresses(wg.Addresses)
-
-		if len(wg.Routes) > 0 {
-			cfgString += processRoutes(wg.Routes)
+		err := commonT.Execute(&buf, networkFileVariables{
+			Type:      "wireguard",
+			Name:      wg.Name,
+			MTU:       configuredMTU,
+			Addresses: wg.Addresses,
+			Routes:    wg.Routes,
+		})
+		if err != nil {
+			return nil, err
 		}
 
 		ret = append(ret, networkdConfigFile{
 			Name:     fmt.Sprintf("23-%s.network", wg.Name),
-			Contents: cfgString,
+			Contents: buf.String(),
 		})
 	}
 
 	return ret, nil
-}
-
-func processAddresses(addresses []string) string {
-	var ret strings.Builder
-
-	if len(addresses) != 0 {
-		_, _ = ret.WriteString("LinkLocalAddressing=ipv6\n")
-	} else {
-		_, _ = ret.WriteString("LinkLocalAddressing=no\n")
-		_, _ = ret.WriteString("ConfigureWithoutCarrier=yes\n")
-	}
-
-	hasDHCP4 := false
-	hasDHCP6 := false
-	acceptIPv6RA := false
-
-	for _, addr := range addresses {
-		switch addr {
-		case "dhcp4":
-			hasDHCP4 = true
-		case "dhcp6":
-			acceptIPv6RA = true
-			hasDHCP6 = true
-		case "slaac":
-			acceptIPv6RA = true
-
-		default:
-			_, _ = fmt.Fprintf(&ret, "Address=%s\n", addr)
-		}
-	}
-
-	if acceptIPv6RA {
-		_, _ = ret.WriteString("IPv6AcceptRA=true\n")
-	} else {
-		_, _ = ret.WriteString("IPv6AcceptRA=false\n")
-	}
-
-	if hasDHCP4 && hasDHCP6 { //nolint:gocritic
-		_, _ = ret.WriteString("DHCP=yes\n")
-	} else if hasDHCP4 {
-		_, _ = ret.WriteString("DHCP=ipv4\n")
-	} else if hasDHCP6 {
-		_, _ = ret.WriteString("DHCP=ipv6\n")
-	}
-
-	return ret.String()
-}
-
-func processRoutes(routes []api.SystemNetworkRoute) string {
-	var ret strings.Builder
-
-	for _, route := range routes {
-		_, _ = ret.WriteString("\n[Route]\n")
-
-		switch route.Via {
-		case "dhcp4":
-			_, _ = ret.WriteString("Gateway=_dhcp4\n")
-		case "slaac":
-			_, _ = ret.WriteString("Gateway=_ipv6ra\n")
-		default:
-			_, _ = fmt.Fprintf(&ret, "Gateway=%s\n", route.Via)
-		}
-
-		_, _ = fmt.Fprintf(&ret, "Destination=%s\n", route.To)
-	}
-
-	return ret.String()
-}
-
-func generateNetworkSectionContents(name string, vlans []api.SystemNetworkVLAN, dns *api.SystemNetworkDNS, timeCfg *api.SystemNetworkTime) string {
-	var ret strings.Builder
-
-	// Add any matching VLANs to the config.
-
-	for _, v := range vlans {
-		if v.Parent == name {
-			_, _ = fmt.Fprintf(&ret, "VLAN=%s\n", v.Name)
-		}
-	}
-
-	// If there are search domains or name servers or DNS over TLS defined, add those to the config.
-	if dns != nil {
-		if len(dns.SearchDomains) > 0 {
-			_, _ = fmt.Fprintf(&ret, "Domains=%s\n", strings.Join(dns.SearchDomains, " "))
-		}
-
-		for _, ns := range dns.Nameservers {
-			_, _ = fmt.Fprintf(&ret, "DNS=%s\n", ns)
-		}
-
-		if dns.DNSOverTLS {
-			_, _ = fmt.Fprint(&ret, "DNSOverTLS=yes\n")
-		}
-	}
-
-	// If there are time servers defined, add them to the config.
-	if timeCfg != nil {
-		for _, ts := range timeCfg.NTPServers {
-			_, _ = fmt.Fprintf(&ret, "NTP=%s\n", ts)
-		}
-	}
-
-	return ret.String()
 }
 
 func generateTimesyncContents(timeCfg api.SystemNetworkTime) string {
@@ -1956,7 +1819,7 @@ func generateTimesyncContents(timeCfg api.SystemNetworkTime) string {
 	return "[Time]\nFallbackNTP=" + strings.Join(timeCfg.NTPServers, " ") + "\n"
 }
 
-func generateVLANContents(devName string, additionalVLANTags []int, vlans []api.SystemNetworkVLAN) string {
+func getVLANTags(devName string, additionalVLANTags []int, vlans []api.SystemNetworkVLAN) []int {
 	vlanTags := []int{}
 
 	// Add any additional VLAN tags.
@@ -1973,30 +1836,8 @@ func generateVLANContents(devName string, additionalVLANTags []int, vlans []api.
 
 	// Sort and remove any duplicate tags.
 	slices.Sort(vlanTags)
-	vlanTags = slices.Compact(vlanTags)
 
-	var ret strings.Builder
-
-	if len(vlanTags) > 0 {
-		for _, tag := range vlanTags {
-			_, _ = ret.WriteString("\n[BridgeVLAN]\n")
-			_, _ = fmt.Fprintf(&ret, "VLAN=%d\n", tag)
-		}
-	}
-
-	return ret.String()
-}
-
-func generateLinkSectionContents(addresses []string, requiredForOnline string) string {
-	if len(addresses) == 0 || requiredForOnline == "no" {
-		return "RequiredForOnline=no"
-	}
-
-	if requiredForOnline == "" {
-		requiredForOnline = "any"
-	}
-
-	return "RequiredForOnline=yes\nRequiredFamilyForOnline=" + requiredForOnline
+	return slices.Compact(vlanTags)
 }
 
 func cleanupStaleDevices(ctx context.Context, oldCfg *api.SystemNetworkConfig, newCfg *api.SystemNetworkConfig) error {

--- a/incus-osd/internal/network/networkd.go
+++ b/incus-osd/internal/network/networkd.go
@@ -1,4 +1,4 @@
-package systemd
+package network
 
 import (
 	"bytes"
@@ -25,6 +25,7 @@ import (
 	"github.com/lxc/incus-os/incus-osd/internal/nftables"
 	"github.com/lxc/incus-os/incus-osd/internal/proxy"
 	"github.com/lxc/incus-os/incus-osd/internal/state"
+	"github.com/lxc/incus-os/incus-osd/internal/systemd"
 )
 
 var muNetworkState sync.Mutex
@@ -55,7 +56,7 @@ func ApplyNetworkConfiguration(ctx context.Context, s *state.State, networkCfg *
 	}()
 
 	// If a timezone is specified, apply it before doing any network configuration.
-	err := SetTimezone(ctx, networkCfg.Time)
+	err := systemd.SetTimezone(ctx, networkCfg.Time)
 	if err != nil {
 		return err
 	}
@@ -102,7 +103,7 @@ func ApplyNetworkConfiguration(ctx context.Context, s *state.State, networkCfg *
 	s.System.Network.Config = networkCfg
 
 	// Apply the configured hostname, or reset back to default if not set.
-	err = SetHostname(ctx, s.Hostname())
+	err = systemd.SetHostname(ctx, s.Hostname())
 	if err != nil {
 		return err
 	}
@@ -147,7 +148,7 @@ func ApplyNetworkConfiguration(ctx context.Context, s *state.State, networkCfg *
 	}
 
 	// Restart networking after new config files have been generated.
-	err = RestartUnit(ctx, "systemd-networkd")
+	err = systemd.RestartUnit(ctx, "systemd-networkd")
 	if err != nil {
 		return err
 	}
@@ -170,7 +171,7 @@ func ApplyNetworkConfiguration(ctx context.Context, s *state.State, networkCfg *
 
 	// (Re)start NTP time synchronization. Since we might be overriding the default fallback NTP servers,
 	// the service is disabled by default and only started once we have performed the network (re)configuration.
-	err = RestartUnit(ctx, "systemd-timesyncd")
+	err = systemd.RestartUnit(ctx, "systemd-timesyncd")
 	if err != nil {
 		return err
 	}
@@ -988,12 +989,12 @@ ff02::2 ip6-allrouters
 // new config files from the supplied NetworkConfig struct.
 func generateNetworkConfiguration(ctx context.Context, networkCfg *api.SystemNetworkConfig) error {
 	// Remove any existing configuration.
-	err := os.RemoveAll(SystemdNetworkConfigPath)
+	err := os.RemoveAll(systemd.SystemdNetworkConfigPath)
 	if err != nil {
 		return err
 	}
 
-	err = os.Mkdir(SystemdNetworkConfigPath, 0o755)
+	err = os.Mkdir(systemd.SystemdNetworkConfigPath, 0o755)
 	if err != nil {
 		return err
 	}
@@ -1005,7 +1006,7 @@ func generateNetworkConfiguration(ctx context.Context, networkCfg *api.SystemNet
 	}
 
 	for _, cfg := range cfgs {
-		err := os.WriteFile(filepath.Join(SystemdNetworkConfigPath, cfg.Name), []byte(cfg.Contents), 0o644)
+		err := os.WriteFile(filepath.Join(systemd.SystemdNetworkConfigPath, cfg.Name), []byte(cfg.Contents), 0o644)
 		if err != nil {
 			return err
 		}
@@ -1013,7 +1014,7 @@ func generateNetworkConfiguration(ctx context.Context, networkCfg *api.SystemNet
 
 	// Generate .netdev files.
 	for _, cfg := range generateNetdevFileContents(*networkCfg) {
-		err := os.WriteFile(filepath.Join(SystemdNetworkConfigPath, cfg.Name), []byte(cfg.Contents), 0o644)
+		err := os.WriteFile(filepath.Join(systemd.SystemdNetworkConfigPath, cfg.Name), []byte(cfg.Contents), 0o644)
 		if err != nil {
 			return err
 		}
@@ -1026,7 +1027,7 @@ func generateNetworkConfiguration(ctx context.Context, networkCfg *api.SystemNet
 	}
 
 	for _, cfg := range cfgs {
-		err := os.WriteFile(filepath.Join(SystemdNetworkConfigPath, cfg.Name), []byte(cfg.Contents), 0o644)
+		err := os.WriteFile(filepath.Join(systemd.SystemdNetworkConfigPath, cfg.Name), []byte(cfg.Contents), 0o644)
 		if err != nil {
 			return err
 		}
@@ -1038,7 +1039,7 @@ func generateNetworkConfiguration(ctx context.Context, networkCfg *api.SystemNet
 		ntpCfg = generateTimesyncContents(*networkCfg.Time)
 
 		if ntpCfg != "" {
-			err := os.WriteFile(SystemdTimesyncConfigFile, []byte(ntpCfg), 0o644)
+			err := os.WriteFile(systemd.SystemdTimesyncConfigFile, []byte(ntpCfg), 0o644)
 			if err != nil {
 				return err
 			}
@@ -1047,7 +1048,7 @@ func generateNetworkConfiguration(ctx context.Context, networkCfg *api.SystemNet
 
 	// If there's no NTP configuration, remove the old config file that might exist.
 	if networkCfg.Time == nil || ntpCfg == "" {
-		_ = os.Remove(SystemdTimesyncConfigFile)
+		_ = os.Remove(systemd.SystemdTimesyncConfigFile)
 	}
 
 	return nil
@@ -1258,7 +1259,7 @@ func waitForSystemdTimesyncd(ctx context.Context, timeout time.Duration) error {
 		if count == 5 {
 			count = 0
 
-			err = RestartUnit(ctx, "systemd-timesyncd")
+			err = systemd.RestartUnit(ctx, "systemd-timesyncd")
 			if err != nil {
 				return err
 			}

--- a/incus-osd/internal/network/networkd.go
+++ b/incus-osd/internal/network/networkd.go
@@ -1044,20 +1044,15 @@ func generateNetworkConfiguration(ctx context.Context, networkCfg *api.SystemNet
 	}
 
 	// Generate systemd-timesyncd configuration if any timeservers are defined.
-	ntpCfg := ""
-	if networkCfg.Time != nil {
-		ntpCfg = generateTimesyncContents(*networkCfg.Time)
+	if networkCfg.Time != nil && len(networkCfg.Time.NTPServers) > 0 {
+		ntpCfg := "[Time]\nFallbackNTP=" + strings.Join(networkCfg.Time.NTPServers, " ") + "\n"
 
-		if ntpCfg != "" {
-			err := os.WriteFile(systemd.SystemdTimesyncConfigFile, []byte(ntpCfg), 0o644)
-			if err != nil {
-				return err
-			}
+		err := os.WriteFile(systemd.SystemdTimesyncConfigFile, []byte(ntpCfg), 0o644)
+		if err != nil {
+			return err
 		}
-	}
-
-	// If there's no NTP configuration, remove the old config file that might exist.
-	if networkCfg.Time == nil || ntpCfg == "" {
+	} else {
+		// If there's no NTP configuration, remove any old config file that might exist.
 		_ = os.Remove(systemd.SystemdTimesyncConfigFile)
 	}
 
@@ -1809,14 +1804,6 @@ func generateNetworkFileContents(ctx context.Context, networkCfg api.SystemNetwo
 	}
 
 	return ret, nil
-}
-
-func generateTimesyncContents(timeCfg api.SystemNetworkTime) string {
-	if len(timeCfg.NTPServers) == 0 {
-		return ""
-	}
-
-	return "[Time]\nFallbackNTP=" + strings.Join(timeCfg.NTPServers, " ") + "\n"
 }
 
 func getVLANTags(devName string, additionalVLANTags []int, vlans []api.SystemNetworkVLAN) []int {

--- a/incus-osd/internal/network/networkd_test.go
+++ b/incus-osd/internal/network/networkd_test.go
@@ -614,11 +614,11 @@ func TestLinkFileGeneration(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, cfgs, 3)
 	require.Equal(t, "00-_paabbccddee01.link", cfgs[0].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:01\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=_paabbccddee01\nMTUBytes=9009\nGenericReceiveOffload=false\nGenericReceiveOffloadHardware=false\nGenericSegmentationOffload=false\nTCPSegmentationOffload=false\nTCP6SegmentationOffload=false\nWakeOnLan=magic\nWakeOnLan=secureon\nWakeOnLanPassword=11:22:33:44:55:66\n[EnergyEfficientEthernet]\nEnable=false\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:01\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=_paabbccddee01\nMTUBytes=9009\nGenericReceiveOffload=false\nGenericReceiveOffloadHardware=false\nGenericSegmentationOffload=false\nTCPSegmentationOffload=false\nTCP6SegmentationOffload=false\nWakeOnLan=magic\nWakeOnLan=secureon\nWakeOnLanPassword=11:22:33:44:55:66\n\n[EnergyEfficientEthernet]\nEnable=false\n", cfgs[0].Contents)
 	require.Equal(t, "01-_paabbccddee02.link", cfgs[1].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:02\n\n[Link]\nNamePolicy=\nName=_paabbccddee02\nMTUBytes=9009\nTCPSegmentationOffload=false\nTCP6SegmentationOffload=false\n[EnergyEfficientEthernet]\nEnable=false\n", cfgs[1].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:02\n\n[Link]\nNamePolicy=\nName=_paabbccddee02\nMTUBytes=9009\nTCPSegmentationOffload=false\nTCP6SegmentationOffload=false\n\n[EnergyEfficientEthernet]\nEnable=false\n", cfgs[1].Contents)
 	require.Equal(t, "01-_paabbccddee03.link", cfgs[2].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:03\n\n[Link]\nNamePolicy=\nName=_paabbccddee03\nMTUBytes=9009\nTCPSegmentationOffload=false\nTCP6SegmentationOffload=false\n[EnergyEfficientEthernet]\nEnable=false\n", cfgs[2].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:03\n\n[Link]\nNamePolicy=\nName=_paabbccddee03\nMTUBytes=9009\nTCPSegmentationOffload=false\nTCP6SegmentationOffload=false\n\n[EnergyEfficientEthernet]\nEnable=false\n", cfgs[2].Contents)
 
 	// Test sixth config .link file generation.
 	networkCfg = api.SystemNetworkConfig{}
@@ -629,7 +629,7 @@ func TestLinkFileGeneration(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, cfgs, 1)
 	require.Equal(t, "00-_paabbccddee01.link", cfgs[0].Name)
-	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:01\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=_paabbccddee01\nMTUBytes=9009\nGenericReceiveOffload=false\nGenericReceiveOffloadHardware=false\nTCPSegmentationOffload=false\nTCP6SegmentationOffload=false\nWakeOnLan=magic\nWakeOnLan=secureon\nWakeOnLanPassword=11:22:33:44:55:66\n[EnergyEfficientEthernet]\nEnable=false\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nPermanentMACAddress=AA:BB:CC:DD:EE:01\n\n[Link]\nMACAddressPolicy=random\nNamePolicy=\nName=_paabbccddee01\nMTUBytes=9009\nGenericReceiveOffload=false\nGenericReceiveOffloadHardware=false\nTCPSegmentationOffload=false\nTCP6SegmentationOffload=false\nWakeOnLan=magic\nWakeOnLan=secureon\nWakeOnLanPassword=11:22:33:44:55:66\n\n[EnergyEfficientEthernet]\nEnable=false\n", cfgs[0].Contents)
 }
 
 func TestNetdevFileGeneration(t *testing.T) {
@@ -641,7 +641,8 @@ func TestNetdevFileGeneration(t *testing.T) {
 	err := yaml.Load([]byte(networkdConfig1), &networkCfg)
 	require.NoError(t, err)
 
-	cfgs := generateNetdevFileContents(networkCfg)
+	cfgs, err := generateNetdevFileContents(networkCfg)
+	require.NoError(t, err)
 	require.Len(t, cfgs, 9)
 	require.Equal(t, "10-san1.netdev", cfgs[0].Name)
 	require.Equal(t, "[NetDev]\nName=san1\nKind=bridge\n\n[Bridge]\nVLANFiltering=true\n", cfgs[0].Contents)
@@ -660,21 +661,22 @@ func TestNetdevFileGeneration(t *testing.T) {
 	require.Equal(t, "12-uplink.netdev", cfgs[7].Name)
 	require.Equal(t, "[NetDev]\nName=uplink\nKind=vlan\n\n[VLAN]\nId=1234\n", cfgs[7].Contents)
 	require.Equal(t, "13-wg0.netdev", cfgs[8].Name)
-	require.Equal(t, "[NetDev]\nName=wg0\nKind=wireguard\n\n[WireGuard]\nPrivateKey=AE1SCwtkp8ruDYlUa9x9wsoTzEOePl3P9sMdFFa9PmI=\nListenPort=51820\n\n[WireGuardPeer]\nPublicKey=rJhRcAtHUldTAA/J+TPQPQpr6G9C2Arf5FiTVwjOYCE=\nAllowedIPs=10.9.0.1/32\nAllowedIPs=fd25:6c9a:6c19::1/128\nAllowedIPs=192.168.1.0/24\nEndpoint=10.102.89.87:51820\n\n\n[WireGuardPeer]\nPublicKey=qPYSgwaJe0VZb4M8smTPpd2rfKHz0X0ypq54ZY4ATVQ=\nAllowedIPs=10.9.0.3/32\nAllowedIPs=fd25:6c9a:6c19::3/128\nEndpoint=10.180.60.231:51820\n\n\n", cfgs[8].Contents)
+	require.Equal(t, "[NetDev]\nName=wg0\nKind=wireguard\n\n[WireGuard]\nPrivateKey=AE1SCwtkp8ruDYlUa9x9wsoTzEOePl3P9sMdFFa9PmI=\nListenPort=51820\n\n[WireGuardPeer]\nPublicKey=rJhRcAtHUldTAA/J+TPQPQpr6G9C2Arf5FiTVwjOYCE=\nAllowedIPs=10.9.0.1/32\nAllowedIPs=fd25:6c9a:6c19::1/128\nAllowedIPs=192.168.1.0/24\nEndpoint=10.102.89.87:51820\n\n[WireGuardPeer]\nPublicKey=qPYSgwaJe0VZb4M8smTPpd2rfKHz0X0ypq54ZY4ATVQ=\nAllowedIPs=10.9.0.3/32\nAllowedIPs=fd25:6c9a:6c19::3/128\nEndpoint=10.180.60.231:51820\n\n", cfgs[8].Contents)
 
 	// Test second config .netdev file generation.
 	networkCfg = api.SystemNetworkConfig{}
 	err = yaml.Load([]byte(networkdConfig2), &networkCfg)
 	require.NoError(t, err)
 
-	cfgs = generateNetdevFileContents(networkCfg)
+	cfgs, err = generateNetdevFileContents(networkCfg)
+	require.NoError(t, err)
 	require.Len(t, cfgs, 3)
 	require.Equal(t, "10-management.netdev", cfgs[0].Name)
 	require.Equal(t, "[NetDev]\nName=management\nKind=bridge\n\n[Bridge]\nVLANFiltering=true\n", cfgs[0].Contents)
 	require.Equal(t, "10-_vmanagement.netdev", cfgs[1].Name)
 	require.Equal(t, "[NetDev]\nName=_vmanagement\nKind=veth\nMACAddress=AA:BB:CC:DD:EE:01\n\n[Peer]\nName=_iaabbccddee01\n", cfgs[1].Contents)
 	require.Equal(t, "13-wg0.netdev", cfgs[2].Name)
-	require.Equal(t, "[NetDev]\nName=wg0\nKind=wireguard\n\n[WireGuard]\nPrivateKey=\n\n\n", cfgs[2].Contents)
+	require.Equal(t, "[NetDev]\nName=wg0\nKind=wireguard\n\n[WireGuard]\nPrivateKey=\n\n", cfgs[2].Contents)
 
 	// Test third config .netdev file generation.
 	networkCfg = api.SystemNetworkConfig{}
@@ -686,7 +688,8 @@ func TestNetdevFileGeneration(t *testing.T) {
 	err = ValidateNetworkConfiguration(&networkCfg, true)
 	require.NoError(t, err)
 
-	cfgs = generateNetdevFileContents(networkCfg)
+	cfgs, err = generateNetdevFileContents(networkCfg)
+	require.NoError(t, err)
 	require.Len(t, cfgs, 2)
 	require.Equal(t, "10-ffeeddccbbaa.netdev", cfgs[0].Name)
 	require.Equal(t, "[NetDev]\nName=ffeeddccbbaa\nKind=bridge\n\n[Bridge]\nVLANFiltering=true\n", cfgs[0].Contents)
@@ -698,7 +701,8 @@ func TestNetdevFileGeneration(t *testing.T) {
 	err = yaml.Load([]byte(networkdConfig4), &networkCfg)
 	require.NoError(t, err)
 
-	cfgs = generateNetdevFileContents(networkCfg)
+	cfgs, err = generateNetdevFileContents(networkCfg)
+	require.NoError(t, err)
 	require.Len(t, cfgs, 4)
 	require.Equal(t, "11-_buplink.netdev", cfgs[0].Name)
 	require.Equal(t, "[NetDev]\nName=_buplink\nKind=bond\n\n[Bond]\nMode=802.3ad\nTransmitHashPolicy=layer3+4\nLACPTransmitRate=fast\n", cfgs[0].Contents)
@@ -743,7 +747,7 @@ func TestNetworkFileGeneration(t *testing.T) {
 	require.Equal(t, "21-_bmanagement-dev1.network", cfgs[9].Name)
 	require.Equal(t, "[Match]\nName=_paabbccddee04\n\n[Link]\nMTUBytes=9009\n\n[Network]\nLLDP=false\nEmitLLDP=false\nBond=_bmanagement\n", cfgs[9].Contents)
 	require.Equal(t, "21-_vmanagement.network", cfgs[10].Name)
-	require.Equal(t, "[Match]\nName=_vmanagement\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=any\nMTUBytes=8750\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nVLAN=uplink\nLinkLocalAddressing=ipv6\nAddress=10.0.100.10/24\nAddress=fd40:1234:1234:100::10/64\nIPv6AcceptRA=false\n\n[Route]\nGateway=10.0.100.1\nDestination=0.0.0.0/0\n\n[Route]\nGateway=fd40:1234:1234:100::1\nDestination=::/0\n", cfgs[10].Contents)
+	require.Equal(t, "[Match]\nName=_vmanagement\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=any\nMTUBytes=8750\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nVLAN=uplink\nLinkLocalAddressing=ipv6\nAddress=10.0.100.10/24\nAddress=fd40:1234:1234:100::10/64\nIPv6AcceptRA=false\n[Route]\nGateway=10.0.100.1\nDestination=0.0.0.0/0\n\n[Route]\nGateway=fd40:1234:1234:100::1\nDestination=::/0\n\n", cfgs[10].Contents)
 	require.Equal(t, "21-_iaabbccddee03.network", cfgs[11].Name)
 	require.Equal(t, "[Match]\nName=_iaabbccddee03\n\n[Link]\nMTUBytes=9000\n\n[Network]\nBridge=management\n\n[BridgeVLAN]\nVLAN=100\n\n[BridgeVLAN]\nVLAN=1234\n", cfgs[11].Contents)
 	require.Equal(t, "21-_bmanagement.network", cfgs[12].Name)
@@ -751,9 +755,9 @@ func TestNetworkFileGeneration(t *testing.T) {
 	require.Equal(t, "21-management.network", cfgs[13].Name)
 	require.Equal(t, "[Match]\nName=management\n\n[Link]\nMTUBytes=9000\n\n[Network]\nLinkLocalAddressing=no\nConfigureWithoutCarrier=yes\n", cfgs[13].Contents)
 	require.Equal(t, "22-uplink.network", cfgs[14].Name)
-	require.Equal(t, "[Match]\nName=uplink\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=ipv4\nMTUBytes=1500\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=false\nDHCP=ipv4\n\n[Route]\nGateway=_dhcp4\nDestination=0.0.0.0/0\n", cfgs[14].Contents)
+	require.Equal(t, "[Match]\nName=uplink\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=ipv4\nMTUBytes=1500\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=false\nDHCP=ipv4\n[Route]\nGateway=_dhcp4\nDestination=0.0.0.0/0\n\n", cfgs[14].Contents)
 	require.Equal(t, "23-wg0.network", cfgs[15].Name)
-	require.Equal(t, "[Match]\nName=wg0\n\n[Link]\nMTUBytes=1500\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.9.0.7/24\nAddress=fd25:6c9a:6c19::7/64\nIPv6AcceptRA=false\n\n[Route]\nGateway=10.9.0.3\nDestination=192.168.2.0/24\n", cfgs[15].Contents)
+	require.Equal(t, "[Match]\nName=wg0\n\n[Link]\nMTUBytes=1500\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=10.9.0.7/24\nAddress=fd25:6c9a:6c19::7/64\nIPv6AcceptRA=false\n[Route]\nGateway=10.9.0.3\nDestination=192.168.2.0/24\n\n", cfgs[15].Contents)
 
 	// Test second config .network file generation.
 	networkCfg = api.SystemNetworkConfig{}
@@ -764,7 +768,7 @@ func TestNetworkFileGeneration(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, cfgs, 5)
 	require.Equal(t, "20-_vmanagement.network", cfgs[0].Name)
-	require.Equal(t, "[Match]\nName=_vmanagement\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=ipv6\nMTUBytes=8500\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=true\nDHCP=ipv4\n\n[Route]\nGateway=_dhcp4\nDestination=0.0.0.0/0\n\n[Route]\nGateway=_ipv6ra\nDestination=::/0\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nName=_vmanagement\n\n[Link]\nRequiredForOnline=yes\nRequiredFamilyForOnline=ipv6\nMTUBytes=8500\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=true\nDHCP=ipv4\n[Route]\nGateway=_dhcp4\nDestination=0.0.0.0/0\n\n[Route]\nGateway=_ipv6ra\nDestination=::/0\n\n", cfgs[0].Contents)
 	require.Equal(t, "20-_iaabbccddee01.network", cfgs[1].Name)
 	require.Equal(t, "[Match]\nName=_iaabbccddee01\n\n[Link]\nMTUBytes=9009\n\n[Network]\nBridge=management\n", cfgs[1].Contents)
 	require.Equal(t, "20-_paabbccddee01.network", cfgs[2].Name)
@@ -788,7 +792,7 @@ func TestNetworkFileGeneration(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, cfgs, 4)
 	require.Equal(t, "20-_vffeeddccbbaa.network", cfgs[0].Name)
-	require.Equal(t, "[Match]\nName=_vffeeddccbbaa\n\n[Link]\nRequiredForOnline=no\nMTUBytes=1500\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nDomains=example.org\nDNS=ns1.example.org\nDNS=ns2.example.org\nDNSOverTLS=yes\nNTP=pool.ntp.example.org\nNTP=10.10.10.10\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=false\nDHCP=ipv4\n", cfgs[0].Contents)
+	require.Equal(t, "[Match]\nName=_vffeeddccbbaa\n\n[Link]\nRequiredForOnline=no\nMTUBytes=1500\n\n[DHCP]\nClientIdentifier=mac\nRouteMetric=100\nUseMTU=true\n\n[DHCPv6]\nWithoutRA=solicit\n\n[Network]\nDomains=example.org \nDNS=ns1.example.org\nDNS=ns2.example.org\nDNSOverTLS=yes\nNTP=pool.ntp.example.org\nNTP=10.10.10.10\nLinkLocalAddressing=ipv6\nIPv6AcceptRA=false\nDHCP=ipv4\n", cfgs[0].Contents)
 	require.Equal(t, "20-_iffeeddccbbaa.network", cfgs[1].Name)
 	require.Equal(t, "[Match]\nName=_iffeeddccbbaa\n\n[Link]\nMTUBytes=9009\n\n[Network]\nBridge=ffeeddccbbaa\n", cfgs[1].Contents)
 	require.Equal(t, "20-_pffeeddccbbaa.network", cfgs[2].Name)

--- a/incus-osd/internal/network/networkd_test.go
+++ b/incus-osd/internal/network/networkd_test.go
@@ -1,4 +1,4 @@
-package systemd
+package network
 
 import (
 	"context"

--- a/incus-osd/internal/network/networkd_validate.go
+++ b/incus-osd/internal/network/networkd_validate.go
@@ -1,4 +1,4 @@
-package systemd
+package network
 
 import (
 	"encoding/base64"

--- a/incus-osd/internal/network/templates/link.txt
+++ b/incus-osd/internal/network/templates/link.txt
@@ -1,0 +1,43 @@
+[Match]
+PermanentMACAddress={{.Hwaddr}}
+
+[Link]
+{{- if .RandomMAC}}
+MACAddressPolicy=random{{- end}}
+NamePolicy=
+Name=_p{{.Name}}
+MTUBytes={{.MTU}}
+{{- if .Ethernet}}
+  {{- if .Ethernet.DisableGRO}}
+GenericReceiveOffload=false
+GenericReceiveOffloadHardware=false
+  {{- end}}
+  {{- if .Ethernet.DisableGSO}}
+GenericSegmentationOffload=false
+  {{- end}}
+  {{- if .Ethernet.DisableIPv4TSO}}
+TCPSegmentationOffload=false
+  {{- end}}
+  {{- if .Ethernet.DisableIPv6TSO}}
+TCP6SegmentationOffload=false
+  {{- end}}
+  {{- if .Ethernet.WakeOnLAN}}
+    {{- if gt (len .Ethernet.WakeOnLANModes) 0 }}
+      {{- range .Ethernet.WakeOnLANModes}}
+WakeOnLan={{.}}
+      {{- end}}
+    {{- else}}
+WakeOnLan=magic
+    {{- end}}
+    {{- range .Ethernet.WakeOnLANModes}}
+      {{- if eq . "secureon"}}
+WakeOnLanPassword={{$.Ethernet.WakeOnLANPassword}}
+      {{- end}}
+    {{- end}}
+  {{- end}}
+  {{- if .Ethernet.DisableEnergyEfficient}}
+
+[EnergyEfficientEthernet]
+Enable=false
+  {{- end}}
+{{- end}}

--- a/incus-osd/internal/network/templates/netdev.txt
+++ b/incus-osd/internal/network/templates/netdev.txt
@@ -1,0 +1,43 @@
+[NetDev]
+Name={{.Name}}
+Kind={{.Type}}
+{{- if .Hwaddr}}
+MACAddress={{.Hwaddr}}{{end}}
+
+{{if eq .Type "bridge"}}[Bridge]
+VLANFiltering=true
+{{- else if eq .Type "veth"}}[Peer]
+Name=_i{{.StrippedHwaddr}}
+{{- else if eq .Type "bond"}}[Bond]
+  {{- if .BondMode}}
+Mode={{.BondMode}}
+  {{- if eq .BondMode "802.3ad"}}
+TransmitHashPolicy=layer3+4
+LACPTransmitRate=fast
+  {{- else if eq .BondMode "active-backup"}}
+MIIMonitorSec=100ms
+  {{- end}}
+  {{- end}}
+{{- else if eq .Type "vlan"}}[VLAN]
+Id={{.VLANID}}
+{{- else if eq .Type "wireguard"}}[WireGuard]
+PrivateKey={{.WGPrivateKey}}
+  {{- if .WGPort}}
+ListenPort={{.WGPort}}{{end}}
+{{range .WGPeers}}
+[WireGuardPeer]
+PublicKey={{.PublicKey}}
+    {{- range .AllowedIPs}}
+AllowedIPs={{.}}
+    {{- end}}
+    {{- if .PresharedKey}}
+PresharedKey={{.PresharedKey}}
+    {{- end}}
+    {{- if .Endpoint}}
+Endpoint={{.Endpoint}}
+    {{- end}}
+    {{- if .PersistentKeepalive}}
+PersistentKeepalive={{.PersistentKeepalive}}
+    {{- end}}
+{{end}}
+{{- end}}

--- a/incus-osd/internal/network/templates/network-bond-bridge.txt
+++ b/incus-osd/internal/network/templates/network-bond-bridge.txt
@@ -1,0 +1,25 @@
+[Match]
+{{- if eq .Type "bond"}}
+Name=_b{{.Name}}
+{{- else if eq .Type "veth-bridge"}}
+Name=_i{{.Name}}
+{{- else}}
+Name={{.Name}}
+{{- end}}
+
+[Link]
+MTUBytes={{.MTU}}
+
+[Network]
+{{- if ne .Type "veth-bridge"}}
+LinkLocalAddressing=no
+ConfigureWithoutCarrier=yes
+{{- end}}
+{{- if ne .Type "bridge"}}
+Bridge={{.Bridge}}
+  {{- range .VLANTags}}
+
+[BridgeVLAN]
+VLAN={{.}}
+  {{- end}}
+{{- end}}

--- a/incus-osd/internal/network/templates/network-common.txt
+++ b/incus-osd/internal/network/templates/network-common.txt
@@ -1,0 +1,97 @@
+[Match]
+{{- if eq .Type "veth-user"}}
+Name=_v{{.Name}}
+{{- else}}
+Name={{.Name}}
+{{- end}}
+
+[Link]
+{{- if ne .Type "wireguard"}}
+  {{- if or (eq (len .Addresses) 0) (eq .RequiredForOnline "no") }}
+RequiredForOnline=no
+  {{- else}}
+    {{- $req := .RequiredForOnline}}
+    {{- if eq .RequiredForOnline ""}}
+      {{- $req = "any"}}
+    {{- end}}
+RequiredForOnline=yes
+RequiredFamilyForOnline={{$req}}
+  {{- end}}
+{{- end}}
+MTUBytes={{.MTU}}
+{{if ne .Type "wireguard"}}
+[DHCP]
+ClientIdentifier=mac
+RouteMetric=100
+UseMTU=true
+
+[DHCPv6]
+WithoutRA=solicit
+{{end}}
+[Network]
+{{- range .VLANs}}
+  {{- if eq .Parent $.Name}}
+VLAN={{.Name}}
+  {{- end}}
+{{- end}}
+{{- if .DNS}}
+  {{- if .DNS.SearchDomains}}
+Domains={{range .DNS.SearchDomains}}{{.}} {{end}}
+  {{- end}}
+  {{- range .DNS.Nameservers}}
+DNS={{.}}
+  {{- end}}
+  {{- if .DNS.DNSOverTLS}}
+DNSOverTLS=yes
+  {{- end}}
+{{- end}}
+{{- if .TimeConfig}}
+  {{- range .TimeConfig.NTPServers}}
+NTP={{.}}
+  {{- end}}
+{{- end}}
+{{- if eq (len .Addresses) 0}}
+LinkLocalAddressing=no
+ConfigureWithoutCarrier=yes
+{{- else}}
+LinkLocalAddressing=ipv6
+{{- end}}
+{{- $hasDHCP4 := false}}
+{{- $hasDHCP6 := false}}
+{{- $acceptIPv6RA := false}}
+{{- range .Addresses}}
+  {{- if eq . "dhcp4"}}
+    {{- $hasDHCP4 = true}}
+  {{- else if eq . "dhcp6"}}
+    {{- $hasDHCP6 = true}}
+    {{- $acceptIPv6RA = true}}
+  {{- else if eq . "slaac"}}
+    {{- $acceptIPv6RA = true}}
+  {{- else}}
+Address={{.}}
+  {{- end}}
+{{- end}}
+{{- if $acceptIPv6RA}}
+IPv6AcceptRA=true
+{{- else}}
+IPv6AcceptRA=false
+{{- end}}
+{{- if and $hasDHCP4 $hasDHCP6}}
+DHCP=yes
+{{- else if $hasDHCP4}}
+DHCP=ipv4
+{{- else if $hasDHCP6}}
+DHCP=ipv6
+{{- end}}
+
+{{- range .Routes}}
+[Route]
+{{- if eq .Via "dhcp4"}}
+Gateway=_dhcp4
+{{- else if eq .Via "slaac"}}
+Gateway=_ipv6ra
+{{- else}}
+Gateway={{.Via}}
+{{- end}}
+Destination={{.To}}
+{{end}}

--- a/incus-osd/internal/network/templates/network-physical.txt
+++ b/incus-osd/internal/network/templates/network-physical.txt
@@ -1,0 +1,20 @@
+[Match]
+Name=_p{{.Name}}
+
+[Link]
+MTUBytes={{.MTU}}
+
+[Network]
+LLDP={{.LLDP}}
+EmitLLDP={{.LLDP}}
+{{- if .Bond}}
+Bond=_b{{.Bond}}
+{{- end}}
+{{- if .Bridge}}
+Bridge={{.Bridge}}
+{{- end}}
+{{- range .VLANTags}}
+
+[BridgeVLAN]
+VLAN={{.}}
+{{- end}}

--- a/incus-osd/internal/rest/api_system_network.go
+++ b/incus-osd/internal/rest/api_system_network.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/lxc/incus-os/incus-osd/api"
+	"github.com/lxc/incus-os/incus-osd/internal/network"
 	"github.com/lxc/incus-os/incus-osd/internal/nftables"
 	"github.com/lxc/incus-os/incus-osd/internal/providers"
 	"github.com/lxc/incus-os/incus-osd/internal/rest/response"
@@ -81,7 +82,7 @@ func (s *Server) apiSystemNetwork(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		// Refresh network state; needed to get current LLDP info.
-		err := systemd.UpdateNetworkState(r.Context(), &s.state.System.Network)
+		err := network.UpdateNetworkState(r.Context(), &s.state.System.Network)
 		if err != nil {
 			_ = response.InternalError(err).Render(w)
 
@@ -230,7 +231,7 @@ func applyNetworkConfiguration(ctx context.Context, s *state.State, networkCfg *
 		return err
 	}
 
-	err = systemd.ApplyNetworkConfiguration(ctx, s, networkCfg, timeout, false, providers.Notify, false)
+	err = network.ApplyNetworkConfiguration(ctx, s, networkCfg, timeout, false, providers.Notify, false)
 	if err != nil {
 		return err
 	}

--- a/incus-osd/internal/tui/tui.go
+++ b/incus-osd/internal/tui/tui.go
@@ -18,8 +18,8 @@ import (
 	"github.com/rivo/tview"
 
 	"github.com/lxc/incus-os/incus-osd/internal/applications"
+	"github.com/lxc/incus-os/incus-osd/internal/network"
 	"github.com/lxc/incus-os/incus-osd/internal/state"
-	"github.com/lxc/incus-os/incus-osd/internal/systemd"
 )
 
 var (
@@ -375,7 +375,7 @@ func (t *TUI) getIPAddresses() []string {
 			return
 		}
 
-		addrs, err := systemd.GetIPAddresses(context.Background(), name)
+		addrs, err := network.GetIPAddresses(context.Background(), name)
 		if err == nil {
 			ret = append(ret, name+"("+strings.Join(addrs, ", ")+")")
 		}

--- a/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
+++ b/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
@@ -164,7 +164,7 @@ class IncusTestVM:
         else:
             if self.vm_ip is None:
                 result = subprocess.run(["incus", "list", self.vm_name, "--columns", "4", "--format", "csv"], capture_output=True, check=True)
-                match = re.search(r"(\d+\.\d+\.\d+\.\d+) \(_venp5s0\)", str(result.stdout))
+                match = re.search(r"(\d+\.\d+\.\d+\.\d+) \(_v(enp5s|bond)0\)", str(result.stdout))
                 if match is None:
                     raise IncusOSException("failed to get IP address for VM")
 

--- a/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
+++ b/incus-osd/tests/incusos_tests/incus_test_vm/__init__.py
@@ -210,13 +210,15 @@ class IncusTestVM:
         return subprocess.run(["incus", "exec", self.vm_name, "--", *cmd], capture_output=capture_output, check=check)
 
 class IncusTestNetwork:
-    def __init__(self):
+    def __init__(self, dns_mode="managed", mtu=1500):
         self.name = util._get_random_string()
+        self.dns_mode = dns_mode
+        self.mtu = mtu
 
     def __enter__(self):
         """Create a temporary Incus bridge network for testing purposes."""
 
-        subprocess.run(["incus", "network", "create", self.name, "--type=bridge"], capture_output=True, check=True)
+        subprocess.run(["incus", "network", "create", self.name, "--type=bridge", "dns.mode="+self.dns_mode, "bridge.mtu="+str(self.mtu)], capture_output=True, check=True)
 
         return self
 

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_network.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_network.py
@@ -327,3 +327,201 @@ def TestIncusOSAPISystemNetworkConfigInterfaces(install_image):
 
             if "instances" not in interfaces["vm"]["roles"] or len(interfaces["vm"]["roles"]) != 1:
                 raise IncusOSException("missing expected roles for vm interface: " + str(interfaces["vm"]["roles"]))
+
+def TestIncusOSAPISystemNetworkBond(install_image):
+    test_name = "incusos-api-system-network-bond"
+    test_seed = {
+        "install.json": "{}",
+        "network.json": """{"bonds":[{"addresses":["dhcp4","slaac"],"members":["enp5s0","enp6s0"],"mode":"active-backup","mtu":1450,"name":"bond0"}]}""",
+    }
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with IncusTestNetwork(dns_mode="none", mtu=9000) as bond_network:
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+            # Configure two NICs for creation of a bond
+            vm.AddDevice("eth0", "nic", "network="+bond_network.name)
+            vm.AddDevice("eth1", "nic", "network="+bond_network.name)
+
+            vm.WaitSystemReady(os_version)
+
+            # Allow the network state to settle
+            time.sleep(5)
+
+            # Get current network state
+            result = vm.APIRequest("/1.0/system/network")
+            if result["status_code"] != 200:
+                raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+            interfaces = result["metadata"]["state"]["interfaces"]
+
+            if len(interfaces) != 1 or "bond0" not in interfaces:
+                raise IncusOSException("expected bond bond0 to exist")
+
+            if interfaces["bond0"]["type"] != "bond":
+                raise IncusOSException("expected bond bond0 type to be a bond")
+
+            if len(interfaces["bond0"]["addresses"]) != 2:
+                raise IncusOSException("expected bond bond0 to have exactly two addresses")
+
+            if interfaces["bond0"]["mtu"] != 1450:
+                raise IncusOSException("expected bond bond0 MTU to be 1450")
+
+            if len(interfaces["bond0"]["members"]) != 2:
+                raise IncusOSException("expected bond bond0 to have exactly two members")
+
+            members = []
+            for name, member in interfaces["bond0"]["members"].items():
+                members.append(name)
+
+                if member["mtu"] != 9000:
+                    raise IncusOSException("expected bond member " + name + " to have a MTU of 9000")
+
+            # Perform an initial simple connectivity test
+            _checkNetworkConnectivity(vm)
+
+            # Disable the first bond member and ensure we still have connectivity
+            vm.RunCommand("networkctl", "down", members[0])
+            time.sleep(1)
+            _checkNetworkConnectivity(vm)
+
+            # Disable the second bond member and verify we don't have connectivity
+            vm.RunCommand("networkctl", "down", members[1])
+            time.sleep(1)
+            try:
+                _checkNetworkConnectivity(vm)
+            except:
+                # Except an exception to have been raised when curl fails
+                pass
+            else:
+                raise IncusOSException("unexpected network connectivity with both bond members disabled")
+
+            # Re-enable the first bond member and check that connectivity has returned
+            vm.RunCommand("networkctl", "up", members[0])
+            time.sleep(1)
+            _checkNetworkConnectivity(vm)
+
+def TestIncusOSAPISystemNetworkComplex(install_image):
+    test_name = "incusos-api-system-network-complex"
+    test_seed = {
+        "install.json": "{}",
+        "network.json": """{"interfaces":[{"addresses":["dhcp4","slaac"],"hwaddr":"enp5s0","mtu":1789,"name":"enp5s0","required_for_online":"both"}],"bonds":[{"addresses":["192.168.200.200/24"],"lldp":true,"members":["enp6s0","enp7s0"],"mode":"active-backup","mtu":9000,"name":"backbone","required_for_online":"no","roles":["management","instances"],"routes":[{"to":"0.0.0.0/0","via":"192.168.200.1"}],"vlan_tags":[101,102,105]},{"addresses":["dhcp4"],"lldp":true,"members":["enp8s0","enp9s0"],"mode":"active-backup","mtu":8500,"name":"dmz","required_for_online":"no","roles":["instances"]}],"vlans":[{"addresses":["192.168.100.100/24"],"id":110,"mtu":2345,"name":"internal","parent":"backbone","roles":["cluster"]}]}""",
+    }
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with IncusTestNetwork(dns_mode="none", mtu=9000) as bond_network1:
+        with IncusTestNetwork(dns_mode="none", mtu=9000) as bond_network2:
+            with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+                # Configure four NICs for creation of bonds
+                vm.AddDevice("eth1", "nic", "network="+bond_network1.name)
+                vm.AddDevice("eth2", "nic", "network="+bond_network1.name)
+                vm.AddDevice("eth3", "nic", "network="+bond_network2.name)
+                vm.AddDevice("eth4", "nic", "network="+bond_network2.name)
+
+                vm.WaitSystemReady(os_version)
+
+                # Allow the network state to settle
+                time.sleep(5)
+
+                # Perform an initial simple connectivity test
+                _checkNetworkConnectivity(vm)
+
+                # Get current network state
+                result = vm.APIRequest("/1.0/system/network")
+                if result["status_code"] != 200:
+                    raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+                interfaces = result["metadata"]["state"]["interfaces"]
+
+                # Check that all four reported interfaces are properly configured
+                if len(interfaces) != 4:
+                    raise IncusOSException("expected four interfaces to exist")
+
+                if "enp5s0" not in interfaces:
+                    raise IncusOSException("interface enp5s0 doesn't exist")
+
+                if len(interfaces["enp5s0"]["addresses"]) != 2:
+                    raise IncusOSException("expected interface enp5s0 to have two addresses")
+
+                if interfaces["enp5s0"]["type"] != "interface":
+                    raise IncusOSException("interface enp5s0 type isn't interface")
+
+                if interfaces["enp5s0"]["mtu"] != 1789:
+                    raise IncusOSException("interface enp5s0 MTU wasn't 1789")
+
+                if "internal" not in interfaces:
+                    raise IncusOSException("vlan internal doesn't exist")
+
+                if len(interfaces["internal"]["addresses"]) != 1:
+                    raise IncusOSException("expected vlan internal to have one address")
+
+                if interfaces["internal"]["addresses"][0] != "192.168.100.100":
+                    raise IncusOSException("vlan internal has incorrect address")
+
+                if interfaces["internal"]["type"] != "vlan":
+                    raise IncusOSException("vlan internal type isn't vlan")
+
+                if interfaces["internal"]["mtu"] != 2345:
+                    raise IncusOSException("vlan internal MTU wasn't 2345")
+
+                if len(interfaces["internal"]["roles"]) != 1:
+                    raise IncusOSException("expected vlan internal to have one role")
+
+                if interfaces["internal"]["roles"][0] != "cluster":
+                    raise IncusOSException("vlan internal has incorrect role")
+
+                if "backbone" not in interfaces:
+                    raise IncusOSException("bond backbone doesn't exist")
+
+                if len(interfaces["backbone"]["addresses"]) != 1:
+                    raise IncusOSException("expected bond backbone to have one address")
+
+                if interfaces["backbone"]["addresses"][0] != "192.168.200.200":
+                    raise IncusOSException("bond backbone has incorrect address")
+
+                if interfaces["backbone"]["type"] != "bond":
+                    raise IncusOSException("bond backbone type isn't bond")
+
+                if len(interfaces["backbone"]["members"]) != 2:
+                    raise IncusOSException("bond backbone doesn't have two members")
+
+                if interfaces["backbone"]["mtu"] != 9000:
+                    raise IncusOSException("bond backbone MTU wasn't 9000")
+
+                if len(interfaces["backbone"]["roles"]) != 2:
+                    raise IncusOSException("expected bond backbone to have two roles")
+
+                if "management" not in interfaces["backbone"]["roles"] or "instances" not in interfaces["backbone"]["roles"]:
+                    raise IncusOSException("bond backbone has incorrect roles")
+
+                if "dmz" not in interfaces:
+                    raise IncusOSException("bond dmz doesn't exist")
+
+                if len(interfaces["dmz"]["addresses"]) != 1:
+                    raise IncusOSException("expected bond dmz to have one address")
+
+                if interfaces["dmz"]["type"] != "bond":
+                    raise IncusOSException("bond dmz type isn't bond")
+
+                if len(interfaces["dmz"]["members"]) != 2:
+                    raise IncusOSException("bond dmz doesn't have two members")
+
+                if interfaces["dmz"]["mtu"] != 8500:
+                    raise IncusOSException("bond dmz MTU wasn't 8500")
+
+                if len(interfaces["dmz"]["roles"]) != 1:
+                    raise IncusOSException("expected bond dmz to have one role")
+
+                if interfaces["dmz"]["roles"][0] != "instances":
+                    raise IncusOSException("bond dmz has incorrect role")
+
+                # Check VLANs
+                output = vm.RunCommand("ip", "-d", "link", "show", "dev", "internal")
+                if "vlan protocol 802.1Q id 110 " not in output.stdout.decode("utf-8"):
+                    raise IncusOSException("VLAN 110 not present on interface internal")
+
+                for id in ["101", "102", "105", "110"]:
+                    output = vm.RunCommand("bridge", "vlan", "show", "dev", "_bbackbone", "vid", id)
+                    if "_bbackbone" not in output.stdout.decode("utf-8"):
+                        raise IncusOSException("VLAN " + id + " not present on bond backbone")


### PR DESCRIPTION
This moves us from our spaghettified string-builder approach of constructing the various systemd-networkd configuration files to using Go's text templating library.

Because this is essentially rewriting our network configuration generation logic, I'd like to wait to merge this until a fresh IncusOS release has been made. Then we can merge and push out a test build to verify there are no obvious regressions in our test environment before these changes are included in a stable release.

Closes #728 