### PR TITLE
Update for newer Go / golangci-lint

### DIFF
--- a/.github/workflows/certificate-e2e.yml
+++ b/.github/workflows/certificate-e2e.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: 1.26.x
 
       - name: Install dependencies
         env:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: 1.26.x
 
       - name: Install dependencies
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: 1.26.x
 
       - name: Fix repository permissions
         run: |
@@ -87,7 +87,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: 1.26.x
 
       - name: Install dependencies
         run: |

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ test-update-sb-keys:
 .PHONY: update-gomod
 update-gomod:
 	cd incus-osd && go get -t -v -u ./...
-	cd incus-osd && go mod tidy --go=1.26.7
+	cd incus-osd && go mod tidy --go=1.26.6
 	cd incus-osd && go get toolchain@none
 
 .PHONY: update-app-versions

--- a/incus-osd/.golangci.yml
+++ b/incus-osd/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - depguard
     - err113
     - exhaustruct
+    - exhaustruct_v5
     - funlen # handled by revive
     - gochecknoglobals
     - gocognit
@@ -71,6 +72,17 @@ linters:
         - name: function-result-limit
           arguments:
             - 8
+
+    staticcheck:
+      checks:
+        - all
+        - -SA4023 # Hangs and produces false positives as of staticcheck 2026.1 rc.
+        - -ST1000
+        - -ST1003
+        - -ST1016
+        - -ST1020
+        - -ST1021
+        - -ST1022
 
     tagliatelle:
       case:

--- a/incus-osd/go.mod
+++ b/incus-osd/go.mod
@@ -1,6 +1,6 @@
 module github.com/lxc/incus-os/incus-osd
 
-go 1.26.7
+go 1.26.6
 
 require (
 	github.com/FuturFusion/migration-manager v0.6.15
@@ -103,7 +103,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	go4.org/mem v0.0.0-20240501181205-ae6ca9944745 // indirect
 	golang.org/x/crypto v0.55.0 // indirect
-	golang.org/x/exp v0.0.0-20260813180055-c1d0aacb2297 // indirect
+	golang.org/x/exp v0.0.0-20260820122028-d6e0b57b1a69 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/term v0.45.0 // indirect

--- a/incus-osd/go.sum
+++ b/incus-osd/go.sum
@@ -275,8 +275,8 @@ golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
 golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
-golang.org/x/exp v0.0.0-20260813180055-c1d0aacb2297 h1:YXnL44eJ77R+ji4/ooy8UsXIhz+lbi2Qgdlc8iRN0gY=
-golang.org/x/exp v0.0.0-20260813180055-c1d0aacb2297/go.mod h1:Mkmymgv+uMpSQ/XxJ/7GpdrdYoqm3u72jEbpCLiJmNk=
+golang.org/x/exp v0.0.0-20260820122028-d6e0b57b1a69 h1:ZWbzF1An5vqXvvbp91IMvPTgvtwx8Vm6NXIXv45/ZUo=
+golang.org/x/exp v0.0.0-20260820122028-d6e0b57b1a69/go.mod h1:Mkmymgv+uMpSQ/XxJ/7GpdrdYoqm3u72jEbpCLiJmNk=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.39.0 h1:UF5zwQdCRRUpHfyPwr7d4UrGiVeldIsogtzWVnczL74=

--- a/incus-osd/internal/rest/api_root.go
+++ b/incus-osd/internal/rest/api_root.go
@@ -128,7 +128,7 @@ func (s *Server) apiRoot10(w http.ResponseWriter, r *http.Request) {
 		}
 
 		fields := strings.Fields(string(content))
-		uptimeStr := strings.Split(fields[0], ".")[0]
+		uptimeStr, _, _ := strings.Cut(fields[0], ".")
 
 		uptime, err := strconv.ParseInt(uptimeStr, 10, 64)
 		if err != nil {


### PR DESCRIPTION
OpenTofu currently fails to build on 1.27, so hold back to 1.26.x everywhere.

golangci-lint in an effort to support Go 1.27 has imported a broken RC of static-check which hangs on SA4023, so directly list the tests we want and exclude that one and those that are normally internally disabled by golangci-lint.

A new golangci-lint should come out today or tomorrow with a fix. Not sure about timeline on an update OpenTofu.