### PR TITLE
base: Ship Intel ice DDP firmware

### DIFF
--- a/app-build/applications.json
+++ b/app-build/applications.json
@@ -77,6 +77,10 @@
         "build_targets": [],
         "install_targets": [
             [
+                "intel/ice/ddp",
+                "usr/lib/firmware/intel/ice/"
+            ],
+            [
                 "qed",
                 "usr/lib/firmware/"
             ],
@@ -90,6 +94,7 @@
             ]
         ],
         "clean_targets": [
+            "usr/lib/firmware/intel/ice",
             "usr/lib/firmware/qed",
             "usr/lib/firmware/ql2*_fw.bin",
             "usr/lib/firmware/rtl_nic"

--- a/app-build/build-applications.py
+++ b/app-build/build-applications.py
@@ -208,6 +208,19 @@ def install(image, artifact):
         subprocess.run(["mkdir", "-p", os.path.join(base_path, target[1])], check=True)
         subprocess.run(["cp", "-r", *sources, os.path.join(base_path, target[1])], check=True)
 
+    if artifact.startswith("linux-firmware"):
+        with open(os.path.join(directory, "WHENCE"), "r") as f:
+            for line in f:
+                if not line.startswith("Link:"):
+                    continue
+
+                link, target = line.removeprefix("Link:").split("->", 1)
+                link_path = os.path.join(base_path, "usr/lib/firmware", link.strip())
+                if not os.path.exists(os.path.join(os.path.dirname(link_path), target.strip())):
+                    continue
+
+                subprocess.run(["ln", "-sf", target.strip(), link_path], check=True)
+
     # Conditionally install the Migration Manager worker image if performing an x86_64 build
     if artifact == "migration-manager" and ARCH == "amd64":
         subprocess.run(["mkdir", "-p", os.path.join(base_path, "usr/share/migration-manager/images/")], check=True)


### PR DESCRIPTION
The base image contains no firmware for Intel E800 series NICs, so the ice driver enters Safe Mode on every boot:

```
ice 0000:01:00.0: Direct firmware load for intel/ice/ddp/ice.pkg failed with error -2
ice 0000:01:00.0: The DDP package file was not found or could not be read. Entering Safe Mode
```

Install firmware-intel-misc from non-free-firmware (already an enabled repository component), which ships intel/ice/ddp/ice.pkg and the DDP variants.

Fixes #1305