### PR TITLE
Rework storage API

### DIFF
--- a/doc/reference/system/storage.md
+++ b/doc/reference/system/storage.md
@@ -12,11 +12,17 @@ It is also possible to add, remove, and replace devices from an existing storage
 
 Configuration fields are defined in the [`SystemStorageConfig` struct](https://github.com/lxc/incus-os/blob/main/incus-osd/api/system_storage.go).
 
-The following configuration options can be set:
+The following system-wide configuration options can be set:
 
 * `pools`: An array of zero or more user-defined storage pool definitions.
-* `scrub_schedule`: A cron expression with five fields defining when to perform an automatic scrub of all the storage pools. Defaults to 0 4 * * 0.
+* `scrub_schedule`: A cron expression with five fields defining when to perform an automatic scrub of all the storage pools. Defaults to `0 4 * * 0`.
+
+User-defined storage pools are defined in the [`SystemStoragePool` struct](https://github.com/lxc/incus-os/blob/main/incus-osd/api/system_storage.go), which has the following options:
+
+* `name`: The name of the storage pool.
+* `type`: The type of the storage pool, which must be one of `zfs-raid0`, `zfs-raid1`, `zfs-raid10`, `zfs-raidz1`, `zfs-raidz2`, or `zfs-raidz3`.
 * `allow_mixed_dev_sizes`: If true, allow creation of a storage pool with devices of different sizes. Note that in most cases this will result in a storage pool whose total available capacity will be constrained by the smallest device size.
+* `devices`, `cache`, `log,` and `special`: Used to assign various storage devices to the pool in different roles.
 
 ```{note}
 When specifying devices for a pool, order is important. IncusOS will always return a sorted list which it will use when comparing the list of devices it receives via the API to determine what device(s) to add, remove, or replace in the pool. Put another way, `"devices": ["/dev/sda", "/dev/sdb"]` != `"devices": ["/dev/sdb", "/dev/sda"]`.
@@ -28,7 +34,6 @@ Create a storage pool `mypool` as ZFS raidz1 with four devices, one cache device
 
 ```yaml
 config:
-  scrub_schedule: "0 0 * * 6"
   pools:
   - name: "mypool"
     type: "zfs-raidz1"
@@ -44,13 +49,13 @@ config:
 
     log:
     - "/dev/sdg"
+  scrub_schedule: "0 0 * * 6"
 ```
 
-Replace failed device `/dev/sdb` with `/dev/sdh`:
+Replace failed device `/dev/sdb` in the above example with `/dev/sdh`:
 
 ```yaml
 config:
-  scrub_schedule: "0 0 * * 6"
   pools:
   - name: "mypool"
     type: "zfs-raidz1"
@@ -66,13 +71,13 @@ config:
 
     log:
     - "/dev/sdg"
+  scrub_schedule: "0 0 * * 6"
 ```
 
 Create a storage pool `mypool` as ZFS raidz1 with three spinning devices, and a special vdev backed by three NVME devices also in a raidz1 configuration:
 
 ```yaml
 config:
-  scrub_schedule: "0 0 * * 6"
   pools:
   - name: "mypool"
     type: "zfs-raidz1"
@@ -89,6 +94,7 @@ config:
       - "/dev/nvme0n1"
       - "/dev/nvme1n1"
       - "/dev/nvme2n1"
+  scrub_schedule: "0 4 * * 0"
 ```
 
 Get the pool encryption keys for safe storage (base64 encoded):
@@ -109,13 +115,14 @@ It is possible to convert a singe device storage pool to a mirrored pool with tw
 Given an existing storage pool:
 
 ```yaml
-state:
+config:
   pools:
   - name: "mypool"
     type: "zfs-raid0"
 
     devices:
     - "/dev/sdb"
+  scrub_schedule: "0 4 * * 0"
 ```
 
 IncusOS can convert this to a mirrored storage pool using new device `/dev/sdc` with the following configuration. Note the change of pool type from `zfs-raid0` to `zfs-raid1`.
@@ -129,6 +136,7 @@ config:
     devices:
     - "/dev/sdb"
     - "/dev/sdc"
+  scrub_schedule: "0 4 * * 0"
 ```
 
 IncusOS does not support other forms of in-place storage pool conversions.
@@ -165,6 +173,8 @@ Wipe drive `scsi-0QEMU_QEMU_HARDDISK_incus_disk`, which must be specified by its
 ./incus admin os system storage wipe-drive -d '{"id":"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk"}'
 ```
 
+By default, wiping a drive will attempt to use `blkdiscard` to quickly wipe a drive. However, for drives that do not support this operation, or to explicitly zero the entire device, you can include the `"secure_wipe":true` parameter when issuing the wipe command. Be aware that for large, spinning disks this may take a significant amount of time to complete.
+
 ## Importing an existing pool
 
 When importing an existing encrypted storage pool, IncusOS needs to be informed of its encryption key before the data can be made available. Because there is no way to prompt for an encryption passphrase, only ZFS pools using a raw encryption key can be imported. Specify the raw base64 encoded encryption key when importing storage pool `mypool` by running
@@ -193,7 +203,7 @@ Each volume has its own:
 * Quota (in bytes, a zero value means unrestricted)
 * Use (`incus` or `linstor`)
 
-The list of volumes are visible directly in the storage state data.
+The list of volumes are visible directly in the storage configuration data.
 
 Creating and deleting volumes can be done through the command line with:
 

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1371,11 +1371,6 @@ definitions:
                     $ref: '#/definitions/SystemStorageDrive'
                 type: array
                 x-go-name: Drives
-            pools:
-                items:
-                    $ref: '#/definitions/SystemStoragePool'
-                type: array
-                x-go-name: Pools
             root_partition:
                 $ref: '#/definitions/SystemStorageRootPartition'
         title: SystemStorageState represents additional state for the system's local storage.

--- a/doc/tutorials/storage-expand-local-pool.md
+++ b/doc/tutorials/storage-expand-local-pool.md
@@ -25,50 +25,63 @@ For this tutorial, let's assume there are three drives, each 50GiB in size. Incu
 We can get the system's current storage state:
 
 ```
-gibmat@futurfusion:~$ incus admin os system storage show
+$ incus admin os system storage show
 WARNING: The IncusOS API and configuration is subject to change
 
-config: {}
+config:
+  pools:
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
+      encryption_key_status: available
+      managed: true
+      name: local
+      pool_allocated_space_in_bytes: 4.562944e+06
+      raw_pool_size_in_bytes: 1.7716740096e+10
+      state: ONLINE
+      type: zfs-raid0
+      usable_pool_size_in_bytes: 1.7716740096e+10
+      volumes:
+        - name: incus
+          quota_in_bytes: 0
+          usage_in_bytes: 2.965504e+06
+          use: incus
+  scrub_schedule: 0 4 * * 0
 state:
   drives:
-  - boot: false
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_disk1
-  - boot: false
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_disk2
-  - boot: true
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root
-    member_pool: local
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_root
-  pools:
-  - devices:
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
-    encryption_key_status: available
-    name: local
-    pool_allocated_space_in_bytes: 4.3008e+06
-    raw_pool_size_in_bytes: 1.7716740096e+10
-    state: ONLINE
-    type: zfs-raid0
-    usable_pool_size_in_bytes: 1.7716740096e+10
+    - boot: false
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_disk1
+    - boot: false
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_disk2
+    - boot: true
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root
+      member_pool: local
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_root
+  root_partition:
+    available_in_bytes: 2.5271922688e+10
+    size_in_bytes: 2.6225119232e+10
 ```
 
 ## RAID0
@@ -80,62 +93,76 @@ Let's add `/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1` to the "local" 
 ```
 config:
   pools:
-  - name: local
-    type: zfs-raid0
-    devices:
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
+      name: local
+      type: zfs-raid0
+  scrub_schedule: 0 4 * * 0
 ```
 
 After saving and exiting, IncusOS will apply the changes. We can see the updated storage configuration reflecting the expansion of the "local" storage pool:
 
 ```
-gibmat@futurfusion:~$ incus admin os system storage show
+$ incus admin os system storage show
 WARNING: The IncusOS API and configuration is subject to change
 
-config: {}
+config:
+  pools:
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
+      encryption_key_status: available
+      managed: true
+      name: local
+      pool_allocated_space_in_bytes: 4.882432e+06
+      raw_pool_size_in_bytes: 7.0866960384e+10
+      state: ONLINE
+      type: zfs-raid0
+      usable_pool_size_in_bytes: 7.0866960384e+10
+      volumes:
+        - name: incus
+          quota_in_bytes: 0
+          usage_in_bytes: 2.965504e+06
+          use: incus
+  scrub_schedule: 0 4 * * 0
 state:
   drives:
-  - boot: false
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
-    member_pool: local
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_disk1
-  - boot: false
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_disk2
-  - boot: true
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root
-    member_pool: local
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_root
-  pools:
-  - devices:
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
-    encryption_key_status: available
-    name: local
-    pool_allocated_space_in_bytes: 4.558848e+06
-    raw_pool_size_in_bytes: 7.0866960384e+10
-    state: ONLINE
-    type: zfs-raid0
-    usable_pool_size_in_bytes: 7.0866960384e+10
+    - boot: false
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
+      member_pool: local
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_disk1
+    - boot: false
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_disk2
+    - boot: true
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root
+      member_pool: local
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_root
+  root_partition:
+    available_in_bytes: 2.5271922688e+10
+    size_in_bytes: 2.6225119232e+10
 ```
 
 ## RAID1
@@ -147,11 +174,12 @@ Let's add `/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1` to the "local" 
 ```
 config:
   pools:
-  - name: local
-    type: zfs-raid1
-    devices:
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
+      name: local
+      type: zfs-raid1
+  scrub_schedule: 0 4 * * 0
 ```
 
 ```{note}
@@ -162,52 +190,71 @@ After saving and exiting, IncusOS will apply the changes. We can see the updated
 
 ```
 
-gibmat@futurfusion:~$ incus admin os system storage show
+$ incus admin os system storage show
 WARNING: The IncusOS API and configuration is subject to change
 
-config: {}
+config:
+  pools:
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1-part11
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
+      encryption_key_status: available
+      last_scrub:
+        end_time: "2026-08-27T19:45:13Z"
+        errors: 0
+        progress: 100.00%
+        start_time: "2026-08-27T19:45:13Z"
+        state: FINISHED
+      managed: true
+      name: local
+      pool_allocated_space_in_bytes: 4.58752e+06
+      raw_pool_size_in_bytes: 1.7716740096e+10
+      state: ONLINE
+      type: zfs-raid1
+      usable_pool_size_in_bytes: 1.7716740096e+10
+      volumes:
+        - name: incus
+          quota_in_bytes: 0
+          usage_in_bytes: 2.965504e+06
+          use: incus
+  scrub_schedule: 0 4 * * 0
 state:
   drives:
-  - boot: false
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
-    member_pool: local
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_disk1
-  - boot: false
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_disk2
-  - boot: true
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root
-    member_pool: local
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_root
-  pools:
-  - devices:
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1-part11
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
-    encryption_key_status: available
-    name: local
-    pool_allocated_space_in_bytes: 4.42368e+06
-    raw_pool_size_in_bytes: 1.7716740096e+10
-    state: ONLINE
-    type: zfs-raid1
-    usable_pool_size_in_bytes: 1.7716740096e+10
+    - boot: false
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
+      member_pool: local
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_disk1
+    - boot: false
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_disk2
+    - boot: true
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root
+      member_pool: local
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_root
+  root_partition:
+    available_in_bytes: 2.5271922688e+10
+    size_in_bytes: 2.6225119232e+10
 ```
 
 ### Recovering a failed non-system drive
@@ -219,62 +266,86 @@ Once again, run `incus admin os system storage edit` and replace `disk1` with `d
 ```
 config:
   pools:
-  - name: local
-    type: zfs-raid1
-    devices:
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
+      name: local
+      type: zfs-raid1
+  scrub_schedule: 0 4 * * 0
+```
+
+```{note}
+When specifying devices for a pool, order is important. IncusOS will always return a sorted list which it will use when comparing the list of devices it receives via the API to determine what device(s) to add, remove, or replace in the pool. Put another way, `"devices": ["/dev/sda", "/dev/sdb"]` != `"devices": ["/dev/sdb", "/dev/sda"]`.
 ```
 
 After saving and exiting, IncusOS will apply the changes. Depending on how much data is stored in the "local" pool, it might take some time for ZFS to finish the resilver. Eventually the process will complete, and the system's storage state will look like the following:
 
 ```
-gibmat@futurfusion:~$ incus admin os system storage show
+$ incus admin os system storage show
 WARNING: The IncusOS API and configuration is subject to change
 
-config: {}
+config:
+  pools:
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2-part11
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
+      encryption_key_status: available
+      last_scrub:
+        end_time: "2026-08-27T19:47:36Z"
+        errors: 0
+        progress: 100.00%
+        start_time: "2026-08-27T19:47:36Z"
+        state: FINISHED
+      managed: true
+      name: local
+      pool_allocated_space_in_bytes: 4.734976e+06
+      raw_pool_size_in_bytes: 1.7716740096e+10
+      state: ONLINE
+      type: zfs-raid1
+      usable_pool_size_in_bytes: 1.7716740096e+10
+      volumes:
+        - name: incus
+          quota_in_bytes: 0
+          usage_in_bytes: 2.965504e+06
+          use: incus
+  scrub_schedule: 0 4 * * 0
 state:
   drives:
-  - boot: false
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_disk1
-  - boot: false
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
-    member_pool: local
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_disk2
-  - boot: true
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root
-    member_pool: local
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_root
-  pools:
-  - devices:
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2-part11
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
-    encryption_key_status: available
-    name: local
-    pool_allocated_space_in_bytes: 4.460544e+06
-    raw_pool_size_in_bytes: 1.7716740096e+10
-    state: ONLINE
-    type: zfs-raid1
-    usable_pool_size_in_bytes: 1.7716740096e+10
+    - boot: false
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_disk1
+    - boot: false
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
+      member_pool: local
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_disk2
+    - boot: true
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root
+      member_pool: local
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_root
+  root_partition:
+    available_in_bytes: 2.5271922688e+10
+    size_in_bytes: 2.6225119232e+10
 ```
 
 ### Recovering a failed system drive
@@ -282,9 +353,10 @@ state:
 If the main system drive fails, it is possible to recover the data from the "local" storage pool. After reinstalling IncusOS on a new drive, if the second drive is physically present on first boot IncusOS will attempt to recover the "local" storage pool:
 
 ```
-2025-11-18 18:05:22 INFO Bringing up the local storage
-2025-11-18 18:05:22 INFO Attempting to recover storage pool 'local' using existing non-system drive
-2025-11-18 18:05:23 INFO System is ready release=202511181747
+2026-08-27 19:52:00 INFO Bringing up the local storage
+2026-08-27 19:52:01 INFO Attempting to recover storage pool 'local' using existing non-system drive
+[snip]
+2026-08-27 19:52:25 INFO System is ready version=202608271552
 ```
 
 This will restore the pool to a good state, but because this is a fresh IncusOS install you must supply the encryption key for the previously-created "local" storage pool:

--- a/doc/tutorials/storage-import-unencrypted-incus-pool.md
+++ b/doc/tutorials/storage-import-unencrypted-incus-pool.md
@@ -20,33 +20,33 @@ oldpool  encryption  off          default
 Incus has configured this ZFS pool as a storage pool called `incus`:
 
 ```
-gibmat@futurfusion:~$ incus storage list
-+-------+--------+--------------------------------------+---------+---------+
-| NAME  | DRIVER |             DESCRIPTION              | USED BY |  STATE  |
-+-------+--------+--------------------------------------+---------+---------+
-| incus | zfs    |                                      | 4       | CREATED |
-+-------+--------+--------------------------------------+---------+---------+
-| local | zfs    | Local storage pool (on system drive) | 3       | CREATED |
-+-------+--------+--------------------------------------+---------+---------+
+$ incus storage list
+┌───────┬────────┬──────────────────────────────────────┬─────────┬─────────┐
+│ NAME  │ DRIVER │             DESCRIPTION              │ USED BY │  STATE  │
+├───────┼────────┼──────────────────────────────────────┼─────────┼─────────┤
+│ incus │ zfs    │                                      │ 4       │ CREATED │
+├───────┼────────┼──────────────────────────────────────┼─────────┼─────────┤
+│ local │ zfs    │ Local storage pool (on system drive) │ 4       │ CREATED │
+└───────┴────────┴──────────────────────────────────────┴─────────┴─────────┘
 ```
 
 There are two instances on the server:
 
 ```
-gibmat@futurfusion:~$ incus list
-+-------------+---------+-----------------------+--------------------------------------------------+-----------------+-----------+
-|    NAME     |  STATE  |         IPV4          |                       IPV6                       |      TYPE       | SNAPSHOTS |
-+-------------+---------+-----------------------+--------------------------------------------------+-----------------+-----------+
-| debian13    | RUNNING | 10.79.37.82 (eth0)    | fd42:6e71:c59b:9a92:1266:6aff:fe87:2cc (eth0)    | CONTAINER       | 0         |
-+-------------+---------+-----------------------+--------------------------------------------------+-----------------+-----------+
-| debian13-vm | RUNNING | 10.79.37.185 (enp5s0) | fd42:6e71:c59b:9a92:1266:6aff:fe63:ab3c (enp5s0) | VIRTUAL-MACHINE | 0         |
-+-------------+---------+-----------------------+--------------------------------------------------+-----------------+-----------+
+$ incus list
+┌─────────────┬─────────┬───────────────────────┬──────────────────────────────────────────────────┬─────────────────┬───────────┐
+│    NAME     │  STATE  │         IPV4          │                       IPV6                       │      TYPE       │ SNAPSHOTS │
+├─────────────┼─────────┼───────────────────────┼──────────────────────────────────────────────────┼─────────────────┼───────────┤
+│ debian13    │ RUNNING │ 10.48.100.68 (eth0)   │ fd42:8ee2:bc1a:484b:1266:6aff:fe7f:88f7 (eth0)   │ CONTAINER       │ 0         │
+├─────────────┼─────────┼───────────────────────┼──────────────────────────────────────────────────┼─────────────────┼───────────┤
+│ debian13-vm │ RUNNING │ 10.48.100.75 (enp5s0) │ fd42:8ee2:bc1a:484b:1266:6aff:fec3:b763 (enp5s0) │ VIRTUAL-MACHINE │ 0         │
+└─────────────┴─────────┴───────────────────────┴──────────────────────────────────────────────────┴─────────────────┴───────────┘
 ```
 
 Ensure all instances are stopped before powering down the system to install IncusOS:
 
 ```
-gibmat@futurfusion:~$ for instance in $(incus list --columns n --format compact,noheader); do incus stop $instance; done
+for instance in $(incus list --columns n --format compact,noheader); do incus stop $instance; done
 ```
 
 ## Install IncusOS and create a new encrypted storage volume
@@ -60,145 +60,167 @@ Once IncusOS is installed, we will create a new ZFS pool `newpool` via the Incus
 Show the system's current storage state:
 
 ```
-gibmat@futurfusion:~$ incus admin os system storage show
+$ incus admin os system storage show
 WARNING: The IncusOS API and configuration is subject to change
 
-config: {}
+config:
+  pools:
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
+      encryption_key_status: available
+      managed: true
+      name: local
+      pool_allocated_space_in_bytes: 4.575232e+06
+      raw_pool_size_in_bytes: 1.7716740096e+10
+      state: ONLINE
+      type: zfs-raid0
+      usable_pool_size_in_bytes: 1.7716740096e+10
+      volumes:
+        - name: incus
+          quota_in_bytes: 0
+          usage_in_bytes: 2.965504e+06
+          use: incus
+  scrub_schedule: 0 4 * * 0
 state:
   drives:
-  - boot: false
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_disk1
-  - boot: false
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_disk2
-  - boot: true
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root
-    member_pool: local
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_root
-  pools:
-  - devices:
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
-    encryption_key_status: available
-    name: local
-    pool_allocated_space_in_bytes: 4.288512e+06
-    raw_pool_size_in_bytes: 1.7716740096e+10
-    state: ONLINE
-    type: zfs-raid0
-    usable_pool_size_in_bytes: 1.7716740096e+10
-    volumes:
-    - name: incus
-      quota_in_bytes: 0
-      usage_in_bytes: 2.768896e+06
-      use: '-'
+    - boot: false
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_disk1
+    - boot: false
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_disk2
+    - boot: true
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root
+      member_pool: local
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_root
+  root_partition:
+    available_in_bytes: 2.5271922688e+10
+    size_in_bytes: 2.6225119232e+10
 ```
 
 Create `newpool`:
 
 ```
-gibmat@futurfusion:~$ incus admin os system storage edit
+incus admin os system storage edit
 ```
 
 ```
 config:
   pools:
-  - name: newpool
-    devices:
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
-    type: zfs-raid0
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
+      name: local
+      type: zfs-raid0
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
+      name: newpool
+      type: zfs-raid0
+  scrub_schedule: 0 4 * * 0
 ```
 
 Create a storage volume for Incus to use in `newpool`:
 
 ```
-gibmat@futurfusion:~$ incus admin os system storage create-volume -d '{"pool":"newpool","name":"incus","use":"incus"}'
+incus admin os system storage create-volume -d '{"pool":"newpool","name":"incus","use":"incus"}'
 ```
 
 Show that the new ZFS pool and volume have indeed been created:
 
 ```
-gibmat@futurfusion:~$ incus admin os system storage show
+$ incus admin os system storage show
 WARNING: The IncusOS API and configuration is subject to change
 
-config: {}
+config:
+  pools:
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
+      encryption_key_status: available
+      managed: true
+      name: local
+      pool_allocated_space_in_bytes: 4.575232e+06
+      raw_pool_size_in_bytes: 1.7716740096e+10
+      state: ONLINE
+      type: zfs-raid0
+      usable_pool_size_in_bytes: 1.7716740096e+10
+      volumes:
+        - name: incus
+          quota_in_bytes: 0
+          usage_in_bytes: 2.965504e+06
+          use: incus
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
+      encryption_key_status: available
+      managed: true
+      name: newpool
+      pool_allocated_space_in_bytes: 1.101824e+06
+      raw_pool_size_in_bytes: 5.3150220288e+10
+      state: ONLINE
+      type: zfs-raid0
+      usable_pool_size_in_bytes: 5.3150220288e+10
+      volumes:
+        - name: incus
+          quota_in_bytes: 0
+          usage_in_bytes: 196608
+          use: incus
+  scrub_schedule: 0 4 * * 0
 state:
   drives:
-  - boot: false
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_disk1
-  - boot: false
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
-    member_pool: newpool
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_disk2
-  - boot: true
-    bus: scsi
-    capacity_in_bytes: 5.36870912e+10
-    id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root
-    member_pool: local
-    model_family: QEMU
-    model_name: QEMU HARDDISK
-    remote: false
-    removable: false
-    serial_number: incus_root
-  pools:
-  - devices:
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
-    encryption_key_status: available
-    name: local
-    pool_allocated_space_in_bytes: 4.288512e+06
-    raw_pool_size_in_bytes: 1.7716740096e+10
-    state: ONLINE
-    type: zfs-raid0
-    usable_pool_size_in_bytes: 1.7716740096e+10
-    volumes:
-    - name: incus
-      quota_in_bytes: 0
-      usage_in_bytes: 2.768896e+06
-      use: '-'
-  - devices:
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
-    encryption_key_status: available
-    name: newpool
-    pool_allocated_space_in_bytes: 835584
-    raw_pool_size_in_bytes: 5.3150220288e+10
-    state: ONLINE
-    type: zfs-raid0
-    usable_pool_size_in_bytes: 5.3150220288e+10
-    volumes:
-    - name: incus
-      quota_in_bytes: 0
-      usage_in_bytes: 196608
-      use: incus
+    - boot: false
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_disk1
+    - boot: false
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2
+      member_pool: newpool
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_disk2
+    - boot: true
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root
+      member_pool: local
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_root
+  root_partition:
+    available_in_bytes: 2.5271918592e+10
+    size_in_bytes: 2.6225119232e+10
 ```
 
 ## Create a new Incus storage pool
@@ -206,33 +228,28 @@ state:
 Next, create a new Incus storage pool called `incus_new` using the new storage volume:
 
 ```
-gibmat@futurfusion:~$ incus storage create incus_new zfs source=newpool/incus
+$ incus storage create incus_new zfs source=newpool/incus
 Storage pool incus_new created
-gibmat@futurfusion:~$ incus storage list
-+-----------+--------+--------------------------------------+---------+---------+
-|   NAME    | DRIVER |             DESCRIPTION              | USED BY |  STATE  |
-+-----------+--------+--------------------------------------+---------+---------+
-| incus_new | zfs    |                                      | 0       | CREATED |
-+-----------+--------+--------------------------------------+---------+---------+
-| local     | zfs    | Local storage pool (on system drive) | 3       | CREATED |
-+-----------+--------+--------------------------------------+---------+---------+
-
+$ incus storage list
+┌───────────┬────────┬──────────────────────────────────────┬─────────┬─────────┐
+│   NAME    │ DRIVER │             DESCRIPTION              │ USED BY │  STATE  │
+├───────────┼────────┼──────────────────────────────────────┼─────────┼─────────┤
+│ incus_new │ zfs    │                                      │ 0       │ CREATED │
+├───────────┼────────┼──────────────────────────────────────┼─────────┼─────────┤
+│ local     │ zfs    │ Local storage pool (on system drive) │ 4       │ CREATED │
+└───────────┴────────┴──────────────────────────────────────┴─────────┴─────────┘
 ```
 
 ## Use `incus admin recover` to import existing instances
 
-```{note}
-The ability to run `incus admin recover` against a remote server, such as IncusOS, requires Incus version 6.19 or greater.
 ```
-
-```
-gibmat@futurfusion:~$ incus admin recover
+$ incus admin recover
 This server currently has the following storage pools:
  - incus_new (backend="zfs", source="newpool/incus")
  - local (backend="zfs", source="local/incus")
 Would you like to recover another storage pool? (yes/no) [default=no]: yes
 Name of the storage pool: incus
-Name of the storage backend (dir, zfs): zfs
+Name of the storage backend (btrfs, dir, lvm, lvmcluster, zfs): zfs
 Source of the storage pool (block device, volume group, dataset, path, ... as applicable): oldpool
 Additional storage pool configuration property (KEY=VALUE, empty when done):
 Would you like to recover another storage pool? (yes/no) [default=no]:
@@ -256,22 +273,22 @@ Starting recovery...
 Now that we have both the old and new ZFS pools available, we can move the instances from the unencrypted `oldpool` to the encrypted `newpool`:
 
 ```
-gibmat@futurfusion:~$ for instance in $(incus list --columns n --format compact,noheader); do incus move $instance $instance --storage incus_new; done
+for instance in $(incus list --columns n --format compact,noheader); do incus move $instance $instance --storage incus_new; done
 ```
 
 Once complete, delete the old Incus storage pool:
 
 ```
-gibmat@futurfusion:~$ incus storage delete incus
+$ incus storage delete incus
 Storage pool incus deleted
-gibmat@futurfusion:~$ incus storage list
-+-----------+--------+--------------------------------------+---------+---------+
-|   NAME    | DRIVER |             DESCRIPTION              | USED BY |  STATE  |
-+-----------+--------+--------------------------------------+---------+---------+
-| incus_new | zfs    |                                      | 2       | CREATED |
-+-----------+--------+--------------------------------------+---------+---------+
-| local     | zfs    | Local storage pool (on system drive) | 3       | CREATED |
-+-----------+--------+--------------------------------------+---------+---------+
+$ incus storage list
+┌───────────┬────────┬──────────────────────────────────────┬─────────┬─────────┐
+│   NAME    │ DRIVER │             DESCRIPTION              │ USED BY │  STATE  │
+├───────────┼────────┼──────────────────────────────────────┼─────────┼─────────┤
+│ incus_new │ zfs    │                                      │ 2       │ CREATED │
+├───────────┼────────┼──────────────────────────────────────┼─────────┼─────────┤
+│ local     │ zfs    │ Local storage pool (on system drive) │ 4       │ CREATED │
+└───────────┴────────┴──────────────────────────────────────┴─────────┴─────────┘
 ```
 
 ## Start instances and verify running
@@ -279,15 +296,15 @@ gibmat@futurfusion:~$ incus storage list
 Now you can start the migrated instances on the IncusOS server using the encrypted storage volume:
 
 ```
-gibmat@futurfusion:~$ for instance in $(incus list --columns n --format compact,noheader); do incus start $instance; done
-gibmat@futurfusion:~$ incus list
-+-------------+---------+-----------------------+------------------------------------------------+-----------------+-----------+
-|    NAME     |  STATE  |         IPV4          |                      IPV6                      |      TYPE       | SNAPSHOTS |
-+-------------+---------+-----------------------+------------------------------------------------+-----------------+-----------+
-| debian13    | RUNNING | 10.119.172.82 (eth0)  | fd42:d040:6b43:6e18:1266:6aff:fe87:2cc (eth0)  | CONTAINER       | 0         |
-+-------------+---------+-----------------------+------------------------------------------------+-----------------+-----------+
-| debian13-vm | RUNNING | 10.119.172.185 (eth0) | fd42:d040:6b43:6e18:1266:6aff:fe63:ab3c (eth0) | VIRTUAL-MACHINE | 0         |
-+-------------+---------+-----------------------+------------------------------------------------+-----------------+-----------+
+$ for instance in $(incus list --columns n --format compact,noheader); do incus start $instance; done
+$ incus list
+┌─────────────┬─────────┬───────────────────────┬──────────────────────────────────────────────────┬─────────────────┬───────────┐
+│    NAME     │  STATE  │         IPV4          │                       IPV6                       │      TYPE       │ SNAPSHOTS │
+├─────────────┼─────────┼───────────────────────┼──────────────────────────────────────────────────┼─────────────────┼───────────┤
+│ debian13    │ RUNNING │ 10.203.93.68 (eth0)   │ fd42:39f9:1631:1319:1266:6aff:fe7f:88f7 (eth0)   │ CONTAINER       │ 0         │
+├─────────────┼─────────┼───────────────────────┼──────────────────────────────────────────────────┼─────────────────┼───────────┤
+│ debian13-vm │ RUNNING │ 10.203.93.75 (enp5s0) │ fd42:39f9:1631:1319:1266:6aff:fec3:b763 (enp5s0) │ VIRTUAL-MACHINE │ 0         │
+└─────────────┴─────────┴───────────────────────┴──────────────────────────────────────────────────┴─────────────────┴───────────┘
 
 ```
 
@@ -296,7 +313,7 @@ gibmat@futurfusion:~$ incus list
 Finally, you can wipe the disk(s) that composed the old, unencrypted storage pool:
 
 ```
-gibmat@futurfusion:~$ incus admin os system storage wipe-drive -d '{"id":"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1"}'
+$ incus admin os system storage wipe-drive -d '{"id":"/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1"}'
 WARNING: The IncusOS API and configuration is subject to change
 
 Are you sure you want to wipe the drive? (yes/no) [default=no]: yes

--- a/doc/tutorials/storage-preparing-volume-incus.md
+++ b/doc/tutorials/storage-preparing-volume-incus.md
@@ -19,32 +19,79 @@ Assuming we want to create a pool `my-pool` using the device `/dev/disk/by-id/sc
 ```
 config:
   pools:
-    - name: my-pool
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
+      name: local
       type: zfs-raid0
-      devices:
-      - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
+      name: my-pool
+      type: zfs-raid0
+  scrub_schedule: 0 4 * * 0
 ```
 
 Afterwards we see the new pool is created, but unused:
 
 ```
-gibmat@futurfusion:~$ incus admin os system storage show
+$ incus admin os system storage show
 WARNING: The IncusOS API and configuration is subject to change
 
-[snip]
-
-state:
+config:
   pools:
-  - devices:
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
-    encryption_key_status: available
-    name: my-pool
-    pool_allocated_space_in_bytes: 724992
-    raw_pool_size_in_bytes: 5.3150220288e+10
-    state: ONLINE
-    type: zfs-raid0
-    usable_pool_size_in_bytes: 5.3150220288e+10
-    volumes: []
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
+      encryption_key_status: available
+      managed: true
+      name: local
+      pool_allocated_space_in_bytes: 4.562944e+06
+      raw_pool_size_in_bytes: 1.7716740096e+10
+      state: ONLINE
+      type: zfs-raid0
+      usable_pool_size_in_bytes: 1.7716740096e+10
+      volumes:
+        - name: incus
+          quota_in_bytes: 0
+          usage_in_bytes: 2.965504e+06
+          use: incus
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
+      encryption_key_status: available
+      managed: true
+      name: my-pool
+      pool_allocated_space_in_bytes: 540672
+      raw_pool_size_in_bytes: 5.3150220288e+10
+      state: ONLINE
+      type: zfs-raid0
+      usable_pool_size_in_bytes: 5.3150220288e+10
+      volumes: []
+  scrub_schedule: 0 4 * * 0
+state:
+  drives:
+    - boot: false
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
+      member_pool: my-pool
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_disk1
+    - boot: true
+      bus: scsi
+      capacity_in_bytes: 5.36870912e+10
+      id: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root
+      member_pool: local
+      model_family: QEMU
+      model_name: QEMU HARDDISK
+      multipath: false
+      remote: false
+      removable: false
+      serial_number: incus_root
+  root_partition:
+    available_in_bytes: 2.5271918592e+10
+    size_in_bytes: 2.6225119232e+10
 ```
 
 ## Creating a volume
@@ -52,28 +99,44 @@ state:
 We will now create a new storage volume `my-volume` for use by Incus:
 
 ```
-gibmat@futurfusion:~$ incus admin os system storage create-volume -d '{"pool":"my-pool","name":"my-volume","use":"incus"}'
-gibmat@futurfusion:~$ incus admin os system storage show
+$ incus admin os system storage create-volume -d '{"pool":"my-pool","name":"my-volume","use":"incus"}'
+$ incus admin os system storage show
 WARNING: The IncusOS API and configuration is subject to change
 
-[snip]
-
-state:
+config:
   pools:
-  - devices:
-    - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
-    encryption_key_status: available
-    name: my-pool
-    pool_allocated_space_in_bytes: 1.04448e+06
-    raw_pool_size_in_bytes: 5.3150220288e+10
-    state: ONLINE
-    type: zfs-raid0
-    usable_pool_size_in_bytes: 5.3150220288e+10
-    volumes:
-    - name: my-volume
-      quota_in_bytes: 0
-      usage_in_bytes: 196608
-      use: incus
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11
+      encryption_key_status: available
+      managed: true
+      name: local
+      pool_allocated_space_in_bytes: 4.562944e+06
+      raw_pool_size_in_bytes: 1.7716740096e+10
+      state: ONLINE
+      type: zfs-raid0
+      usable_pool_size_in_bytes: 1.7716740096e+10
+      volumes:
+        - name: incus
+          quota_in_bytes: 0
+          usage_in_bytes: 2.965504e+06
+          use: incus
+    - devices:
+        - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1
+      encryption_key_status: available
+      managed: true
+      name: my-pool
+      pool_allocated_space_in_bytes: 1.101824e+06
+      raw_pool_size_in_bytes: 5.3150220288e+10
+      state: ONLINE
+      type: zfs-raid0
+      usable_pool_size_in_bytes: 5.3150220288e+10
+      volumes:
+        - name: my-volume
+          quota_in_bytes: 0
+          usage_in_bytes: 196608
+          use: incus
+
+[snip]
 ```
 
 ## Making the volume available to Incus
@@ -81,14 +144,14 @@ state:
 Finally, we can easily add the storage volume for Incus to use:
 
 ```
-gibmat@futurfusion:~$ incus storage create incusos-volume zfs source=my-pool/my-volume
+$ incus storage create incusos-volume zfs source=my-pool/my-volume
 Storage pool incusos-volume created
-gibmat@futurfusion:~$ incus storage list
-+----------------+--------+--------------------------------------+---------+---------+
-|      NAME      | DRIVER |             DESCRIPTION              | USED BY |  STATE  |
-+----------------+--------+--------------------------------------+---------+---------+
-| local          | zfs    | Local storage pool (on system drive) | 3       | CREATED |
-+----------------+--------+--------------------------------------+---------+---------+
-| incusos-volume | zfs    |                                      | 0       | CREATED |
-+----------------+--------+--------------------------------------+---------+---------+
+$ incus storage list
+┌────────────────┬────────┬──────────────────────────────────────┬─────────┬─────────┐
+│      NAME      │ DRIVER │             DESCRIPTION              │ USED BY │  STATE  │
+├────────────────┼────────┼──────────────────────────────────────┼─────────┼─────────┤
+│ incusos-volume │ zfs    │                                      │ 0       │ CREATED │
+├────────────────┼────────┼──────────────────────────────────────┼─────────┼─────────┤
+│ local          │ zfs    │ Local storage pool (on system drive) │ 4       │ CREATED │
+└────────────────┴────────┴──────────────────────────────────────┴─────────┴─────────┘
 ```

--- a/incus-osd/api/system_storage.go
+++ b/incus-osd/api/system_storage.go
@@ -11,7 +11,6 @@ type SystemStorageConfig struct {
 // SystemStorageState represents additional state for the system's local storage.
 type SystemStorageState struct {
 	Drives        []SystemStorageDrive       `json:"drives"         yaml:"drives"`
-	Pools         []SystemStoragePool        `json:"pools"          yaml:"pools"`
 	RootPartition SystemStorageRootPartition `json:"root_partition" yaml:"root_partition"`
 }
 

--- a/incus-osd/cli/cli_system_info_storage.go
+++ b/incus-osd/cli/cli_system_info_storage.go
@@ -65,11 +65,11 @@ func renderStorageInfo(resp *incusapi.Response) error {
 	}
 
 	// Pools table.
-	if len(storage.State.Pools) > 0 {
+	if len(storage.Config.Pools) > 0 {
 		_, _ = fmt.Println("\nPools:") //nolint:forbidigo
 
-		poolRows := make([][]string, 0, len(storage.State.Pools))
-		for _, pool := range storage.State.Pools {
+		poolRows := make([][]string, 0, len(storage.Config.Pools))
+		for _, pool := range storage.Config.Pools {
 			poolRows = append(poolRows, []string{
 				pool.Name,
 				pool.Type,

--- a/incus-osd/internal/rest/api_system_storage.go
+++ b/incus-osd/internal/rest/api_system_storage.go
@@ -81,12 +81,14 @@ func (s *Server) apiSystemStorage(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodGet:
-		info, err := storage.GetStorageInfo(r.Context())
+		info, pools, err := storage.GetStorageInfo(r.Context())
 		if err != nil {
 			_ = response.InternalError(err).Render(w)
 
 			return
 		}
+
+		s.state.System.Storage.Config.Pools = pools
 
 		ret := api.SystemStorage{
 			State:  info,

--- a/incus-osd/internal/storage/storage.go
+++ b/incus-osd/internal/storage/storage.go
@@ -689,8 +689,9 @@ func calculateScrubProgress(stats zpoolScanStats) string {
 }
 
 // GetStorageInfo returns current SMART data for each drive and the status of each local zpool.
-func GetStorageInfo(ctx context.Context) (api.SystemStorageState, error) {
+func GetStorageInfo(ctx context.Context) (api.SystemStorageState, []api.SystemStoragePool, error) {
 	ret := api.SystemStorageState{}
+	retPools := []api.SystemStoragePool{}
 
 	type zpoolStatusRaw struct {
 		Pools map[string]json.RawMessage `json:"pools"`
@@ -699,24 +700,24 @@ func GetStorageInfo(ctx context.Context) (api.SystemStorageState, error) {
 	// Get the status of the zpool(s).
 	zpoolOutput, err := subprocess.RunCommandContext(ctx, "zpool", "status", "-jp", "--json-int")
 	if err != nil {
-		return ret, err
+		return ret, retPools, err
 	}
 
 	zpools := zpoolStatusRaw{}
 
 	err = json.Unmarshal([]byte(zpoolOutput), &zpools)
 	if err != nil {
-		return ret, err
+		return ret, retPools, err
 	}
 
 	// Populate the Config.State struct.
 	for zpoolName := range zpools.Pools {
 		poolConfig, err := getZpoolMembersHelper(ctx, []byte(zpoolOutput), zpoolName)
 		if err != nil {
-			return ret, err
+			return ret, retPools, err
 		}
 
-		ret.Pools = append(ret.Pools, poolConfig)
+		retPools = append(retPools, poolConfig)
 	}
 
 	// Get a list of all local drives.
@@ -724,19 +725,19 @@ func GetStorageInfo(ctx context.Context) (api.SystemStorageState, error) {
 	// Exclude devices with major numbers 1 (RAM disk), 2 (floppy disks), 7 (loopback), 43 (NBD), 147 (DRBD), 230 (zvols), 251 (Ceph RBD)
 	output, err := subprocess.RunCommandContext(ctx, "lsblk", "-JMpdb", "-e", "1,2,7,43,147,230,251", "-o", "KNAME,ID_LINK,SIZE,SUBSYSTEMS,RM,WWN")
 	if err != nil {
-		return ret, err
+		return ret, retPools, err
 	}
 
 	drives := LsblkOutput{}
 
 	err = json.Unmarshal([]byte(output), &drives)
 	if err != nil {
-		return ret, err
+		return ret, retPools, err
 	}
 
 	bootDevice, err := GetUnderlyingDevice()
 	if err != nil {
-		return ret, err
+		return ret, retPools, err
 	}
 
 	// Get SMART data and populate struct for each drive.
@@ -771,7 +772,7 @@ func GetStorageInfo(ctx context.Context) (api.SystemStorageState, error) {
 		// Determine if this is a remote device (NVMEoTCP, FC, etc).
 		isRemote, err := IsRemoteDevice(drive.KName)
 		if err != nil {
-			return ret, err
+			return ret, retPools, err
 		}
 
 		// If model_family or model_name are empty, try to populate values by looking at SCSI fields.
@@ -808,7 +809,7 @@ func GetStorageInfo(ctx context.Context) (api.SystemStorageState, error) {
 		// Resolve the device name to a more stable by-id symlink.
 		deviceID, err := DeviceToID(ctx, drive.KName, true)
 		if err != nil {
-			return ret, err
+			return ret, retPools, err
 		}
 
 		// Check if the drive belongs to a zpool.
@@ -817,7 +818,7 @@ func GetStorageInfo(ctx context.Context) (api.SystemStorageState, error) {
 		for zpoolName := range zpools.Pools {
 			poolConfig, err := getZpoolMembersHelper(ctx, []byte(zpoolOutput), zpoolName)
 			if err != nil {
-				return ret, err
+				return ret, retPools, err
 			}
 
 			if isMemberDrive(poolConfig.Devices, deviceID) || isMemberDrive(poolConfig.Log, deviceID) || isMemberDrive(poolConfig.Cache, deviceID) || (poolConfig.Special != nil && isMemberDrive(poolConfig.Special.Devices, deviceID)) ||
@@ -934,7 +935,7 @@ func GetStorageInfo(ctx context.Context) (api.SystemStorageState, error) {
 
 	err = unix.Statfs("/", &fs)
 	if err != nil {
-		return ret, err
+		return ret, retPools, err
 	}
 
 	blockSize := int(fs.Bsize)
@@ -944,7 +945,7 @@ func GetStorageInfo(ctx context.Context) (api.SystemStorageState, error) {
 		AvailableInBytes: int(fs.Bavail) * blockSize, //nolint:gosec
 	}
 
-	return ret, nil
+	return ret, retPools, nil
 }
 
 // Helper function that checks if a given drive is a member of the provided list of drives.
@@ -1103,7 +1104,7 @@ func isBootDevice(ctx context.Context, deviceName string, bootDevice string) boo
 // and then remove the corresponding encryption key.
 func WipeDrive(ctx context.Context, drive string, secure bool) error {
 	// Get a list of all drives.
-	drives, err := GetStorageInfo(ctx)
+	drives, _, err := GetStorageInfo(ctx)
 	if err != nil {
 		return err
 	}

--- a/incus-osd/internal/zfs/zfs.go
+++ b/incus-osd/internal/zfs/zfs.go
@@ -1012,14 +1012,14 @@ func ScrubZpool(ctx context.Context, poolName string) error {
 		return errors.New("zpool '" + poolName + "' doesn't exist")
 	}
 
-	info, err := storage.GetStorageInfo(ctx)
+	_, pools, err := storage.GetStorageInfo(ctx)
 	if err != nil {
 		return err
 	}
 
 	pool := api.SystemStoragePool{}
 
-	for _, p := range info.Pools {
+	for _, p := range pools {
 		if p.Name == poolName {
 			pool = p
 		}
@@ -1040,13 +1040,13 @@ func ScrubZpool(ctx context.Context, poolName string) error {
 
 // ScrubAllPools scrubs all pools in the system sequentially, blocking until the scrub is complete.
 func ScrubAllPools(ctx context.Context) error {
-	info, err := storage.GetStorageInfo(ctx)
+	_, pools, err := storage.GetStorageInfo(ctx)
 	if err != nil {
 		return err
 	}
 
 	// Scrub every pool sequentially.
-	for _, pool := range info.Pools {
+	for _, pool := range pools {
 		slog.InfoContext(ctx, "Scrubbing pool", slog.String("pool", pool.Name))
 
 		// If a scrub is already in progress for a pool, skip it.
@@ -1062,14 +1062,14 @@ func ScrubAllPools(ctx context.Context) error {
 
 		// Wait for the scrub to finish.
 		for {
-			latestInfo, err := storage.GetStorageInfo(ctx)
+			_, latestPools, err := storage.GetStorageInfo(ctx)
 			if err != nil {
 				return err
 			}
 
 			latestPoolInfo := api.SystemStoragePool{}
 
-			for _, p := range latestInfo.Pools {
+			for _, p := range latestPools {
 				if p.Name == pool.Name {
 					latestPoolInfo = p
 				}

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_storage.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_storage.py
@@ -230,12 +230,12 @@ def TestIncusOSAPISystemStorageMixedDeviceSize(install_image):
                     if result["status_code"] != 200:
                         raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                    if len(result["metadata"]["state"]["pools"]) != 2:
+                    if len(result["metadata"]["config"]["pools"]) != 2:
                         raise IncusOSException("expected two storage pools")
 
-                    poolState = result["metadata"]["state"]["pools"][0]
+                    poolState = result["metadata"]["config"]["pools"][0]
                     if poolState["name"] != "mypool":
-                        poolState = result["metadata"]["state"]["pools"][1]
+                        poolState = result["metadata"]["config"]["pools"][1]
 
                     if len(poolState["devices"]) != 3:
                         raise IncusOSException("expected three member devices for 'mypool' pool")
@@ -269,12 +269,12 @@ def TestIncusOSAPISystemStorageConvertToMirror(install_image):
                 if result["status_code"] != 200:
                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                if len(result["metadata"]["state"]["pools"]) != 2:
+                if len(result["metadata"]["config"]["pools"]) != 2:
                     raise IncusOSException("expected two storage pools")
 
-                poolState = result["metadata"]["state"]["pools"][0]
+                poolState = result["metadata"]["config"]["pools"][0]
                 if poolState["name"] != "mypool":
-                    poolState = result["metadata"]["state"]["pools"][1]
+                    poolState = result["metadata"]["config"]["pools"][1]
 
                 if len(poolState["devices"]) != 1:
                     raise IncusOSException("expected exactly one device for 'mypool' pool")
@@ -292,12 +292,12 @@ def TestIncusOSAPISystemStorageConvertToMirror(install_image):
                 if result["status_code"] != 200:
                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                if len(result["metadata"]["state"]["pools"]) != 2:
+                if len(result["metadata"]["config"]["pools"]) != 2:
                     raise IncusOSException("expected two storage pools")
 
-                poolState = result["metadata"]["state"]["pools"][0]
+                poolState = result["metadata"]["config"]["pools"][0]
                 if poolState["name"] != "mypool":
-                    poolState = result["metadata"]["state"]["pools"][1]
+                    poolState = result["metadata"]["config"]["pools"][1]
 
                 if len(poolState["devices"]) != 2:
                     raise IncusOSException("expected exactly two devices for 'mypool' pool")
@@ -337,12 +337,12 @@ def TestIncusOSAPISystemStoragePoolLogDevices(install_image):
                     if result["status_code"] != 200:
                         raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                    if len(result["metadata"]["state"]["pools"]) != 2:
+                    if len(result["metadata"]["config"]["pools"]) != 2:
                         raise IncusOSException("expected two storage pools")
 
-                    poolState = result["metadata"]["state"]["pools"][0]
+                    poolState = result["metadata"]["config"]["pools"][0]
                     if poolState["name"] != "mypool":
-                        poolState = result["metadata"]["state"]["pools"][1]
+                        poolState = result["metadata"]["config"]["pools"][1]
 
                     if poolState["type"] != "zfs-raid0":
                         raise IncusOSException("'mypool' type isn't zfs-raid0")
@@ -378,12 +378,12 @@ def TestIncusOSAPISystemStoragePoolLogDevices(install_image):
                     if result["status_code"] != 200:
                         raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                    if len(result["metadata"]["state"]["pools"]) != 2:
+                    if len(result["metadata"]["config"]["pools"]) != 2:
                         raise IncusOSException("expected two storage pools")
 
-                    poolState = result["metadata"]["state"]["pools"][0]
+                    poolState = result["metadata"]["config"]["pools"][0]
                     if poolState["name"] != "mypool":
-                        poolState = result["metadata"]["state"]["pools"][1]
+                        poolState = result["metadata"]["config"]["pools"][1]
 
                     if poolState["type"] != "zfs-raid0":
                         raise IncusOSException("'mypool' type isn't zfs-raid0")
@@ -445,12 +445,12 @@ def TestIncusOSAPISystemStoragePoolDeleteReplaceDevices(install_image):
                         if result["status_code"] != 200:
                             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                        if len(result["metadata"]["state"]["pools"]) != 2:
+                        if len(result["metadata"]["config"]["pools"]) != 2:
                             raise IncusOSException("expected two storage pools")
 
-                        poolState = result["metadata"]["state"]["pools"][0]
+                        poolState = result["metadata"]["config"]["pools"][0]
                         if poolState["name"] != "mypool":
-                            poolState = result["metadata"]["state"]["pools"][1]
+                            poolState = result["metadata"]["config"]["pools"][1]
 
                         if poolState["type"] != "zfs-raid1":
                             raise IncusOSException("'mypool' type isn't zfs-raid1")
@@ -474,12 +474,12 @@ def TestIncusOSAPISystemStoragePoolDeleteReplaceDevices(install_image):
                         if result["status_code"] != 200:
                             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                        if len(result["metadata"]["state"]["pools"]) != 2:
+                        if len(result["metadata"]["config"]["pools"]) != 2:
                             raise IncusOSException("expected two storage pools")
 
-                        poolState = result["metadata"]["state"]["pools"][0]
+                        poolState = result["metadata"]["config"]["pools"][0]
                         if poolState["name"] != "mypool":
-                            poolState = result["metadata"]["state"]["pools"][1]
+                            poolState = result["metadata"]["config"]["pools"][1]
 
                         if poolState["type"] != "zfs-raid1":
                             raise IncusOSException("'mypool' type isn't zfs-raid1")
@@ -506,12 +506,12 @@ def TestIncusOSAPISystemStoragePoolDeleteReplaceDevices(install_image):
                         if result["status_code"] != 200:
                             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                        if len(result["metadata"]["state"]["pools"]) != 2:
+                        if len(result["metadata"]["config"]["pools"]) != 2:
                             raise IncusOSException("expected two storage pools")
 
-                        poolState = result["metadata"]["state"]["pools"][0]
+                        poolState = result["metadata"]["config"]["pools"][0]
                         if poolState["name"] != "mypool":
-                            poolState = result["metadata"]["state"]["pools"][1]
+                            poolState = result["metadata"]["config"]["pools"][1]
 
                         if poolState["type"] != "zfs-raid1":
                             raise IncusOSException("'mypool' type isn't zfs-raid1")
@@ -535,12 +535,12 @@ def TestIncusOSAPISystemStoragePoolDeleteReplaceDevices(install_image):
                         if result["status_code"] != 200:
                             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                        if len(result["metadata"]["state"]["pools"]) != 2:
+                        if len(result["metadata"]["config"]["pools"]) != 2:
                             raise IncusOSException("expected two storage pools")
 
-                        poolState = result["metadata"]["state"]["pools"][0]
+                        poolState = result["metadata"]["config"]["pools"][0]
                         if poolState["name"] != "mypool":
-                            poolState = result["metadata"]["state"]["pools"][1]
+                            poolState = result["metadata"]["config"]["pools"][1]
 
                         if poolState["type"] != "zfs-raid1":
                             raise IncusOSException("'mypool' type isn't zfs-raid1")
@@ -600,12 +600,12 @@ def TestIncusOSAPISystemStoragePoolExpansionTests(install_image):
                                 if result["status_code"] != 200:
                                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                                if len(result["metadata"]["state"]["pools"]) != 2:
+                                if len(result["metadata"]["config"]["pools"]) != 2:
                                     raise IncusOSException("expected two storage pools")
 
-                                poolState = result["metadata"]["state"]["pools"][0]
+                                poolState = result["metadata"]["config"]["pools"][0]
                                 if poolState["name"] != "mypool":
-                                    poolState = result["metadata"]["state"]["pools"][1]
+                                    poolState = result["metadata"]["config"]["pools"][1]
 
                                 if poolState["type"] != "zfs-raid0":
                                     raise IncusOSException("'mypool' type isn't zfs-raid0")
@@ -629,12 +629,12 @@ def TestIncusOSAPISystemStoragePoolExpansionTests(install_image):
                                 if result["status_code"] != 200:
                                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                                if len(result["metadata"]["state"]["pools"]) != 2:
+                                if len(result["metadata"]["config"]["pools"]) != 2:
                                     raise IncusOSException("expected two storage pools")
 
-                                poolState = result["metadata"]["state"]["pools"][0]
+                                poolState = result["metadata"]["config"]["pools"][0]
                                 if poolState["name"] != "mypool":
-                                    poolState = result["metadata"]["state"]["pools"][1]
+                                    poolState = result["metadata"]["config"]["pools"][1]
 
                                 if poolState["type"] != "zfs-raid0":
                                     raise IncusOSException("'mypool' type isn't zfs-raid0")
@@ -662,12 +662,12 @@ def TestIncusOSAPISystemStoragePoolExpansionTests(install_image):
                                 if result["status_code"] != 200:
                                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                                if len(result["metadata"]["state"]["pools"]) != 2:
+                                if len(result["metadata"]["config"]["pools"]) != 2:
                                     raise IncusOSException("expected two storage pools")
 
-                                poolState = result["metadata"]["state"]["pools"][0]
+                                poolState = result["metadata"]["config"]["pools"][0]
                                 if poolState["name"] != "mypool":
-                                    poolState = result["metadata"]["state"]["pools"][1]
+                                    poolState = result["metadata"]["config"]["pools"][1]
 
                                 if poolState["type"] != "zfs-raid1":
                                     raise IncusOSException("'mypool' type isn't zfs-raid1")
@@ -691,12 +691,12 @@ def TestIncusOSAPISystemStoragePoolExpansionTests(install_image):
                                 if result["status_code"] != 200:
                                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                                if len(result["metadata"]["state"]["pools"]) != 2:
+                                if len(result["metadata"]["config"]["pools"]) != 2:
                                     raise IncusOSException("expected two storage pools")
 
-                                poolState = result["metadata"]["state"]["pools"][0]
+                                poolState = result["metadata"]["config"]["pools"][0]
                                 if poolState["name"] != "mypool":
-                                    poolState = result["metadata"]["state"]["pools"][1]
+                                    poolState = result["metadata"]["config"]["pools"][1]
 
                                 if poolState["type"] != "zfs-raid1":
                                     raise IncusOSException("'mypool' type isn't zfs-raid1")
@@ -732,12 +732,12 @@ def TestIncusOSAPISystemStoragePoolExpansionTests(install_image):
                                 if result["status_code"] != 200:
                                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                                if len(result["metadata"]["state"]["pools"]) != 2:
+                                if len(result["metadata"]["config"]["pools"]) != 2:
                                     raise IncusOSException("expected two storage pools")
 
-                                poolState = result["metadata"]["state"]["pools"][0]
+                                poolState = result["metadata"]["config"]["pools"][0]
                                 if poolState["name"] != "mypool":
-                                    poolState = result["metadata"]["state"]["pools"][1]
+                                    poolState = result["metadata"]["config"]["pools"][1]
 
                                 if poolState["type"] != "zfs-raid10":
                                     raise IncusOSException("'mypool' type isn't zfs-raid10")
@@ -769,12 +769,12 @@ def TestIncusOSAPISystemStoragePoolExpansionTests(install_image):
                                 if result["status_code"] != 200:
                                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                                if len(result["metadata"]["state"]["pools"]) != 2:
+                                if len(result["metadata"]["config"]["pools"]) != 2:
                                     raise IncusOSException("expected two storage pools")
 
-                                poolState = result["metadata"]["state"]["pools"][0]
+                                poolState = result["metadata"]["config"]["pools"][0]
                                 if poolState["name"] != "mypool":
-                                    poolState = result["metadata"]["state"]["pools"][1]
+                                    poolState = result["metadata"]["config"]["pools"][1]
 
                                 if poolState["type"] != "zfs-raid10":
                                     raise IncusOSException("'mypool' type isn't zfs-raid10")
@@ -802,12 +802,12 @@ def TestIncusOSAPISystemStoragePoolExpansionTests(install_image):
                                 if result["status_code"] != 200:
                                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                                if len(result["metadata"]["state"]["pools"]) != 2:
+                                if len(result["metadata"]["config"]["pools"]) != 2:
                                     raise IncusOSException("expected two storage pools")
 
-                                poolState = result["metadata"]["state"]["pools"][0]
+                                poolState = result["metadata"]["config"]["pools"][0]
                                 if poolState["name"] != "mypool":
-                                    poolState = result["metadata"]["state"]["pools"][1]
+                                    poolState = result["metadata"]["config"]["pools"][1]
 
                                 if poolState["type"] != "zfs-raidz1":
                                     raise IncusOSException("'mypool' type isn't zfs-raidz1")
@@ -831,12 +831,12 @@ def TestIncusOSAPISystemStoragePoolExpansionTests(install_image):
                                 if result["status_code"] != 200:
                                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                                if len(result["metadata"]["state"]["pools"]) != 2:
+                                if len(result["metadata"]["config"]["pools"]) != 2:
                                     raise IncusOSException("expected two storage pools")
 
-                                poolState = result["metadata"]["state"]["pools"][0]
+                                poolState = result["metadata"]["config"]["pools"][0]
                                 if poolState["name"] != "mypool":
-                                    poolState = result["metadata"]["state"]["pools"][1]
+                                    poolState = result["metadata"]["config"]["pools"][1]
 
                                 if poolState["type"] != "zfs-raidz1":
                                     raise IncusOSException("'mypool' type isn't zfs-raidz1")
@@ -903,12 +903,12 @@ def TestIncusOSAPISystemStoragePoolSpecialDevice(install_image):
                                 if result["status_code"] != 200:
                                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                                if len(result["metadata"]["state"]["pools"]) != 2:
+                                if len(result["metadata"]["config"]["pools"]) != 2:
                                     raise IncusOSException("expected two storage pools")
 
-                                poolState = result["metadata"]["state"]["pools"][0]
+                                poolState = result["metadata"]["config"]["pools"][0]
                                 if poolState["name"] != "mypool":
-                                    poolState = result["metadata"]["state"]["pools"][1]
+                                    poolState = result["metadata"]["config"]["pools"][1]
 
                                 if poolState["type"] != "zfs-raid0":
                                     raise IncusOSException("'mypool' type isn't zfs-raid0")
@@ -943,12 +943,12 @@ def TestIncusOSAPISystemStoragePoolSpecialDevice(install_image):
                                 if result["status_code"] != 200:
                                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                                if len(result["metadata"]["state"]["pools"]) != 2:
+                                if len(result["metadata"]["config"]["pools"]) != 2:
                                     raise IncusOSException("expected two storage pools")
 
-                                poolState = result["metadata"]["state"]["pools"][0]
+                                poolState = result["metadata"]["config"]["pools"][0]
                                 if poolState["name"] != "mypool":
-                                    poolState = result["metadata"]["state"]["pools"][1]
+                                    poolState = result["metadata"]["config"]["pools"][1]
 
                                 if poolState["type"] != "zfs-raid0":
                                     raise IncusOSException("'mypool' type isn't zfs-raid0")
@@ -988,12 +988,12 @@ def TestIncusOSAPISystemStoragePoolSpecialDevice(install_image):
                                 if result["status_code"] != 200:
                                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                                if len(result["metadata"]["state"]["pools"]) != 2:
+                                if len(result["metadata"]["config"]["pools"]) != 2:
                                     raise IncusOSException("expected two storage pools")
 
-                                poolState = result["metadata"]["state"]["pools"][0]
+                                poolState = result["metadata"]["config"]["pools"][0]
                                 if poolState["name"] != "mypool":
-                                    poolState = result["metadata"]["state"]["pools"][1]
+                                    poolState = result["metadata"]["config"]["pools"][1]
 
                                 if poolState["type"] != "zfs-raid1":
                                     raise IncusOSException("'mypool' type isn't zfs-raid1")
@@ -1031,12 +1031,12 @@ def TestIncusOSAPISystemStoragePoolSpecialDevice(install_image):
                                 if result["status_code"] != 200:
                                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                                if len(result["metadata"]["state"]["pools"]) != 2:
+                                if len(result["metadata"]["config"]["pools"]) != 2:
                                     raise IncusOSException("expected two storage pools")
 
-                                poolState = result["metadata"]["state"]["pools"][0]
+                                poolState = result["metadata"]["config"]["pools"][0]
                                 if poolState["name"] != "mypool":
-                                    poolState = result["metadata"]["state"]["pools"][1]
+                                    poolState = result["metadata"]["config"]["pools"][1]
 
                                 if poolState["type"] != "zfs-raid1":
                                     raise IncusOSException("'mypool' type isn't zfs-raid1")
@@ -1076,12 +1076,12 @@ def TestIncusOSAPISystemStoragePoolSpecialDevice(install_image):
                                 if result["status_code"] != 200:
                                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                                if len(result["metadata"]["state"]["pools"]) != 2:
+                                if len(result["metadata"]["config"]["pools"]) != 2:
                                     raise IncusOSException("expected two storage pools")
 
-                                poolState = result["metadata"]["state"]["pools"][0]
+                                poolState = result["metadata"]["config"]["pools"][0]
                                 if poolState["name"] != "mypool":
-                                    poolState = result["metadata"]["state"]["pools"][1]
+                                    poolState = result["metadata"]["config"]["pools"][1]
 
                                 if poolState["type"] != "zfs-raidz1":
                                     raise IncusOSException("'mypool' type isn't zfs-raidz1")
@@ -1119,12 +1119,12 @@ def TestIncusOSAPISystemStoragePoolSpecialDevice(install_image):
                                 if result["status_code"] != 200:
                                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                                if len(result["metadata"]["state"]["pools"]) != 2:
+                                if len(result["metadata"]["config"]["pools"]) != 2:
                                     raise IncusOSException("expected two storage pools")
 
-                                poolState = result["metadata"]["state"]["pools"][0]
+                                poolState = result["metadata"]["config"]["pools"][0]
                                 if poolState["name"] != "mypool":
-                                    poolState = result["metadata"]["state"]["pools"][1]
+                                    poolState = result["metadata"]["config"]["pools"][1]
 
                                 if poolState["type"] != "zfs-raidz1":
                                     raise IncusOSException("'mypool' type isn't zfs-raidz1")

--- a/incus-osd/tests/incusos_tests/tests_incusos_api_system_storage_local_pool.py
+++ b/incus-osd/tests/incusos_tests/tests_incusos_api_system_storage_local_pool.py
@@ -24,23 +24,23 @@ def TestIncusOSAPISystemStorageLocalPool(install_image):
         if len(result["metadata"]["state"]["drives"]) != 1:
             raise IncusOSException("expected exactly one drive")
 
-        if len(result["metadata"]["state"]["pools"]) != 1:
+        if len(result["metadata"]["config"]["pools"]) != 1:
             raise IncusOSException("expected exactly one pool")
 
         if result["metadata"]["state"]["drives"][0].get("member_pool", "") != "local":
             raise IncusOSException("drive isn't part of the local pool")
 
-        if len(result["metadata"]["state"]["pools"][0]["devices"]) != 1:
+        if len(result["metadata"]["config"]["pools"][0]["devices"]) != 1:
                 raise IncusOSException("expected one member device for local pool")
 
-        if result["metadata"]["state"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
+        if result["metadata"]["config"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
             raise IncusOSException("pool doesn't have expected member device")
 
-        if result["metadata"]["state"]["pools"][0]["type"] != "zfs-raid0":
-            raise IncusOSException("pool has unexpected type: " + result["metadata"]["state"]["pools"][0]["type"])
+        if result["metadata"]["config"]["pools"][0]["type"] != "zfs-raid0":
+            raise IncusOSException("pool has unexpected type: " + result["metadata"]["config"]["pools"][0]["type"])
 
-        if result["metadata"]["state"]["pools"][0]["name"] != "local":
-            raise IncusOSException("pool has unexpected name: " + result["metadata"]["state"]["pools"][0]["name"])
+        if result["metadata"]["config"]["pools"][0]["name"] != "local":
+            raise IncusOSException("pool has unexpected name: " + result["metadata"]["config"]["pools"][0]["name"])
 
 def TestIncusOSAPISystemStorageLocalPoolExpandRAID0(install_image):
     test_name = "incusos-api-system-storage-local-pool-expand-raid0"
@@ -66,7 +66,7 @@ def TestIncusOSAPISystemStorageLocalPoolExpandRAID0(install_image):
             if len(result["metadata"]["state"]["drives"]) != 2:
                 raise IncusOSException("expected exactly two drives")
 
-            if len(result["metadata"]["state"]["pools"]) != 1:
+            if len(result["metadata"]["config"]["pools"]) != 1:
                 raise IncusOSException("expected exactly one pool")
 
             if result["metadata"]["state"]["drives"][0]["id"] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1":
@@ -81,17 +81,17 @@ def TestIncusOSAPISystemStorageLocalPoolExpandRAID0(install_image):
             if result["metadata"]["state"]["drives"][1].get("member_pool", "") != "local":
                 raise IncusOSException("second drive isn't part of the local pool")
 
-            if len(result["metadata"]["state"]["pools"][0]["devices"]) != 1:
+            if len(result["metadata"]["config"]["pools"][0]["devices"]) != 1:
                 raise IncusOSException("expected one member device for local pool")
 
-            if result["metadata"]["state"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
+            if result["metadata"]["config"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
                 raise IncusOSException("pool doesn't have expected member device")
 
-            if result["metadata"]["state"]["pools"][0]["type"] != "zfs-raid0":
-                raise IncusOSException("pool has unexpected type: " + result["metadata"]["state"]["pools"][0]["type"])
+            if result["metadata"]["config"]["pools"][0]["type"] != "zfs-raid0":
+                raise IncusOSException("pool has unexpected type: " + result["metadata"]["config"]["pools"][0]["type"])
 
-            if result["metadata"]["state"]["pools"][0]["name"] != "local":
-                raise IncusOSException("pool has unexpected name: " + result["metadata"]["state"]["pools"][0]["name"])
+            if result["metadata"]["config"]["pools"][0]["name"] != "local":
+                raise IncusOSException("pool has unexpected name: " + result["metadata"]["config"]["pools"][0]["name"])
 
             # Extend the "local" pool with the second drive
             result = vm.APIRequest("/1.0/system/storage", method="PUT", body="""{"config":{"scrub_schedule": "0 4 * * 0", "pools":[{"name":"local","type":"zfs-raid0","devices":["/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11","/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1"]}]}}""")
@@ -106,7 +106,7 @@ def TestIncusOSAPISystemStorageLocalPoolExpandRAID0(install_image):
             if len(result["metadata"]["state"]["drives"]) != 2:
                 raise IncusOSException("expected exactly two drives")
 
-            if len(result["metadata"]["state"]["pools"]) != 1:
+            if len(result["metadata"]["config"]["pools"]) != 1:
                 raise IncusOSException("expected exactly one pool")
 
             if result["metadata"]["state"]["drives"][0]["id"] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1":
@@ -121,20 +121,20 @@ def TestIncusOSAPISystemStorageLocalPoolExpandRAID0(install_image):
             if result["metadata"]["state"]["drives"][1].get("member_pool", "") != "local":
                 raise IncusOSException("second drive isn't part of the local pool")
 
-            if len(result["metadata"]["state"]["pools"][0]["devices"]) != 2:
+            if len(result["metadata"]["config"]["pools"][0]["devices"]) != 2:
                 raise IncusOSException("expected two member devices for local pool")
 
-            if result["metadata"]["state"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1":
+            if result["metadata"]["config"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1":
                 raise IncusOSException("pool doesn't have expected member device")
 
-            if result["metadata"]["state"]["pools"][0]["devices"][1] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
+            if result["metadata"]["config"]["pools"][0]["devices"][1] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
                 raise IncusOSException("pool doesn't have expected member device")
 
-            if result["metadata"]["state"]["pools"][0]["type"] != "zfs-raid0":
-                raise IncusOSException("pool has unexpected type: " + result["metadata"]["state"]["pools"][0]["type"])
+            if result["metadata"]["config"]["pools"][0]["type"] != "zfs-raid0":
+                raise IncusOSException("pool has unexpected type: " + result["metadata"]["config"]["pools"][0]["type"])
 
-            if result["metadata"]["state"]["pools"][0]["name"] != "local":
-                raise IncusOSException("pool has unexpected name: " + result["metadata"]["state"]["pools"][0]["name"])
+            if result["metadata"]["config"]["pools"][0]["name"] != "local":
+                raise IncusOSException("pool has unexpected name: " + result["metadata"]["config"]["pools"][0]["name"])
 
             # Don't allow removal of the main system partition from the pool
             result = vm.APIRequest("/1.0/system/storage", method="PUT", body="""{"config":{"scrub_schedule": "0 4 * * 0", "pools":[{"name":"local","type":"zfs-raid0","devices":["/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1",""]}]}}""")
@@ -157,7 +157,7 @@ def TestIncusOSAPISystemStorageLocalPoolExpandRAID0(install_image):
             if len(result["metadata"]["state"]["drives"]) != 2:
                 raise IncusOSException("expected exactly two drives")
 
-            if len(result["metadata"]["state"]["pools"]) != 1:
+            if len(result["metadata"]["config"]["pools"]) != 1:
                 raise IncusOSException("expected exactly one pool")
 
             if result["metadata"]["state"]["drives"][0]["id"] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1":
@@ -172,17 +172,17 @@ def TestIncusOSAPISystemStorageLocalPoolExpandRAID0(install_image):
             if result["metadata"]["state"]["drives"][1].get("member_pool", "") != "local":
                 raise IncusOSException("second drive isn't part of the local pool")
 
-            if len(result["metadata"]["state"]["pools"][0]["devices"]) != 1:
+            if len(result["metadata"]["config"]["pools"][0]["devices"]) != 1:
                 raise IncusOSException("expected one member device for local pool")
 
-            if result["metadata"]["state"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
+            if result["metadata"]["config"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
                 raise IncusOSException("pool doesn't have expected member device")
 
-            if result["metadata"]["state"]["pools"][0]["type"] != "zfs-raid0":
-                raise IncusOSException("pool has unexpected type: " + result["metadata"]["state"]["pools"][0]["type"])
+            if result["metadata"]["config"]["pools"][0]["type"] != "zfs-raid0":
+                raise IncusOSException("pool has unexpected type: " + result["metadata"]["config"]["pools"][0]["type"])
 
-            if result["metadata"]["state"]["pools"][0]["name"] != "local":
-                raise IncusOSException("pool has unexpected name: " + result["metadata"]["state"]["pools"][0]["name"])
+            if result["metadata"]["config"]["pools"][0]["name"] != "local":
+                raise IncusOSException("pool has unexpected name: " + result["metadata"]["config"]["pools"][0]["name"])
 
 def TestIncusOSAPISystemStorageLocalPoolExpandRAID1(install_image):
     test_name = "incusos-api-system-storage-local-pool-expand-raid1"
@@ -211,7 +211,7 @@ def TestIncusOSAPISystemStorageLocalPoolExpandRAID1(install_image):
                 if len(result["metadata"]["state"]["drives"]) != 3:
                     raise IncusOSException("expected exactly three drives")
 
-                if len(result["metadata"]["state"]["pools"]) != 1:
+                if len(result["metadata"]["config"]["pools"]) != 1:
                     raise IncusOSException("expected exactly one pool")
 
                 if result["metadata"]["state"]["drives"][0]["id"] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1":
@@ -232,17 +232,17 @@ def TestIncusOSAPISystemStorageLocalPoolExpandRAID1(install_image):
                 if result["metadata"]["state"]["drives"][2].get("member_pool", "") != "local":
                     raise IncusOSException("third drive isn't part of the local pool")
 
-                if len(result["metadata"]["state"]["pools"][0]["devices"]) != 1:
+                if len(result["metadata"]["config"]["pools"][0]["devices"]) != 1:
                     raise IncusOSException("expected one member device for local pool")
 
-                if result["metadata"]["state"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
+                if result["metadata"]["config"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
                     raise IncusOSException("pool doesn't have expected member device")
 
-                if result["metadata"]["state"]["pools"][0]["type"] != "zfs-raid0":
-                    raise IncusOSException("pool has unexpected type: " + result["metadata"]["state"]["pools"][0]["type"])
+                if result["metadata"]["config"]["pools"][0]["type"] != "zfs-raid0":
+                    raise IncusOSException("pool has unexpected type: " + result["metadata"]["config"]["pools"][0]["type"])
 
-                if result["metadata"]["state"]["pools"][0]["name"] != "local":
-                    raise IncusOSException("pool has unexpected name: " + result["metadata"]["state"]["pools"][0]["name"])
+                if result["metadata"]["config"]["pools"][0]["name"] != "local":
+                    raise IncusOSException("pool has unexpected name: " + result["metadata"]["config"]["pools"][0]["name"])
 
                 # Extend the "local" pool with the second drive
                 result = vm.APIRequest("/1.0/system/storage", method="PUT", body="""{"config":{"scrub_schedule": "0 4 * * 0", "pools":[{"name":"local","type":"zfs-raid1","devices":["/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11","/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1"]}]}}""")
@@ -257,7 +257,7 @@ def TestIncusOSAPISystemStorageLocalPoolExpandRAID1(install_image):
                 if len(result["metadata"]["state"]["drives"]) != 3:
                     raise IncusOSException("expected exactly three drives")
 
-                if len(result["metadata"]["state"]["pools"]) != 1:
+                if len(result["metadata"]["config"]["pools"]) != 1:
                     raise IncusOSException("expected exactly one pool")
 
                 if result["metadata"]["state"]["drives"][0]["id"] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1":
@@ -278,20 +278,20 @@ def TestIncusOSAPISystemStorageLocalPoolExpandRAID1(install_image):
                 if result["metadata"]["state"]["drives"][2].get("member_pool", "") != "local":
                     raise IncusOSException("second drive isn't part of the local pool")
 
-                if len(result["metadata"]["state"]["pools"][0]["devices"]) != 2:
+                if len(result["metadata"]["config"]["pools"][0]["devices"]) != 2:
                     raise IncusOSException("expected two member devices for local pool")
 
-                if result["metadata"]["state"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1-part11":
+                if result["metadata"]["config"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1-part11":
                     raise IncusOSException("pool doesn't have expected member device")
 
-                if result["metadata"]["state"]["pools"][0]["devices"][1] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
+                if result["metadata"]["config"]["pools"][0]["devices"][1] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
                     raise IncusOSException("pool doesn't have expected member device")
 
-                if result["metadata"]["state"]["pools"][0]["type"] != "zfs-raid1":
-                    raise IncusOSException("pool has unexpected type: " + result["metadata"]["state"]["pools"][0]["type"])
+                if result["metadata"]["config"]["pools"][0]["type"] != "zfs-raid1":
+                    raise IncusOSException("pool has unexpected type: " + result["metadata"]["config"]["pools"][0]["type"])
 
-                if result["metadata"]["state"]["pools"][0]["name"] != "local":
-                    raise IncusOSException("pool has unexpected name: " + result["metadata"]["state"]["pools"][0]["name"])
+                if result["metadata"]["config"]["pools"][0]["name"] != "local":
+                    raise IncusOSException("pool has unexpected name: " + result["metadata"]["config"]["pools"][0]["name"])
 
                 # Can't add a third device to the "local" pool
                 result = vm.APIRequest("/1.0/system/storage", method="PUT", body="""{"config":{"scrub_schedule": "0 4 * * 0", "pools":[{"name":"local","type":"zfs-raid1","devices":["/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1-part11","/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11","/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2"]}]}}""")
@@ -314,7 +314,7 @@ def TestIncusOSAPISystemStorageLocalPoolExpandRAID1(install_image):
                 if len(result["metadata"]["state"]["drives"]) != 3:
                     raise IncusOSException("expected exactly three drives")
 
-                if len(result["metadata"]["state"]["pools"]) != 1:
+                if len(result["metadata"]["config"]["pools"]) != 1:
                     raise IncusOSException("expected exactly one pool")
 
                 if result["metadata"]["state"]["drives"][0]["id"] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1":
@@ -335,20 +335,20 @@ def TestIncusOSAPISystemStorageLocalPoolExpandRAID1(install_image):
                 if result["metadata"]["state"]["drives"][2].get("member_pool", "") != "local":
                     raise IncusOSException("second drive isn't part of the local pool")
 
-                if len(result["metadata"]["state"]["pools"][0]["devices"]) != 2:
+                if len(result["metadata"]["config"]["pools"][0]["devices"]) != 2:
                     raise IncusOSException("expected two member devices for local pool")
 
-                if result["metadata"]["state"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2-part11":
+                if result["metadata"]["config"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2-part11":
                     raise IncusOSException("pool doesn't have expected member device")
 
-                if result["metadata"]["state"]["pools"][0]["devices"][1] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
+                if result["metadata"]["config"]["pools"][0]["devices"][1] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
                     raise IncusOSException("pool doesn't have expected member device")
 
-                if result["metadata"]["state"]["pools"][0]["type"] != "zfs-raid1":
-                    raise IncusOSException("pool has unexpected type: " + result["metadata"]["state"]["pools"][0]["type"])
+                if result["metadata"]["config"]["pools"][0]["type"] != "zfs-raid1":
+                    raise IncusOSException("pool has unexpected type: " + result["metadata"]["config"]["pools"][0]["type"])
 
-                if result["metadata"]["state"]["pools"][0]["name"] != "local":
-                    raise IncusOSException("pool has unexpected name: " + result["metadata"]["state"]["pools"][0]["name"])
+                if result["metadata"]["config"]["pools"][0]["name"] != "local":
+                    raise IncusOSException("pool has unexpected name: " + result["metadata"]["config"]["pools"][0]["name"])
 
 def TestIncusOSAPISystemStorageLocalPoolRecoverFreshInstall(install_image):
     test_name = "incusos-api-system-storage-local-pool-recover"
@@ -409,10 +409,10 @@ def TestIncusOSAPISystemStorageLocalPoolScrub(install_image):
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-        if len(result["metadata"]["state"]["pools"]) != 1:
+        if len(result["metadata"]["config"]["pools"]) != 1:
             raise IncusOSException("expected exactly one pool")
 
-        if "last_scrub" in result["metadata"]["state"]["pools"][0]:
+        if "last_scrub" in result["metadata"]["config"]["pools"][0]:
             raise IncusOSException("expected no last_scrub to be reported since to scrub was requested")
 
         # Scrub the pool.
@@ -428,25 +428,25 @@ def TestIncusOSAPISystemStorageLocalPoolScrub(install_image):
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-        if len(result["metadata"]["state"]["pools"]) != 1:
+        if len(result["metadata"]["config"]["pools"]) != 1:
             raise IncusOSException("expected exactly one pool")
 
-        if "last_scrub" not in result["metadata"]["state"]["pools"][0]:
+        if "last_scrub" not in result["metadata"]["config"]["pools"][0]:
             raise IncusOSException("expected last_scrub to be reported after scrubbing the pool")
 
-        if "start_time" not in result["metadata"]["state"]["pools"][0]["last_scrub"]:
+        if "start_time" not in result["metadata"]["config"]["pools"][0]["last_scrub"]:
             raise IncusOSException("expected start time to be reported on the last scrub")
 
-        if "end_time" not in result["metadata"]["state"]["pools"][0]["last_scrub"]:
+        if "end_time" not in result["metadata"]["config"]["pools"][0]["last_scrub"]:
             raise IncusOSException("expected end time to be reported on the last scrub")
 
-        if result["metadata"]["state"]["pools"][0]["last_scrub"]["state"] != "FINISHED":
+        if result["metadata"]["config"]["pools"][0]["last_scrub"]["state"] != "FINISHED":
             raise IncusOSException("expected last scrub to have 'FINISHED' status")
 
-        if result["metadata"]["state"]["pools"][0]["last_scrub"]["progress"] != "100.00%":
+        if result["metadata"]["config"]["pools"][0]["last_scrub"]["progress"] != "100.00%":
             raise IncusOSException("expected progress to be reported on the last scrub")
 
-        if result["metadata"]["state"]["pools"][0]["last_scrub"]["errors"] != 0:
+        if result["metadata"]["config"]["pools"][0]["last_scrub"]["errors"] != 0:
             raise IncusOSException("expected 0 errors to be reported on the last scrub")
 
 def TestIncusOSAPISystemStorageLocalPoolScrubSchedule(install_image):
@@ -465,7 +465,7 @@ def TestIncusOSAPISystemStorageLocalPoolScrubSchedule(install_image):
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-        if len(result["metadata"]["state"]["pools"]) != 1:
+        if len(result["metadata"]["config"]["pools"]) != 1:
             raise IncusOSException("expected exactly one pool")
 
         if result["metadata"]["config"]["scrub_schedule"] != "0 4 * * 0":
@@ -513,20 +513,20 @@ def TestIncusOSAPISystemStorageLocalPoolDegraded(install_image):
                 if result["status_code"] != 200:
                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                if len(result["metadata"]["state"]["pools"][0]["devices"]) != 2:
+                if len(result["metadata"]["config"]["pools"][0]["devices"]) != 2:
                     raise IncusOSException("expected two member devices for local pool")
 
-                if result["metadata"]["state"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1-part11":
+                if result["metadata"]["config"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1-part11":
                     raise IncusOSException("pool doesn't have expected member device")
 
-                if result["metadata"]["state"]["pools"][0]["devices"][1] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
+                if result["metadata"]["config"]["pools"][0]["devices"][1] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
                     raise IncusOSException("pool doesn't have expected member device")
 
-                if result["metadata"]["state"]["pools"][0]["type"] != "zfs-raid1":
-                    raise IncusOSException("pool has unexpected type: " + result["metadata"]["state"]["pools"][0]["type"])
+                if result["metadata"]["config"]["pools"][0]["type"] != "zfs-raid1":
+                    raise IncusOSException("pool has unexpected type: " + result["metadata"]["config"]["pools"][0]["type"])
 
-                if result["metadata"]["state"]["pools"][0]["name"] != "local":
-                    raise IncusOSException("pool has unexpected name: " + result["metadata"]["state"]["pools"][0]["name"])
+                if result["metadata"]["config"]["pools"][0]["name"] != "local":
+                    raise IncusOSException("pool has unexpected name: " + result["metadata"]["config"]["pools"][0]["name"])
 
                 # Physically yank the second drive and trigger a scrub to put the pool into a degraded state.
                 vm.RemoveDevice("disk1")
@@ -540,26 +540,26 @@ def TestIncusOSAPISystemStorageLocalPoolDegraded(install_image):
                 if result["status_code"] != 200:
                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                if len(result["metadata"]["state"]["pools"][0]["devices"]) != 1:
+                if len(result["metadata"]["config"]["pools"][0]["devices"]) != 1:
                     raise IncusOSException("expected one member device for local pool")
 
-                if result["metadata"]["state"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
+                if result["metadata"]["config"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
                     raise IncusOSException("pool doesn't have expected member device")
 
-                if len(result["metadata"]["state"]["pools"][0]["devices_degraded"]) != 1:
+                if len(result["metadata"]["config"]["pools"][0]["devices_degraded"]) != 1:
                     raise IncusOSException("expected one degraded device for local pool")
 
-                if result["metadata"]["state"]["pools"][0]["devices_degraded"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1-part11":
+                if result["metadata"]["config"]["pools"][0]["devices_degraded"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1-part11":
                     raise IncusOSException("pool doesn't have expected degraded device")
 
-                if result["metadata"]["state"]["pools"][0]["type"] != "zfs-raid1":
-                    raise IncusOSException("pool has unexpected type: " + result["metadata"]["state"]["pools"][0]["type"])
+                if result["metadata"]["config"]["pools"][0]["type"] != "zfs-raid1":
+                    raise IncusOSException("pool has unexpected type: " + result["metadata"]["config"]["pools"][0]["type"])
 
-                if result["metadata"]["state"]["pools"][0]["name"] != "local":
-                    raise IncusOSException("pool has unexpected name: " + result["metadata"]["state"]["pools"][0]["name"])
+                if result["metadata"]["config"]["pools"][0]["name"] != "local":
+                    raise IncusOSException("pool has unexpected name: " + result["metadata"]["config"]["pools"][0]["name"])
 
-                if result["metadata"]["state"]["pools"][0]["state"] != "DEGRADED":
-                    raise IncusOSException("pool has unexpected state: " + result["metadata"]["state"]["pools"][0]["state"])
+                if result["metadata"]["config"]["pools"][0]["state"] != "DEGRADED":
+                    raise IncusOSException("pool has unexpected state: " + result["metadata"]["config"]["pools"][0]["state"])
 
                 # Replace the missing drive with the third one.
                 result = vm.APIRequest("/1.0/system/storage", method="PUT", body="""{"config":{"scrub_schedule": "0 4 * * 0", "pools":[{"name":"local","type":"zfs-raid1","devices":["/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11","/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2"]}]}}""")
@@ -574,26 +574,26 @@ def TestIncusOSAPISystemStorageLocalPoolDegraded(install_image):
                 if result["status_code"] != 200:
                     raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-                if len(result["metadata"]["state"]["pools"][0]["devices"]) != 2:
+                if len(result["metadata"]["config"]["pools"][0]["devices"]) != 2:
                     raise IncusOSException("expected two member devices for local pool")
 
-                if result["metadata"]["state"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2-part11":
+                if result["metadata"]["config"]["pools"][0]["devices"][0] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk2-part11":
                     raise IncusOSException("pool doesn't have expected member device")
 
-                if result["metadata"]["state"]["pools"][0]["devices"][1] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
+                if result["metadata"]["config"]["pools"][0]["devices"][1] != "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_root-part11":
                     raise IncusOSException("pool doesn't have expected member device")
 
-                if len(result["metadata"]["state"]["pools"][0].get("devices_degraded", [])) != 0:
+                if len(result["metadata"]["config"]["pools"][0].get("devices_degraded", [])) != 0:
                     raise IncusOSException("expected no degraded devices for local pool")
 
-                if result["metadata"]["state"]["pools"][0]["type"] != "zfs-raid1":
-                    raise IncusOSException("pool has unexpected type: " + result["metadata"]["state"]["pools"][0]["type"])
+                if result["metadata"]["config"]["pools"][0]["type"] != "zfs-raid1":
+                    raise IncusOSException("pool has unexpected type: " + result["metadata"]["config"]["pools"][0]["type"])
 
-                if result["metadata"]["state"]["pools"][0]["name"] != "local":
-                    raise IncusOSException("pool has unexpected name: " + result["metadata"]["state"]["pools"][0]["name"])
+                if result["metadata"]["config"]["pools"][0]["name"] != "local":
+                    raise IncusOSException("pool has unexpected name: " + result["metadata"]["config"]["pools"][0]["name"])
 
-                if result["metadata"]["state"]["pools"][0]["state"] != "ONLINE":
-                    raise IncusOSException("pool has unexpected state: " + result["metadata"]["state"]["pools"][0]["state"])
+                if result["metadata"]["config"]["pools"][0]["state"] != "ONLINE":
+                    raise IncusOSException("pool has unexpected state: " + result["metadata"]["config"]["pools"][0]["state"])
 
 def TestIncusOSAPISystemStorageLocalAutoexpand(install_image):
     test_name = "incusos-api-system-storage-local-autoexpand"
@@ -611,7 +611,7 @@ def TestIncusOSAPISystemStorageLocalAutoexpand(install_image):
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-        if result["metadata"]["state"]["pools"][0]["raw_pool_size_in_bytes"] != 17716740096:
+        if result["metadata"]["config"]["pools"][0]["raw_pool_size_in_bytes"] != 17716740096:
             raise IncusOSException("local pool has incorrect initial size")
 
         # Stop the VM and expand the root device
@@ -633,5 +633,5 @@ def TestIncusOSAPISystemStorageLocalAutoexpand(install_image):
         if result["status_code"] != 200:
             raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
 
-        if result["metadata"]["state"]["pools"][0]["raw_pool_size_in_bytes"] != 23085449216:
+        if result["metadata"]["config"]["pools"][0]["raw_pool_size_in_bytes"] != 23085449216:
             raise IncusOSException("local pool has incorrect updated size")


### PR DESCRIPTION
Technically this is a breaking change in the API, as the `Pools` field is removed from the `SystemStorageState` struct. Existing code can be updated to use the `Pools` field from the `SystemStorageConfig` struct. @breml 

Closes #1009