### PR TITLE
incus-osd/install: Add magic disk wipe confirmation value

### DIFF
--- a/incus-osd/internal/install/install.go
+++ b/incus-osd/internal/install/install.go
@@ -237,7 +237,7 @@ func CheckSystemRequirements(ctx context.Context) error { //nolint:revive
 			switch installSeed.ForceInstallConfirmation {
 			case "":
 				return fmt.Errorf("%s is already installed on this system; to confirm overwriting, add `ForceInstallConfirmation=%s` to the install seed and reboot", osName, confirmationValue)
-			case confirmationValue:
+			case confirmationValue, "FORCE-WIPE-I-KNOW-WHAT-IAM-DOING":
 				// Get the device that IncusOS is currently installed on.
 				output, err := subprocess.RunCommandContext(ctx, "dmsetup", "deps", "-o", "blkdevname", "/dev/mapper/root")
 				if err != nil {


### PR DESCRIPTION
This allows Operations Center to perform full reinstalls of existing IncusOS systems without needing to read individual consoles to get system-specific confirmation values.

Closes #1335