### PR TITLE
mkosi.images/operations-center: Add mtools to the list of installed packages

### DIFF
--- a/mkosi.images/operations-center/mkosi.conf
+++ b/mkosi.images/operations-center/mkosi.conf
@@ -10,4 +10,5 @@ ImageVersion=
 [Content]
 BaseTrees=%O/base
 Packages=
+    mtools
     xz-utils


### PR DESCRIPTION
This will be needed by Operations Center so it can dynamically generate mini ISO images for enrolling SecureBoot keys on systems that lack proper SecureBoot APIs via RedFish or similar remote management protocols.