### PR TITLE
Fix execution of hotfix scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A daily test is also run, exercising most of the API endpoints and
 running tests that would be impractical (too slow) to run for every pull
 request.
 
-[![Daily API tests](https://github.com/lxc/incus-os/actions/workflows/daily.yml/badge.svg)](https://github.com/lxc/incus-os/actions/workflows/daily.yml)
+[![Daily API tests](https://github.com/lxc/incus-os/actions/workflows/daily.yml/badge.svg)](https://github.com/lxc/incus-os/actions/workflows/daily.yml) [![Weekly Certificate E2E tests](https://github.com/lxc/incus-os/actions/workflows/certificate-e2e.yml/badge.svg)](https://github.com/lxc/incus-os/actions/workflows/certificate-e2e.yml)
 
 # Contributing
 This repository is released under the terms of the Apache 2.0 license.

--- a/incus-osd/internal/recovery/recovery.go
+++ b/incus-osd/internal/recovery/recovery.go
@@ -137,13 +137,25 @@ func RunSignedScript(ctx context.Context, signedScript []byte) (string, error) {
 		return "", err
 	}
 
-	// Write the script contents to a temp file.
-	scriptFile, err := os.CreateTemp("", "")
+	// Create a temporary tmpfs mount for running the recovery script from.
+	mountDir, err := os.MkdirTemp("", "incus-os-hotfix")
 	if err != nil {
 		return "", err
 	}
+	defer os.RemoveAll(mountDir)
 
-	defer os.Remove(scriptFile.Name())
+	// Mount a new tmpfs.
+	err = unix.Mount("tmpfs", mountDir, "tmpfs", unix.MS_NOSUID|unix.MS_NODEV, "size=16m")
+	if err != nil {
+		return "", err
+	}
+	defer unix.Unmount(mountDir, 0)
+
+	// Write the script contents to a temp file.
+	scriptFile, err := os.CreateTemp(mountDir, "")
+	if err != nil {
+		return "", err
+	}
 
 	_, err = scriptFile.WriteString(strings.ReplaceAll(verified.String(), "\r\n", "\n"))
 	if err != nil {

--- a/incus-osd/tests/common.py
+++ b/incus-osd/tests/common.py
@@ -5,6 +5,7 @@ import os
 import requests
 import shutil
 import subprocess
+import time
 import urllib.request
 
 from incusos_tests.incus_test_vm import IncusOSException
@@ -81,13 +82,21 @@ def _download_images(require_prior_release_stable=True):
 
     return prior_image_img, current_image_img, current_image_iso
 
+def _timed(fn):
+    def _fn(*a, **k):
+        start = time.time()
+        ret = fn(*a, **k)
+        elapsed = int(time.time() - start)
+        return elapsed, ret
+    return _fn
+
 def _run_tests(tests, max_workers=3):
     num_pass = 0
     num_fail = 0
 
     # Run the tests
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = {executor.submit(fn, image): name for name,fn,image in tests.GetTests()}
+        futures = {executor.submit(_timed(fn), image): name for name,fn,image in tests.GetTests()}
 
         print("Running %d tests...\n" % len(futures), flush=True)
 
@@ -95,7 +104,7 @@ def _run_tests(tests, max_workers=3):
             name = futures[future]
 
             try:
-                data = future.result()
+                elapsed, _ = future.result()
             except IncusOSException as e:
                 num_fail += 1
                 print("FAIL: %s: %s" % (name, e.args[0]), flush=True)
@@ -115,7 +124,8 @@ def _run_tests(tests, max_workers=3):
                 print("FAIL: %s: %s" % (name, e), flush=True)
             else:
                 num_pass += 1
-                print("PASS: %s" % name, flush=True)
+                minute, second = divmod(elapsed, 60)
+                print("PASS: %s (%02d:%02d)" % (name, minute, second), flush=True)
 
     print("\nDone with tests: %d/%d passed." % (num_pass, num_fail+num_pass), flush=True)
 

--- a/incus-osd/tests/incusos_tests/tests_certificate_e2e.py
+++ b/incus-osd/tests/incusos_tests/tests_certificate_e2e.py
@@ -116,7 +116,7 @@ def testSecureBootKeyRotation(vm, os_name, os_version):
 
         vm.WaitExpectedLog("incus-osd", "Appending certificate SHA256:[0-9A-F]{64} to EFI variable db", regex=True)
 
-        time.sleep(5)
+        time.sleep(15)
         vm.WaitAgentRunning()
         vm.WaitExpectedLog("incus-osd", "System is ready")
 
@@ -127,7 +127,7 @@ def testSecureBootKeyRotation(vm, os_name, os_version):
 
         vm.WaitExpectedLog("incus-osd", "Appending certificate SHA256:[0-9A-F]{64} to EFI variable dbx", regex=True)
 
-        time.sleep(5)
+        time.sleep(15)
         vm.WaitAgentRunning()
         vm.WaitExpectedLog("incus-osd", "System is ready")
 
@@ -191,7 +191,7 @@ def testSecureBootKeyRotation(vm, os_name, os_version):
 
         vm.WaitExpectedLog("incus-osd", "Appending certificate SHA256:[0-9A-F]{64} to EFI variable dbx", regex=True)
 
-        time.sleep(5)
+        time.sleep(15)
         vm.WaitAgentRunning()
         vm.WaitExpectedLog("incus-osd", "System is ready")
 


### PR DESCRIPTION
#1341 made `/tmp/` noexec, so now we must setup a minimal tmpfs to execute any provided hotfix script.

Also extended tests to report execution time for each successful test.