### PR TITLE
Add storage seed and allow configuring storage pool alignment

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -65,6 +65,7 @@ ISO
 JSON
 KEK
 Kerberos
+KiB
 KVM
 LDAP
 Lenovo

--- a/doc/reference/seed.md
+++ b/doc/reference/seed.md
@@ -152,6 +152,20 @@ The "debug" provider is not intended for general use, and should only be used to
 support work developing IncusOS.
 ```
 
+### `security.{json,yml,yaml}`
+This file provides security configuration for the system.
+
+The structure used is the [security API struct](https://github.com/lxc/incus-os/blob/main/incus-osd/api/system_security.go):
+
+- `custom_ca_certs`: An array of PEM-encoded CA certificates that should be
+  added to the IncusOS trust store.
+
+```{note}
+It is not possible to set encryption recovery key(s) via the security seed. This is
+because the seed must be stored in plain text, which would allow trivial access to
+anyone trying to compromise the encrypted IncusOS root partition.
+```
+
 ### `services.{json,yml,yaml}`
 This file provides preseed information to configure [services](services.md) at
 install time. Each service is optional and uses the `config` section of its
@@ -176,19 +190,15 @@ sensitive information such as authentication keys and prefer setting
 those up after the fact.
 ```
 
-### `security.{json,yml,yaml}`
-This file provides security configuration for the system.
+### `storage.{json,yml,yaml}`
+This file configures initial storage pools for the system.
 
-The structure used is the [security API struct](https://github.com/lxc/incus-os/blob/main/incus-osd/api/system_security.go):
+The structure used is the [storage API struct](https://github.com/lxc/incus-os/blob/main/incus-osd/api/system_storage.go):
 
-- `custom_ca_certs`: An array of PEM-encoded CA certificates that should be
-  added to the IncusOS trust store.
-
-```{note}
-It is not possible to set encryption recovery key(s) via the security seed. This is
-because the seed must be stored in plain text, which would allow trivial access to
-anyone trying to compromise the encrypted IncusOS root partition.
-```
+- `pools`: Define one or more additional pools to automatically create on first boot.
+  The `local` pool is special; any configuration values other than alignment, allowing mixed
+  size devices, setting a pool type of `zfs-raid0` or `zfs-raid1`, or optionally specifying a
+  second drive in addition to `/dev/disk/by-partlabel/local-data` will be ignored.
 
 ### `update.{json,yml,yaml}`
 This file provides update configuration for the system.

--- a/doc/reference/system/storage.md
+++ b/doc/reference/system/storage.md
@@ -25,10 +25,17 @@ User-defined storage pools are defined in the [`SystemStoragePool` struct](https
 * `name`: The name of the storage pool.
 * `type`: The type of the storage pool, which must be one of `zfs-raid0`, `zfs-raid1`, `zfs-raid10`, `zfs-raidz1`, `zfs-raidz2`, or `zfs-raidz3`.
 * `allow_mixed_dev_sizes`: If true, allow creation of a storage pool with devices of different sizes. Note that in most cases this will result in a storage pool whose total available capacity will be constrained by the smallest device size.
+* `alignment`: Optional, if specified sets the default sector alignment size for the pool; must be a power of two.
 * `devices`, `cache`, `log,` and `special`: Used to assign various storage devices to the pool in different roles.
 
-```{note}
+```{warning}
 When specifying devices for a pool, order is important. IncusOS will always return a sorted list which it will use when comparing the list of devices it receives via the API to determine what device(s) to add, remove, or replace in the pool. Put another way, `"devices": ["/dev/sda", "/dev/sdb"]` != `"devices": ["/dev/sdb", "/dev/sda"]`.
+```
+
+```{warning}
+When creating a storage pool with a custom sector alignment value, be aware of the potential for significant performance degradation due to write amplification if the alignment value is smaller than that of the underlying physical device(s). For example, setting an alignment of 512 bytes for a storage pool on a drive with 4KiB sectors will result in write amplification of approximately 8x compared to using an alignment of 4096 bytes.
+
+IncusOS defaults to an alignment value of 4096 bytes, which works well for drives with either 512 byte or 4KiB sector sizes.
 ```
 
 ### Examples

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1214,6 +1214,13 @@ definitions:
         x-go-package: github.com/lxc/incus-os/incus-osd/api
     SystemStoragePool:
         properties:
+            alignment:
+                description: |-
+                    Optionally, configure the sector alignment size for the pool; defaults to 4096 byte sectors.
+                    Must be a power of two. Can only be specified when initially creating the pool.
+                format: int64
+                type: integer
+                x-go-name: Alignment
             allow_mixed_dev_sizes:
                 description: If true, allow creation of a pool with devices of different sizes.
                 type: boolean

--- a/incus-osd/api/seed/storage.go
+++ b/incus-osd/api/seed/storage.go
@@ -1,0 +1,13 @@
+package seed
+
+import (
+	"github.com/lxc/incus-os/incus-osd/api"
+)
+
+// Storage represents the storage seed used to automatically
+// create storage pools on first boot.
+type Storage struct {
+	Pools []api.SystemStoragePool `json:"pools,omitempty" yaml:"pools,omitempty"`
+
+	Version string `json:"version" yaml:"version"`
+}

--- a/incus-osd/api/system_storage.go
+++ b/incus-osd/api/system_storage.go
@@ -38,6 +38,9 @@ type SystemStoragePool struct {
 	Type string `json:"type" yaml:"type"`
 	// If true, allow creation of a pool with devices of different sizes.
 	AllowMixedDevSizes bool `json:"allow_mixed_dev_sizes,omitempty" yaml:"allow_mixed_dev_sizes,omitempty"`
+	// Optionally, configure the sector alignment size for the pool; defaults to 4096 byte sectors.
+	// Must be a power of two. Can only be specified when initially creating the pool.
+	Alignment int `json:"alignment,omitempty" yaml:"alignment,omitempty"`
 
 	// Devices, Cache, Log, and Special can be modified to add/remove/replace devices in the pool.
 	Devices []string                  `json:"devices"           yaml:"devices"`

--- a/incus-osd/internal/seed/storage.go
+++ b/incus-osd/internal/seed/storage.go
@@ -1,0 +1,20 @@
+package seed
+
+import (
+	"context"
+
+	apiseed "github.com/lxc/incus-os/incus-osd/api/seed"
+)
+
+// GetStorage extracts the storage configuration from the seed data.
+func GetStorage(_ context.Context) (*apiseed.Storage, error) {
+	// Get the storage configuration.
+	var config apiseed.Storage
+
+	err := parseFileContents(getSeedPath(), "storage", &config)
+	if err != nil && !IsMissing(err) {
+		return nil, err
+	}
+
+	return &config, nil
+}

--- a/incus-osd/internal/storage/storage.go
+++ b/incus-osd/internal/storage/storage.go
@@ -135,6 +135,14 @@ type zfsGetPartialParse struct {
 	} `json:"datasets"`
 }
 
+type zpoolGetPartialParse struct {
+	Pools map[string]struct {
+		Properties map[string]struct {
+			Value any `json:"value"`
+		} `json:"properties"`
+	} `json:"pools"`
+}
+
 type smartOutput struct {
 	err error
 
@@ -398,6 +406,24 @@ func getZpoolMembersHelper(ctx context.Context, rawJSONContent []byte, zpoolName
 	err := json.Unmarshal(rawJSONContent, &zpoolJSON)
 	if err != nil {
 		return api.SystemStoragePool{}, err
+	}
+
+	// Get the ashift value.
+	zpoolGetOutput, err := subprocess.RunCommandContext(ctx, "zpool", "get", "ashift", zpoolName, "-j", "--json-int")
+	if err != nil {
+		return api.SystemStoragePool{}, err
+	}
+
+	zpoolProperties := zpoolGetPartialParse{}
+
+	err = json.Unmarshal([]byte(zpoolGetOutput), &zpoolProperties)
+	if err != nil {
+		return api.SystemStoragePool{}, err
+	}
+
+	zpoolAshift, ok := zpoolProperties.Pools[zpoolName].Properties["ashift"].Value.(float64)
+	if !ok {
+		return api.SystemStoragePool{}, errors.New("bad type for ashift field")
 	}
 
 	// Get the encryption key status.
@@ -705,6 +731,7 @@ func getZpoolMembersHelper(ctx context.Context, rawJSONContent []byte, zpoolName
 		LastTrim:                  trimStatus,
 		EncryptionKeyStatus:       zpoolKeyStatus,
 		Type:                      zpoolType,
+		Alignment:                 1 << int(zpoolAshift),
 		Devices:                   zpoolDevices["devices"],
 		Log:                       zpoolDevices["log"],
 		Cache:                     zpoolDevices["cache"],

--- a/incus-osd/internal/zfs/zfs.go
+++ b/incus-osd/internal/zfs/zfs.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/lxc/incus-os/incus-osd/api"
 	"github.com/lxc/incus-os/incus-osd/internal/scheduling"
+	"github.com/lxc/incus-os/incus-osd/internal/seed"
 	"github.com/lxc/incus-os/incus-osd/internal/state"
 	"github.com/lxc/incus-os/incus-osd/internal/storage"
 	"github.com/lxc/incus-os/incus-osd/internal/util"
@@ -72,19 +73,65 @@ func LoadPools(ctx context.Context, s *state.State) error {
 
 	// If the "local" pool isn't automatically imported, this is a first boot and we either
 	// need to create a fresh "local" pool or attempt to recover an existing pool.
-	if !storage.PoolExists(ctx, "local") {
+	if !storage.PoolExists(ctx, "local") { //nolint:nestif
 		_, err := subprocess.RunCommandContext(ctx, "zpool", "import", "local")
 		if err != nil {
-			// Failed to import the pool, so create a fresh one.
-			zpool := api.SystemStoragePool{
+			// The local pool doesn't exist, so create it along with any other pools
+			// defined in the storage seed.
+			storageSeed, err := seed.GetStorage(ctx)
+			if err != nil && !seed.IsMissing(err) {
+				return err
+			}
+
+			// Basic local pool definition.
+			localZpool := api.SystemStoragePool{
 				Name:    "local",
 				Type:    "zfs-raid0",
 				Devices: []string{"/dev/disk/by-partlabel/local-data"},
 			}
 
-			err := CreateZpool(ctx, zpool, s)
+			// Selectively expand the local pool definition from the storage seed, if provided.
+			for _, pool := range storageSeed.Pools {
+				if pool.Name == "local" {
+					localZpool.Alignment = pool.Alignment
+					localZpool.AllowMixedDevSizes = pool.AllowMixedDevSizes
+
+					if pool.Type != "" {
+						if pool.Type != "zfs-raid0" && pool.Type != "zfs-raid1" {
+							return errors.New("invalid local pool type from storage seed: " + pool.Type)
+						}
+
+						localZpool.Type = pool.Type
+					}
+
+					if len(pool.Devices) > 0 {
+						if !slices.Contains(pool.Devices, "/dev/disk/by-partlabel/local-data") || len(pool.Devices) > 2 {
+							return fmt.Errorf("invalid local pool devices from storage seed: %v", pool.Devices)
+						}
+
+						localZpool.Devices = pool.Devices
+					}
+
+					break
+				}
+			}
+
+			// Create the local pool.
+			err = CreateZpool(ctx, localZpool, s)
 			if err != nil {
 				return err
+			}
+
+			// Create any other pools from the storage seed.
+			for _, pool := range storageSeed.Pools {
+				if pool.Name == "local" {
+					continue
+				}
+
+				err := CreateZpool(ctx, pool, s)
+				if err != nil {
+					return err
+				}
 			}
 		} else {
 			// We were able to import the existing "local" pool.

--- a/incus-osd/internal/zfs/zfs.go
+++ b/incus-osd/internal/zfs/zfs.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"slices"
@@ -201,6 +202,16 @@ func CreateZpool(ctx context.Context, zpool api.SystemStoragePool, s *state.Stat
 		return errors.New("unsupported pool type " + zpool.Type)
 	}
 
+	// If no alignment is specified, default to 4096 bytes.
+	if zpool.Alignment == 0 {
+		zpool.Alignment = 4096
+	}
+
+	// Verify a valid alignment value was provided.
+	if zpool.Alignment <= 0 || (zpool.Alignment > 0 && (zpool.Alignment&(zpool.Alignment-1)) != 0) {
+		return errors.New("pool alignment value must be a power of two")
+	}
+
 	// Verify at least one device was specified.
 	if len(zpool.Devices) == 0 {
 		return errors.New("at least one device must be specified")
@@ -290,7 +301,7 @@ func CreateZpool(ctx context.Context, zpool api.SystemStoragePool, s *state.Stat
 	}
 
 	// Create the ZFS pool.
-	args := []string{"create", "-o", "ashift=12", "-O", "mountpoint=none", "-O", "encryption=aes-256-gcm", "-O", "keyformat=raw", "-O", "keylocation=file://" + keyfilePath, zpool.Name}
+	args := []string{"create", "-o", fmt.Sprintf("ashift=%d", int(math.Log2(float64(zpool.Alignment)))), "-O", "mountpoint=none", "-O", "encryption=aes-256-gcm", "-O", "keyformat=raw", "-O", "keylocation=file://" + keyfilePath, zpool.Name}
 
 	switch zpool.Type {
 	case "zfs-raid0":
@@ -524,6 +535,11 @@ func UpdateZpool(ctx context.Context, newConfig api.SystemStoragePool) error {
 	// Verify we are given a supported type.
 	if !slices.Contains(supportedPoolTypes, currentConfig.Type) {
 		return errors.New("unsupported pool type " + currentConfig.Type)
+	}
+
+	// Cannot change pool alignment.
+	if currentConfig.Alignment != newConfig.Alignment {
+		return errors.New("cannot change pool alignment after creation")
 	}
 
 	// Verify the update contains at least as many device entries as exist in the current config.

--- a/incus-osd/tests/incusos_tests/__init__.py
+++ b/incus-osd/tests/incusos_tests/__init__.py
@@ -10,7 +10,7 @@ from . import tests_certificate_e2e, tests_flasher_tool, tests_incusos_api, test
 from .install import tests_secureboot_disabled, tests_multipath, tests_smoke, tests_swtpm, tests_system_checks
 
 from .seed import test_external_seed, test_applications, test_install, test_kernel, test_network, test_provider, \
-    test_security, test_update
+    test_security, test_storage, test_update
 
 class IncusOSTests:
     def __init__(self, prior_image_img, current_image_img, current_image_iso):
@@ -82,6 +82,7 @@ class IncusOSTests:
             test_network,
             test_provider,
             test_security,
+            test_storage,
             test_update,
         ]
 

--- a/incus-osd/tests/incusos_tests/seed/test_storage.py
+++ b/incus-osd/tests/incusos_tests/seed/test_storage.py
@@ -1,0 +1,117 @@
+from ..incus_test_vm import IncusTestVM, IncusOSException, util
+
+import os
+import tempfile
+
+def TestSeedStorageExtraPool(install_image):
+    test_name = "seed-storage-extra-pool"
+    test_seed = {
+        "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}""",
+        "storage.json": """{"pools":[{"name":"mypool","alignment":512,"type":"zfs-raid0","devices":["/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1"]}]}""",
+    }
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img:
+        disk_img.truncate(10*1024*1024*1024)
+
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+            vm.AddDevice("disk1", "disk", "source="+disk_img.name)
+
+            vm.WaitSystemReady(os_version)
+
+            # Check that the pools have their expected alignment
+            result = vm.APIRequest("/1.0/system/storage", method="GET")
+            if result["status_code"] != 200:
+                raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+            if len(result["metadata"]["config"]["pools"]) != 2:
+                raise IncusOSException("expected two storage pools")
+
+            localPool = result["metadata"]["config"]["pools"][0]
+            myPool = result["metadata"]["config"]["pools"][1]
+            if localPool["name"] != "local":
+                localPool = result["metadata"]["config"]["pools"][1]
+                myPool = result["metadata"]["config"]["pools"][0]
+
+            if localPool["alignment"] != 4096:
+                raise IncusOSException("local pool alignment isn't 4096: " + str(localPool["alignment"]))
+
+            if myPool["alignment"] != 512:
+                raise IncusOSException("mypool pool alignment isn't 512: " + str(myPool["alignment"]))
+
+            # Delete mypool and verify we can't create a pool with an invalid alignment
+            result = vm.APIRequest("/1.0/system/storage/:delete-pool", method="POST", body="""{"name":"mypool"}""")
+            if result["status_code"] != 200:
+                raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+            result = vm.APIRequest("/1.0/system/storage", method="PUT", body="""{"config":{"scrub_schedule": "0 4 * * 0", "trim_schedule": "0 4 * * 6", "pools":[{"name":"mypool","type":"zfs-raid0","alignment":1023,"devices":["/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1"]}]}}""")
+            if result["status_code"] == 200:
+                raise IncusOSException("unexpected success creating pool with invalid alignment")
+
+            if result["error"] != "pool alignment value must be a power of two":
+                raise IncusOSException("unexpected error message: " + result["error"])
+
+            # Create a new pool with an alignment of 1024
+            result = vm.APIRequest("/1.0/system/storage", method="PUT", body="""{"config":{"scrub_schedule": "0 4 * * 0", "trim_schedule": "0 4 * * 6", "pools":[{"name":"mypool","type":"zfs-raid0","alignment":1024,"devices":["/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1"]}]}}""")
+            if result["status_code"] != 200:
+                raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+            # Verify the new pool has the expected alignment
+            result = vm.APIRequest("/1.0/system/storage", method="GET")
+            if result["status_code"] != 200:
+                raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+            if len(result["metadata"]["config"]["pools"]) != 2:
+                raise IncusOSException("expected two storage pools")
+
+            myPool = result["metadata"]["config"]["pools"][0]
+            if myPool["name"] != "mypool":
+                myPool = result["metadata"]["config"]["pools"][1]
+
+            if myPool["alignment"] != 1024:
+                raise IncusOSException("mypool pool alignment isn't 1024: " + str(myPool["alignment"]))
+
+            # Can't change the alignment for an existing pool
+            result = vm.APIRequest("/1.0/system/storage", method="PUT", body="""{"config":{"scrub_schedule": "0 4 * * 0", "trim_schedule": "0 4 * * 6", "pools":[{"name":"mypool","type":"zfs-raid0","alignment":512,"devices":["/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1"]}]}}""")
+            if result["status_code"] == 200:
+                raise IncusOSException("unexpected success changing pool alignment")
+
+            if result["error"] != "cannot change pool alignment after creation":
+                raise IncusOSException("unexpected error message: " + result["error"])
+
+def TestSeedStorageLocalPool(install_image):
+    test_name = "seed-storage-local-pool"
+    test_seed = {
+        "install.json": """{"target":{"id":"scsi-0QEMU_QEMU_HARDDISK_incus_root"}}""",
+        "storage.json": """{"pools":[{"name":"local","alignment":2048,"allow_mixed_dev_sizes":true,"type":"zfs-raid1","devices":["/dev/disk/by-partlabel/local-data","/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_incus_disk1"]}]}""",
+    }
+
+    test_image, os_name, os_version, client_cert_name = util._prepare_test_image(install_image, test_seed)
+
+    with tempfile.NamedTemporaryFile(dir=os.getcwd()) as disk_img:
+        disk_img.truncate(50*1024*1024*1024)
+
+        with IncusTestVM(os_name, test_name, test_image, client_cert_name) as vm:
+            vm.AddDevice("disk1", "disk", "source="+disk_img.name)
+
+            vm.WaitSystemReady(os_version)
+
+            # Check that the local pool is properly setup
+            result = vm.APIRequest("/1.0/system/storage", method="GET")
+            if result["status_code"] != 200:
+                raise IncusOSException("unexpected status code %d: %s" % (result["error_code"], result["error"]))
+
+            if len(result["metadata"]["config"]["pools"]) != 1:
+                raise IncusOSException("expected exactly one storage pool")
+
+            localPool = result["metadata"]["config"]["pools"][0]
+
+            if localPool["alignment"] != 2048:
+                raise IncusOSException("local pool alignment isn't 2048: " + str(localPool["alignment"]))
+
+            if localPool["type"] != "zfs-raid1":
+                raise IncusOSException("local pool type isn't zfs-raid1: " + localPool["type"])
+
+            if len(localPool["devices"]) != 2:
+                raise IncusOSException("expected local pool to consist of exactly two devices")


### PR DESCRIPTION
This introduces an new `storage` seed that allows for configuring the creation of additional storage pools on first boot, rather than needing to rely on creating these pools via API later on. Limited configuration of the special "local" pool is also allowed via this seed.

The storage API also has a new field `Alignment` that allows for the configuration of a new storage pool's sector alignment. Any valid power of two is allowed; it is assumed the user will properly understand the implications of setting an improper alignment value when creating their storage pool(s). If no alignment is configured, IncusOS will continue to default to an alignment value of 4KiB.