### PR TITLE
base: Delay enabling kernel `lockdown=integrity` mode

### DIFF
--- a/doc/reference/installing-without-secureboot.md
+++ b/doc/reference/installing-without-secureboot.md
@@ -8,6 +8,8 @@ To support users who wish to run IncusOS on these broken systems, Secure Boot ca
 
 * IncusOS will rely on the physical TPM PCR4 event log to verify that the `systemd-boot` stub and UKI that booted match the UEFI measurements and are signed by a trusted certificate. This is normally handled automatically when Secure Boot is enabled, but IncusOS will perform these actions early in the boot process. This opens some avenues of attack to an adversary with physical access to the system.
 
+* IncusOS can't enable the kernel's `lockdown=integrity` mode until after ZFS storage pools are imported. This opens a small attack window during early boot when an attacker could load a malicious kernel module.
+
 Additionally, the following limitations are imposed compared to normal operation:
 
 * Because disk encryption is additionally bound to PCR4, when booting into a prior version of IncusOS you will always need to provide an encryption recovery passphrase.

--- a/incus-osd/internal/zfs/zfs.go
+++ b/incus-osd/internal/zfs/zfs.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/lxc/incus/v7/shared/revert"
@@ -91,6 +92,16 @@ func LoadPools(ctx context.Context, s *state.State) error {
 				return err
 			}
 		}
+	}
+
+	// After we have successfully loaded the ZFS kernel module, make sure the kernel's lockdown=integrity
+	// mode is enabled. This will be the case on systems with SecureBoot enabled, but for systems without
+	// it we do want to prohibit the loading of unverified kernel modules. We cannot simply include this
+	// as a kernel command line option, as it would prevent loading of ZFS, so enable the lockdown as
+	// soon as we can after initially loading the zpools.
+	err = os.WriteFile("/sys/kernel/security/lockdown", []byte("integrity\n"), 0o644)
+	if err != nil && !errors.Is(err, syscall.EPERM) {
+		return err
 	}
 
 	return nil

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -41,7 +41,6 @@ KernelCommandLine=rw
                   loglevel=0
                   systemd.show_status=0
                   rootflags=noexec,nodev,nosuid
-                  lockdown=integrity
                   audit=1
                   audit_backlog_limit=8192
                   rd.systemd.mount-extra=/dev/disk/by-partlabel/esp:/boot:vfat:rw


### PR DESCRIPTION
On systems with SecureBoot enabled, the kernel will automatically be in `lockdown=integrity` mode and able to properly load signed kernel modules such as ZFS. But on systems without SecureBoot, setting this as a kernel command line option prevents the loading of the ZFS module. Instead, immediately after loading the zpools (which will trigger a loading of the module), write to the `/sys/` knob to enable integrity mode which cannot then be turned off without a reboot.

Related to #1341