### PR TITLE
Detect swtpm initrd failure

### DIFF
--- a/mkosi.packages/initrd-utils/initrd-boot-message.sh
+++ b/mkosi.packages/initrd-utils/initrd-boot-message.sh
@@ -10,6 +10,15 @@ done
 SECURE_BOOT_DISABLED=false
 TPM_MISSING=false
 
+# Refuse to boot on any system with less than 1GiB of RAM
+RAM=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+if [ "$RAM" -lt 1048576 ]; then
+    for TTY in $TTYS; do
+        echo "\033[31m$NAME cannot run with less than 1GiB of RAM.\033[0m" > "$TTY" || true
+    done
+    sleep 3600
+fi
+
 # Check if SecureBoot is enabled
 if [ -e /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c ]; then
     raw_secure_boot_state=$(tail -c 1 /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c)

--- a/mkosi.packages/initrd-utils/initrd-swtpm.service
+++ b/mkosi.packages/initrd-utils/initrd-swtpm.service
@@ -5,6 +5,7 @@ Requires=modprobe@tpm_vtpm_proxy.service boot.mount
 Before=cryptsetup.target systemd-cryptsetup@root.service systemd-repart.service
 DefaultDependencies=no
 ConditionPathExists=/boot/swtpm/
+OnFailure=emergency.target
 
 [Service]
 Type=exec


### PR DESCRIPTION
If the `swtpm` service fails for some reason in the initrd, later on when the main `swtpm` service is started we won't have the proper TPM state to load. This will result in errors attempting to setup initial recovery keys or decrypt existing LUKS partitions. Make a failure of `swtpm` in initrd trigger systemd's `emergency.target` to halt any further boot.

Additionally, add a boot-time check that the IncusOS system has at least 1GiB of RAM available. This is the bare minimum needed for the system to boot successfully, but for any real use at least 4GiB of RAM is required as currently documented.